### PR TITLE
fix: remove Node.js 16.x from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Problem
Jest 30+ uses `os.availableParallelism()` which is only available in Node.js 18.6+.

The previous PR was squashed without this fix, causing CI failures.

## Solution
Remove Node.js 16.x from test matrix.

## Impact
- ✅ CI tests will pass on Node.js 18.x and 20.x
- ✅ package.json can be updated to require Node.js >=18.0.0