### PR TITLE
fix: v1.9.13 - Guide should only show instructions, not create files

### DIFF
--- a/lib/guide/interactive-guide.js
+++ b/lib/guide/interactive-guide.js
@@ -512,153 +512,64 @@ class InteractiveGuide {
 
     console.log(this.createStepFrame(
       1,
-      'Demo: Create Your First PRD',
-      'Let\'s create a complete PM workflow walkthrough!\n\n' +
-      'This will demonstrate:\n' +
-      '• Creating a PRD (Product Requirements Document)\n' +
-      '• Breaking it into an epic with tasks\n' +
-      '• Showing the actual file structure\n\n' +
-      'We\'ll use "user-authentication" as our demo feature.'
+      'Create Your First PRD',
+      'Let\'s start with a Product Requirements Document (PRD).\n\n' +
+      'You can create a PRD in two ways:\n' +
+      '• Template-based: Fast, structured approach\n' +
+      '• AI-powered: Brainstorming with Claude Code\n\n' +
+      'For this example, we\'ll show the template approach.'
     ));
 
-    await this.waitForConfirmation();
+    let featureName = await new Promise((resolve) => {
+      this.rl.question('Enter a feature name (e.g., user-authentication): ', resolve);
+    });
 
-    // Step 2: Actually create the PRD structure
+    // Handle empty input
+    if (!featureName.trim()) {
+      featureName = 'user-authentication';
+      console.log(`\n💡 Using example: "${featureName}"\n`);
+    }
+
     console.log(this.createStepFrame(
       2,
-      'Creating Demo PRD Structure',
-      'Creating actual files for "user-authentication" feature:\n\n' +
-      '📝 Creating PRD template...\n' +
-      '📋 Setting up epic structure...\n' +
-      '🎯 Generating sample tasks...\n\n' +
-      'This creates the foundation for PM workflow.'
+      'Generate PRD and Epic',
+      `Creating PRD for "${featureName}" and breaking it into tasks:\n\n` +
+      '1. Create PRD from template\n' +
+      '2. Parse PRD into epic structure\n' +
+      '3. Decompose epic into actionable tasks\n' +
+      '4. Sync with your configured provider\n\n' +
+      '🚀 Next Steps - Open Claude Code:\n\n' +
+      '1. Open Claude Code in this directory\n' +
+      '2. If needed, run: claude --bypass-permissions\n' +
+      '3. Then use these PM commands:',
+      [
+        `/pm:prd-new ${featureName} --template`,
+        `/pm:prd-parse ${featureName}`,
+        `/pm:epic-decompose ${featureName}`,
+        `/pm:epic-sync ${featureName}`
+      ]
     ));
-
-    // Create the actual PRD structure
-    await this.createDemoPRD();
 
     await this.waitForConfirmation();
 
     console.log(this.createStepFrame(
       3,
-      'Files Created - Ready for Claude!',
-      'The demo workflow has created:\n\n' +
-      '📄 .claude/prds/user-authentication.md\n' +
-      '📋 .claude/epics/user-authentication.md\n' +
-      '⚙️  Configuration files\n\n' +
-      '🚀 Now open Claude Code in this directory:\n\n' +
-      '1. Run: claude --bypass-permissions .\n' +
-      '2. Try these commands to see the workflow:\n' +
-      '   • /pm:status (see project overview)\n' +
-      '   • /pm:epic-show user-authentication\n' +
-      '   • /pm:next (get next task)\n\n' +
-      '💡 All PM commands (/pm:xxx) work only in Claude Code!'
+      'Start Working on Tasks',
+      'Now you can start working on individual tasks:\n\n' +
+      '• Get next priority task\n' +
+      '• Start working on specific issue\n' +
+      '• Check project status\n' +
+      '• View daily standup summary\n\n' +
+      '🚀 Open Claude Code and use these commands:',
+      [
+        '/pm:next',
+        '/pm:issue-start ISSUE-ID',
+        '/pm:status',
+        '/pm:standup'
+      ]
     ));
 
     await this.waitForConfirmation();
-  }
-
-  /**
-   * Create a demo PRD structure
-   */
-  async createDemoPRD() {
-    const fs = require('fs').promises;
-    const path = require('path');
-
-    try {
-      // Ensure directories exist
-      await fs.mkdir('.claude/prds', { recursive: true });
-      await fs.mkdir('.claude/epics', { recursive: true });
-
-      // Create PRD
-      const prdContent = `# User Authentication System
-
-## Problem Statement
-Users need a secure way to authenticate and manage their accounts.
-
-## User Stories
-- As a user, I want to register with email and password
-- As a user, I want to login securely
-- As a user, I want to reset my password if forgotten
-- As an admin, I want to manage user permissions
-
-## Acceptance Criteria
-- Email validation on registration
-- Password strength requirements
-- JWT token-based authentication
-- Password reset flow with email verification
-- Role-based access control
-
-## Technical Requirements
-- JWT authentication
-- Password hashing (bcrypt)
-- Email service integration
-- Session management
-- Rate limiting for login attempts
-
-## Success Metrics
-- Registration completion rate > 90%
-- Login success rate > 95%
-- Password reset completion rate > 80%
-`;
-
-      await fs.writeFile('.claude/prds/user-authentication.md', prdContent);
-
-      // Create Epic
-      const epicContent = `---
-epic_id: user-authentication
-title: User Authentication System
-status: planned
-priority: high
-created_date: ${new Date().toISOString().split('T')[0]}
----
-
-# Epic: User Authentication System
-
-## Overview
-Implement a complete user authentication system with registration, login, password management, and role-based access control.
-
-## Tasks
-1. **Setup Authentication Database Schema**
-   - Create users table
-   - Add indexes for email lookups
-   - Setup migration scripts
-
-2. **Implement User Registration**
-   - Email validation
-   - Password strength checking
-   - Duplicate email prevention
-
-3. **Build Login System**
-   - JWT token generation
-   - Session management
-   - Rate limiting
-
-4. **Password Reset Flow**
-   - Email-based reset tokens
-   - Secure token validation
-   - Password update functionality
-
-5. **Role-Based Access Control**
-   - Permission system design
-   - Admin user management
-   - Route protection middleware
-
-## Definition of Done
-- [ ] All user stories implemented
-- [ ] Unit tests coverage > 80%
-- [ ] Integration tests passing
-- [ ] Security audit completed
-- [ ] Documentation updated
-`;
-
-      await fs.writeFile('.claude/epics/user-authentication.md', epicContent);
-
-      console.log('   ✅ Demo files created successfully!');
-    } catch (error) {
-      console.log(`   ⚠️  Could not create demo files: ${error.message}`);
-      console.log('   (This is normal if directory is read-only)');
-    }
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.9.12",
+      "version": "1.9.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## Problem
User feedback: Guide should NOT create any files, only show instructions for Claude commands.

The previous approach was wrong - terminal guide was creating actual PRD/Epic files, but:
- Guide is for showing instructions only
- All PM work should happen in Claude Code
- Terminal should not perform PM actions

## Root Issue
Misunderstood the separation:
- **Terminal**: Installation, configuration, showing instructions  
- **Claude Code**: All PM commands and file creation

## Solution
Revert file creation and keep guide instruction-only:

### Before (Wrong)
```
Creating Demo PRD Structure
📝 Creating PRD template...
📋 Setting up epic structure...
✅ Demo files created successfully!
```

### After (Correct)
```
Generate PRD and Epic
Creating PRD for "user-authentication" and breaking it into tasks:

🚀 Next Steps - Open Claude Code:
1. Open Claude Code in this directory
2. Use these PM commands:
   • /pm:prd-new user-authentication --template
   • /pm:prd-parse user-authentication
```

## Changes
- Remove `createDemoPRD()` method entirely
- Return to instruction-only workflow
- Fix empty feature name issue (default to example)
- Keep clear separation: terminal = instructions, Claude = actions

## User Value
- Correct understanding of tool boundaries
- No unwanted file creation in terminal
- Clear guidance on where to perform PM actions
- Proper workflow separation