### PR TITLE
docs: fix video paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,22 @@ ClaudeAutoPM uses a **hybrid approach** combining deterministic operations with 
 See ClaudeAutoPM in action - from installation to deployment:
 
 ### 1️⃣ Install AutoPM
-![Install AutoPM](Video%201.gif)
+![Install AutoPM](docs/assets/Video%201.gif)
 
 ### 2️⃣ First Claude Execution
-![First Claude Execution](Video%202.gif)
+![First Claude Execution](docs/assets/Video%202.gif)
 
 ### 3️⃣ Creation of PRD
-![Create PRD](Video%203.gif)
+![Create PRD](docs/assets/Video%203.gif)
 
 ### 4️⃣ GitHub Sync and Start Working on Issues
-![GitHub Sync](Video%204.gif)
+![GitHub Sync](docs/assets/Video%204.gif)
 
 ### 5️⃣ Issues Finished
-![Issues Complete](Video%205.gif)
+![Issues Complete](docs/assets/Video%205.gif)
 
 ### 6️⃣ Checking the Work Done (Web App + FastAPI)
-![Web App and FastAPI](Video%206.gif)
+![Web App and FastAPI](docs/assets/Video%206.gif)
 
 ## 🚀 Get Started in 5 Minutes
 


### PR DESCRIPTION
## Summary
- Fixed video GIF paths in README to point to `docs/assets/` directory
- Videos were previously moved but README still referenced root directory
- Updated all 6 video references

## Changes
- `Video 1.gif` → `docs/assets/Video 1.gif`
- `Video 2.gif` → `docs/assets/Video 2.gif`  
- `Video 3.gif` → `docs/assets/Video 3.gif`
- `Video 4.gif` → `docs/assets/Video 4.gif`
- `Video 5.gif` → `docs/assets/Video 5.gif`
- `Video 6.gif` → `docs/assets/Video 6.gif`

## Test Plan
- [x] Videos display correctly in README
- [x] All paths point to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)