### PR TITLE
docs: fix homepage Quick Start section formatting

### DIFF
--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -39,6 +39,27 @@ features:
 
 ---
 
+<style>
+.vp-doc h2 {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.vp-doc ul {
+  padding-left: 1.25rem;
+}
+
+.vp-doc li {
+  margin: 4px 0;
+}
+
+.vp-doc strong {
+  font-weight: 600;
+  color: var(--vp-c-brand);
+}
+</style>
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
Fixes poor formatting of the Quick Start and Why ClaudeAutoPM sections on the homepage.

## Problem
The sections below the hero on the homepage were displaying without proper styling:
- No spacing between headings
- Poor list formatting
- No visual hierarchy

## Solution
Added scoped CSS styles for the home page content sections:
- Added top border and spacing for h2 headings
- Improved list indentation and item spacing
- Applied brand color to emphasized text

## Preview
The Quick Start code block and Why ClaudeAutoPM list will now display with proper formatting matching the VitePress theme.

## Test plan
- [x] Added CSS styles scoped to .vp-doc class
- [x] Tested locally with `npm run docs:dev`
- [ ] Will verify on live site after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)