### PR TITLE
docs: fix navigation by removing links to non-existent pages

### DIFF
--- a/docs-site/docs/.vitepress/config.js
+++ b/docs-site/docs/.vitepress/config.js
@@ -39,43 +39,14 @@ export default defineConfig({
     sidebar: {
       '/guide/': [
         {
-          text: 'Introduction',
+          text: 'Getting Started',
           collapsed: false,
           items: [
-            { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Overview', link: '/guide/getting-started' },
             { text: 'Quick Start', link: '/guide/quick-start' },
             { text: 'Interactive Setup', link: '/guide/interactive-setup' },
             { text: 'Installation Guide', link: '/guide/installation' },
             { text: 'First Project', link: '/guide/first-project' }
-          ]
-        },
-        {
-          text: 'Core Concepts',
-          collapsed: false,
-          items: [
-            { text: 'Project Management', link: '/guide/project-management' },
-            { text: 'AI Agents', link: '/guide/ai-agents' },
-            { text: 'Execution Strategies', link: '/guide/execution-strategies' },
-            { text: 'Context Management', link: '/guide/context-management' }
-          ]
-        },
-        {
-          text: 'Providers',
-          collapsed: false,
-          items: [
-            { text: 'GitHub Integration', link: '/guide/github' },
-            { text: 'Azure DevOps', link: '/guide/azure-devops' },
-            { text: 'Provider Router', link: '/guide/provider-router' }
-          ]
-        },
-        {
-          text: 'Advanced',
-          collapsed: false,
-          items: [
-            { text: 'Custom Agents', link: '/guide/custom-agents' },
-            { text: 'Hooks & Automation', link: '/guide/hooks' },
-            { text: 'Performance Tuning', link: '/guide/performance' },
-            { text: 'Troubleshooting', link: '/guide/troubleshooting' }
           ]
         }
       ],
@@ -85,37 +56,9 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'Overview', link: '/commands/overview' },
-            { text: 'CLI Reference', link: '/commands/cli-reference' }
-          ]
-        },
-        {
-          text: 'Project Management',
-          collapsed: false,
-          items: [
+            { text: 'CLI Reference', link: '/commands/cli-reference' },
             { text: 'PM Commands', link: '/commands/pm-commands' },
-            { text: 'Epic Commands', link: '/commands/pm-epic' },
-            { text: 'Issue Commands', link: '/commands/pm-issue' },
-            { text: 'PRD Commands', link: '/commands/pm-prd' }
-          ]
-        },
-        {
-          text: 'Azure DevOps',
-          collapsed: false,
-          items: [
-            { text: 'Azure Integration', link: '/commands/azure-devops' },
-            { text: 'Task Commands', link: '/commands/azure-task' },
-            { text: 'User Story Commands', link: '/commands/azure-us' },
-            { text: 'Feature Commands', link: '/commands/azure-feature' }
-          ]
-        },
-        {
-          text: 'Development',
-          collapsed: true,
-          items: [
-            { text: 'Python Scaffolding', link: '/commands/python-scaffold' },
-            { text: 'React Scaffolding', link: '/commands/react-scaffold' },
-            { text: 'API Documentation', link: '/commands/api-docs' },
-            { text: 'Testing Commands', link: '/commands/testing' }
+            { text: 'Azure DevOps', link: '/commands/azure-devops' }
           ]
         }
       ],
@@ -166,9 +109,7 @@ export default defineConfig({
           text: 'System Architecture',
           collapsed: false,
           items: [
-            { text: 'Overview', link: '/architecture/overview' },
-            { text: 'Project Structure', link: '/architecture/structure' },
-            { text: 'Core Components', link: '/architecture/components' }
+            { text: 'Overview', link: '/architecture/overview' }
           ]
         }
       ]


### PR DESCRIPTION
## Summary
Fixes 404 errors in documentation navigation by removing links to pages that don't exist yet.

## Problem
Many navigation links in the sidebar pointed to non-existent pages:
- Guide section had 16 links, only 5 pages exist
- Commands section had 12 links, only 4 pages exist
- Architecture section had 3 links, only 1 page exists

This caused 404 errors when users clicked on navigation items.

## Solution
Updated VitePress sidebar configuration to only show existing pages:

**Guide** (5 pages)
- Overview, Quick Start, Interactive Setup, Installation, First Project

**Commands** (4 pages)
- Overview, CLI Reference, PM Commands, Azure DevOps

**Architecture** (1 page)
- Overview only

## Benefits
- No more 404 errors in navigation
- Better UX - users can navigate without hitting broken links
- Clean slate for gradually adding more documentation pages

## Test plan
- [x] Verified all linked pages exist in docs-site/docs/
- [x] Removed all non-existent page links
- [x] Maintained proper sidebar structure
- [ ] Will verify navigation works on live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)