### PR TITLE
🚨 CRITICAL: Fix MCP sync deleting all server configurations

### DIFF
--- a/.claude/config.json
+++ b/.claude/config.json
@@ -60,5 +60,10 @@
       "docker compose",
       "make"
     ]
+  },
+  "mcp": {
+    "activeServers": [
+      "context7-docs"
+    ]
   }
 }


### PR DESCRIPTION
## 🚨 Critical Bug Fix

This PR fixes a **critical data loss bug** in `autopm mcp sync` that was deleting all MCP server configurations.

### 🐛 Bug Description

When running `autopm mcp sync` with no active servers in `config.json`, the command would:
1. Detect `activeServers: []` is empty
2. **Delete entire `mcp-servers.json`** and replace with empty configuration
3. Result: All configured servers (context7-docs, github-mcp, playwright-mcp, etc.) were lost

### 📝 Example of Bug

```bash
# Before bug:
$ cat .claude/mcp-servers.json
{
  "mcpServers": {
    "context7-docs": { ... },
    "github-mcp": { ... },
    "playwright-mcp": { ... }
  }
}

# Run sync with empty activeServers:
$ autopm mcp sync
ℹ️ No active servers to sync

# After bug - ALL SERVERS DELETED:
$ cat .claude/mcp-servers.json
{
  "mcpServers": {},
  "contextPools": {},
  "documentationSources": {}
}
```

### ✅ Fix Implementation

**Changed behavior:**
1. **Read existing** `mcp-servers.json` before sync
2. **Preserve all servers** in the file
3. **Update only active servers** from registry
4. **Never delete** existing configuration

**New sync logic:**
```javascript
// Read existing configuration
let existingMcpConfig = readExistingFile();

// If no active servers, preserve existing
if (activeServers.length === 0) {
  console.log('💡 Preserving existing servers');
  return; // Don't touch the file
}

// Start with existing, update only active
const mcpConfig = {
  mcpServers: existingMcpConfig.mcpServers,  // Keep all
  // ... update only activeServers
};
```

### 🔧 Additional Fix

**Added `mcp.activeServers` to `.claude/config.json`:**
- Enables Claude Code `/mcp` command to see configured servers
- Without this section, Claude Code shows "No MCP servers configured"
- Now properly integrates with Claude Code interface

### 📊 Test Results

```bash
$ autopm mcp sync
🔄 Syncing MCP server configuration...

  ✅ Synced: context7-docs

✅ Configuration synced to .claude/mcp-servers.json
📊 Active servers: 1
📦 Total servers in file: 4  # ← All 4 servers preserved!
```

### 🎯 Impact

**Before this fix:**
- ❌ Running `autopm mcp sync` with no active servers = data loss
- ❌ Claude Code `/mcp` shows "No servers configured"
- ❌ Users lost all their MCP server configurations

**After this fix:**
- ✅ Safe to run `autopm mcp sync` anytime
- ✅ All servers preserved, only active ones updated
- ✅ Claude Code properly sees MCP servers
- ✅ No more data loss risk

### 📝 Files Changed

- `scripts/mcp-handler.js` (+27, -17 lines):
  - Read existing mcp-servers.json before sync
  - Preserve all servers, update only active
  - Better logging with total servers count
  
- `.claude/config.json` (+5 lines):
  - Added `mcp.activeServers` section
  - Enables Claude Code integration

### ⚠️ Breaking Changes

**None** - This is a pure bugfix that makes sync safer.

### 🧪 Testing

- [x] Tested sync with no active servers - preserves existing
- [x] Tested sync with one active server - updates correctly
- [x] Tested that all 4 servers remain after sync
- [x] Verified Claude Code can now see MCP configuration

### 🚀 Deployment

This fix should be released **immediately** as:
- **v1.13.5 (patch)** - Critical bugfix

Users who ran `autopm mcp sync` and lost their configuration should:
1. Restore from git: `git checkout .claude/mcp-servers.json`
2. Or run `autopm mcp enable <server-name>` to re-add servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)