### PR TITLE
chore: release v1.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## Summary
Bumping version to v1.9.4 after merging MCP/context7 documentation updates

## Changelog
- Added MCP context7 documentation sections to 12 agents
- Ensures 100% agent coverage with documentation access  
- Added 3 new agents:
  - frontend-testing-engineer
  - observability-engineer
  - message-queue-engineer

## NPM Release
- Published to npm registry as claude-autopm@1.9.4

🤖 Generated with [Claude Code](https://claude.ai/code)