### PR TITLE
Release v1.13.6 - MCP Format Compatibility Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.6] - 2025-10-01
+
+### 🐛 Bug Fix
+
+**MCP Environment Variable Format**
+- Fixed `autopm mcp sync` copying metadata objects instead of simple strings
+- Claude Code expects `"VAR": "value"` not `"VAR": {default: "value"}`
+- Added `_convertEnvMetadataToStrings()` to convert registry metadata to Claude Code format
+- **Impact: Claude Code `/mcp` command now works correctly**
+
+### 🔧 Technical Changes
+
+**`scripts/mcp-handler.js`:**
+- Added `_convertEnvMetadataToStrings(envObj)` helper method
+- Converts env metadata objects to simple string format
+- Handles three cases:
+  1. Already string → keep unchanged
+  2. Metadata with literal default → use literal value
+  3. Metadata with empty default → use `${VAR:-}` format
+- Modified `sync()` to use conversion before writing
+
+### 📊 Format Conversion
+
+**Before (v1.13.5):**
+```json
+"env": {
+  "CONTEXT7_API_KEY": {              // ❌ Object
+    "default": "",
+    "description": "Your Context7 API key",
+    "required": true
+  }
+}
+```
+
+**After (v1.13.6):**
+```json
+"env": {
+  "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY:-}",  // ✅ String
+  "CONTEXT7_MODE": "documentation"                // ✅ Literal
+}
+```
+
+### 🎯 User Impact
+
+- ✅ Claude Code can parse MCP configurations
+- ✅ `/mcp` command shows servers correctly
+- ✅ Backward compatible with existing formats
+- ✅ Preserves literal defaults from registry
+- ✅ MCP servers now work in Claude Code interface
+
 ## [1.13.5] - 2025-10-01
 
 ### 🚨 Critical Bug Fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.13.5",
+      "version": "1.13.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## Release v1.13.6 - MCP Format Compatibility

This release fixes env variable format incompatibility with Claude Code.

### 🐛 Bug Fixed

**MCP Environment Variable Format**
- `autopm mcp sync` was writing metadata objects instead of simple strings
- Claude Code couldn't parse the format: `{"default": "value", "required": true}`
- **This fix ensures Claude Code can see and use MCP servers**

### ✅ What's Fixed

**Added format conversion:**
```javascript
_convertEnvMetadataToStrings() {
  // Converts:
  // {default: "", required: true} → "${VAR:-}"
  // {default: "literal"} → "literal"  
  // "existing string" → "existing string"
}
```

### 📊 Format Change

**Before (v1.13.5):**
```json
"env": {
  "CONTEXT7_API_KEY": {
    "default": "",
    "description": "Your Context7 API key",
    "required": true
  }
}
```

**After (v1.13.6):**
```json
"env": {
  "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY:-}",
  "CONTEXT7_MODE": "documentation"
}
```

### 🎯 Impact

- ✅ Claude Code can now parse MCP configurations
- ✅ `/mcp` command shows servers correctly
- ✅ Backward compatible with existing string formats
- ✅ Users can finally use MCP servers in Claude Code

### 📦 Version

- Bump: 1.13.5 → **1.13.6** (patch)
- CHANGELOG updated
- Ready for npm publish

### 🔧 How to Update

```bash
npm install -g claude-autopm@1.13.6
cd your-project
autopm mcp sync  # Will convert to correct format
```

Then restart Claude Code to see MCP servers.

### ✅ Checklist

- [x] Format conversion implemented
- [x] Version bumped to 1.13.6
- [x] CHANGELOG updated
- [x] Backward compatible
- [x] Ready for npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)