### PR TITLE
remove: Delete ClaudeAutoPM.wiki submodule

### DIFF
--- a/test/regression/__snapshots__/health-report.json
+++ b/test/regression/__snapshots__/health-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-14T22:26:15.184Z",
+  "timestamp": "2025-09-14T22:27:10.974Z",
   "files": {
     "strategy": {
       "exists": true,


### PR DESCRIPTION
## Summary
- Remove unnecessary wiki submodule from main repository
- Keep main repository clean and focused on framework code
- Wiki documentation exists independently at GitHub Wiki

## Why Remove?
1. **Unnecessary complexity** - Submodules add maintenance overhead
2. **GitHub Wiki is sufficient** - Wiki lives at `/wiki` URL naturally
3. **Sync issues** - Prevents submodule synchronization problems
4. **Clean architecture** - Main repo focuses on framework, wiki on docs

## Changes
- ✅ Removed `ClaudeAutoPM.wiki` submodule directory
- ✅ Updated regression test snapshots
- ✅ Main repository is now cleaner

## Documentation Access
Wiki documentation remains fully accessible at:
- https://github.com/rafeekpro/ClaudeAutoPM/wiki
- All 20 pages of documentation are live and working

## Test Plan
- [x] Pre-commit hooks passed
- [x] All validation checks passed
- [x] Repository structure simplified
- [x] Wiki documentation unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)