### PR TITLE
fix: config show now correctly displays Full DevOps installation options

### DIFF
--- a/bin/commands/config.js
+++ b/bin/commands/config.js
@@ -79,13 +79,28 @@ class ConfigCommand {
 
     console.log('│                                         │');
 
-    // Features - always show them
-    const dockerStatus = config.features?.dockerFirst ? '✅ Enabled' : '❌ Disabled';
-    console.log(`│ Docker First:    ${this.padRight(dockerStatus, 22)} │`);
+    // Installation Configuration - check both new and legacy formats
+    const dockerEnabled = config.tools?.docker?.enabled || config.features?.dockerFirst || false;
+    const dockerFirst = config.tools?.docker?.first || false;
+    const dockerStatus = dockerEnabled ? (dockerFirst ? '✅ Enabled (First)' : '✅ Enabled') : '❌ Disabled';
+    console.log(`│ Docker:          ${this.padRight(dockerStatus, 22)} │`);
 
-    const k8sStatus = config.features?.kubernetes ? '✅ Enabled' : '❌ Disabled';
+    const k8sEnabled = config.tools?.kubernetes?.enabled || config.features?.kubernetes || false;
+    const k8sStatus = k8sEnabled ? '✅ Enabled' : '❌ Disabled';
     console.log(`│ Kubernetes:      ${this.padRight(k8sStatus, 22)} │`);
 
+    // Execution strategy - check both formats
+    const executionStrategy = config.execution_strategy || config.execution?.strategy || 'adaptive';
+    console.log(`│ Execution:       ${this.padRight(executionStrategy, 22)} │`);
+
+    // Show parallel limit if hybrid strategy
+    if (executionStrategy === 'hybrid' && config.parallel_limit) {
+      console.log(`│ Parallel Limit:  ${this.padRight(config.parallel_limit.toString(), 22)} │`);
+    }
+
+    console.log('│                                         │');
+
+    // Features - optional/legacy features
     const mcpStatus = config.features?.mcp ? '✅ Enabled' : '❌ Disabled';
     console.log(`│ MCP:             ${this.padRight(mcpStatus, 22)} │`);
 
@@ -95,12 +110,6 @@ class ConfigCommand {
     // CI/CD
     const cicdPlatform = config.features?.cicd || 'not configured';
     console.log(`│ CI/CD:           ${this.padRight(cicdPlatform, 22)} │`);
-
-    console.log('│                                         │');
-
-    // Execution strategy
-    const executionStrategy = config.execution?.strategy || 'adaptive';
-    console.log(`│ Execution:       ${this.padRight(executionStrategy, 22)} │`);
 
     // Current team
     const currentTeam = config.teams?.current || 'base';

--- a/install/install.js
+++ b/install/install.js
@@ -39,6 +39,7 @@ class Installer {
       '.claude/rules',
       '.claude/scripts',
       '.claude/checklists',
+      '.claude/strategies',
       '.claude/mcp',
       '.claude/.env.example',
       '.claude-code'
@@ -345,11 +346,34 @@ ${this.colors.BOLD}Examples:${this.colors.NC}
     console.log(`
 ${this.colors.BOLD}Select installation scenario:${this.colors.NC}
 
-1. ${this.colors.CYAN}Minimal${this.colors.NC} - Sequential execution, no Docker/K8s
-2. ${this.colors.CYAN}Docker-only${this.colors.NC} - Adaptive execution with Docker
-3. ${this.colors.GREEN}Full DevOps${this.colors.NC} - Adaptive execution with all features ${this.colors.BOLD}(RECOMMENDED)${this.colors.NC}
-4. ${this.colors.YELLOW}Performance${this.colors.NC} - Hybrid parallel execution for power users
-5. ${this.colors.CYAN}Custom${this.colors.NC} - Configure manually
+${this.colors.CYAN}1. Minimal${this.colors.NC} - Traditional development workflow
+   • Sequential agent execution (one at a time)
+   • Native tooling: npm, pip, local installs
+   • Best for: Simple projects, learning, debugging
+   • No containers or orchestration
+
+${this.colors.CYAN}2. Docker-only${this.colors.NC} - Containerized local development
+   • Adaptive execution (smart sequential/parallel choice)
+   • Docker containers for development environment
+   • Best for: Microservices, consistent environments
+   • Local Docker only, no Kubernetes
+
+${this.colors.GREEN}3. Full DevOps${this.colors.NC} - Complete CI/CD pipeline ${this.colors.BOLD}(RECOMMENDED)${this.colors.NC}
+   • Adaptive execution with Docker-first priority
+   • Kubernetes manifests and cloud deployment ready
+   • GitHub Actions with KIND clusters and Kaniko builds
+   • Best for: Production applications, enterprise projects
+
+${this.colors.YELLOW}4. Performance${this.colors.NC} - Maximum parallel execution
+   • Hybrid strategy: up to 5 parallel agents
+   • Advanced context isolation and security
+   • Full DevOps capabilities with speed optimization
+   • Best for: Large projects, massive refactoring, power users
+
+${this.colors.CYAN}5. Custom${this.colors.NC} - Manual configuration
+   • Configure execution strategy manually
+   • Choose your own agents and workflows
+   • Advanced users only
 `);
 
     if (process.env.AUTOPM_TEST_MODE === '1') {


### PR DESCRIPTION
## Summary
- Fixed config display to properly show installation scenario differences
- Full DevOps now shows Docker and Kubernetes as enabled
- Minimal shows both as disabled  
- Performance shows hybrid execution with parallel limit

## Changes
- Updated config.js show() method to read from `tools.docker.enabled` and `tools.kubernetes.enabled`
- Added support for `execution_strategy` field (vs legacy `execution.strategy`)
- Shows Docker "First" indicator when `tools.docker.first` is true
- Displays `parallel_limit` for hybrid execution strategy
- Maintains backward compatibility with legacy config formats

## Test Plan
✅ Tested with minimal config (sequential, Docker/K8s disabled)
✅ Tested with Full DevOps config (adaptive, Docker first, K8s enabled)  
✅ Tested with Performance config (hybrid, parallel limit 5)

## Before/After
**Before**: All installation scenarios showed same minimal info
**After**: Each scenario shows correct Docker/K8s/execution settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)