### PR TITLE
fix: enhance config display with actionable instructions (v1.13.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.9] - 2025-10-01
+
+### 🎨 UX Improvement
+
+**Enhanced Configuration Display (`autopm config show`)**
+- Fixed confusing MCP status messages
+- Added helpful configuration instructions
+- Shows exact steps to fix missing settings
+- **Impact: Users now know exactly how to configure AutoPM**
+
+### 🎯 What Changed
+
+**`bin/commands/config.js`:**
+- Fixed MCP status display - now shows "X active", "X configured", or "Not configured"
+- Checks both `config.mcp.activeServers` and `.claude/mcp-servers.json`
+- Added "Configuration Issues" section with actionable solutions
+- Shows exactly how to set GitHub owner, repo, and token
+- Shows how to set Azure organization, project, and PAT
+- Fixed execution strategy display when it's an object
+- Made `padRight()` safer by converting all inputs to strings
+
+### 📊 Before vs After
+
+**Before (v1.13.8):**
+```
+│ MCP:             ❌ Disabled             │
+```
+*User confused: "I have servers configured!"*
+
+**After (v1.13.9):**
+```
+│ MCP:             ⚠️  2 configured       │
+```
+```
+📋 Configuration Issues:
+
+⚠️  GitHub token not set
+   → Add to .claude/.env: GITHUB_TOKEN=ghp_your_token_here
+
+ℹ️  2 MCP server(s) configured but not active
+   → Run: autopm mcp list  (then: autopm mcp enable <server>)
+```
+
+### 🎯 User Impact
+
+✅ Clear MCP status (active vs configured vs missing)
+✅ Actionable instructions for every missing setting
+✅ Shows exact commands to run
+✅ Shows where to add tokens (.claude/.env)
+✅ No more confusion about configuration state
+
+### 🔧 Technical Details
+
+**MCP Status Logic:**
+1. If `config.mcp.activeServers` exists → show "X active" ✅
+2. Else check `.claude/mcp-servers.json` → show "X configured" ⚠️
+3. Else → show "Not configured" ❌
+
+**Configuration Issues:**
+- Detects missing provider, owner, repo, tokens
+- Shows platform-specific instructions (GitHub vs Azure)
+- Different icon per issue type (⚠️ for problems, ℹ️ for info)
+
 ## [1.13.8] - 2025-10-01
 
 ### ✨ Feature

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## 🎨 UX Fix: Clear Configuration Display

### Problem
Users were confused by the configuration display:
- MCP showed "❌ Disabled" even when servers were configured
- No guidance on HOW to fix missing settings
- Execution strategy showed "[object Object]"
- Inconsistent between "configured" and "active" states

### Solution
Complete UX overhaul of `autopm config show`:
- Clear MCP status: "X active", "X configured", or "Not configured"
- Added "Configuration Issues" section with step-by-step fixes
- Shows exact commands for every missing setting
- Platform-specific instructions (GitHub vs Azure)

### Changes

**bin/commands/config.js:**
- Fixed MCP status detection (checks both config and mcp-servers.json)
- Added configuration issues detection with solutions
- Fixed execution strategy when stored as object
- Made padRight() safer with type conversion

**Before:**
```
│ MCP:             ❌ Disabled             │
```
User: "But I have servers configured! 😕"

**After:**
```
│ MCP:             ⚠️  2 configured       │
```
```
📋 Configuration Issues:

⚠️  GitHub token not set
   → Add to .claude/.env: GITHUB_TOKEN=ghp_your_token_here

ℹ️  2 MCP server(s) configured but not active
   → Run: autopm mcp list  (then: autopm mcp enable <server>)
```

### Testing
- [x] Tested in AUTOPM project (1 active MCP server) ✅
- [x] Tested in voucher project (2 configured, 0 active) ✅
- [x] Tested with missing GitHub config ✅
- [x] All Jest tests pass (33/33) ✅

### User Impact

✅ Crystal clear configuration status
✅ Actionable instructions for every issue
✅ No more confusion about MCP state
✅ Exact commands to run
✅ Shows where to add credentials

### Version
1.13.9 (patch release - UX fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)