### PR TITLE
fix: Critical npm package fix - v1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "files": [
     "bin/",
     "lib/",
+    "src/",
     "autopm/",
     ".github/",
     "scripts/",

--- a/test/regression/__snapshots__/health-report.json
+++ b/test/regression/__snapshots__/health-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-19T10:40:33.176Z",
+  "timestamp": "2025-09-19T11:43:27.830Z",
   "files": {
     "strategy": {
       "exists": true,
@@ -19,7 +19,7 @@
     },
     "packageJson": {
       "exists": true,
-      "size": 5794,
+      "size": 5806,
       "sizeValid": true,
       "contentValid": true,
       "missingPatterns": [],

--- a/test/regression/__snapshots__/health-report.json
+++ b/test/regression/__snapshots__/health-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-19T10:40:24.922Z",
+  "timestamp": "2025-09-19T10:40:33.176Z",
   "files": {
     "strategy": {
       "exists": true,


### PR DESCRIPTION
## Critical Fix for npm Package

### Issue
Users getting error after installing from npm:
```
Fatal error: ENOENT: no such file or directory, scandir '/Users/rla/.nvm/versions/node/v22.19.0/lib/node_modules/claude-autopm/src/commands'
```

### Solution
- Added `src/` directory to the `files` array in package.json
- This ensures src/commands is included in the npm package

### Impact
- Fixes broken npm installation
- Users can now run `autopm` command without errors

### Version
v1.5.2 - Hotfix release