### PR TITLE
hotfix: fix installation detection in interactive guide

### DIFF
--- a/lib/guide/interactive-guide.js
+++ b/lib/guide/interactive-guide.js
@@ -104,7 +104,7 @@ class InteractiveGuide {
    * Check if ClaudeAutoPM is already installed
    */
   isInstalled() {
-    return fs.existsSync('.claude') && fs.existsSync('.claude/teams.json');
+    return fs.existsSync('.claude') && fs.existsSync('.claude/config.json');
   }
 
   /**


### PR DESCRIPTION
## Critical Hotfix - Installation Detection

This fixes a critical bug where completed installations were not being detected by the interactive guide.

### 🐛 Problem
After successful installation, when users tried to configure ClaudeAutoPM, they received:
```
⚠️  ClaudeAutoPM is not installed in this project!
Please install ClaudeAutoPM first by selecting the installation option
```

### 🔍 Root Cause
The `isInstalled()` method was checking for `.claude/teams.json` file, but the installation script doesn't create this file. It only creates `.claude/config.json`.

### ✅ Solution
Changed installation detection from:
```javascript
// BEFORE (incorrect)
return fs.existsSync('.claude') && fs.existsSync('.claude/teams.json');

// AFTER (correct) 
return fs.existsSync('.claude') && fs.existsSync('.claude/config.json');
```

### 🧪 Testing
- ✅ Verified `.claude/config.json` is created during installation
- ✅ Confirmed `.claude/teams.json` does NOT exist after installation  
- ✅ Updated detection now correctly identifies completed installations

### 🎯 Impact
- Users can now properly access configuration flows after installation
- Eliminates confusing "not installed" errors for completed installations
- Fixes workflow continuity in interactive guide

Critical fix for users experiencing post-installation configuration issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)