### PR TITLE
chore: Release v1.5.1 - publish to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {

--- a/test/regression/__snapshots__/health-report.json
+++ b/test/regression/__snapshots__/health-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-19T10:34:16.815Z",
+  "timestamp": "2025-09-19T10:40:24.922Z",
   "files": {
     "strategy": {
       "exists": true,


### PR DESCRIPTION
## Release v1.5.1

### Summary
- Documentation portal with VitePress
- Wiki content migration to GitHub Pages  
- Cleanup of temporary files
- Interactive setup guide improvements

### Changes
- Added comprehensive VitePress documentation site
- Migrated all wiki content to organized structure
- Fixed ESM/CJS compatibility issues in guide
- Cleaned up analysis files and old directories

### Publishing
Ready for npm publish after merge