### PR TITLE
fix: correct MCP package names and remove deprecated (v1.13.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.11] - 2025-10-01
+
+### 🐛 Bug Fix: Corrected Playwright MCP Package Name
+
+**Fixed incorrect Playwright MCP package name**
+- Changed from non-existent `@playwright/mcp-server` to actual `@playwright/mcp`
+- **Impact: Playwright MCP server can now start in Claude Code**
+
+### 🗑️ Breaking Change: Removed Deprecated GitHub MCP
+
+**Removed deprecated GitHub MCP server from default configuration**
+- `@modelcontextprotocol/server-github` is deprecated by maintainers
+- GitHub now provides official server via Copilot API with HTTP transport
+- **Impact: Users need to manually add GitHub MCP if needed**
+
+### 🎯 What Changed
+
+**autopm/.claude/mcp-servers.json:**
+```json
+// Playwright - Fixed:
+"args": ["@playwright/mcp"]  // ✅ Was: @playwright/mcp-server
+
+// GitHub - Removed (deprecated)
+// Use: claude mcp add --transport http github ...
+```
+
+**package.json:**
+```json
+"optionalDependencies": {
+  "@upstash/context7-mcp": "^1.0.0",
+  "@playwright/mcp": "^0.0.40"
+}
+```
+
+### 📊 Default MCP Servers
+
+**After v1.13.11:**
+- ✅ `context7-docs` - Documentation (@upstash/context7-mcp)
+- ✅ `context7-codebase` - Codebase analysis (@upstash/context7-mcp)
+- ✅ `playwright-mcp` - Browser automation (@playwright/mcp)
+- ❌ `github-mcp` - REMOVED (deprecated)
+
+### 📖 Adding GitHub MCP Manually
+
+**New official GitHub MCP (via Copilot API):**
+```bash
+claude mcp add --transport http github \
+  https://api.githubcopilot.com/mcp \
+  -H "Authorization: Bearer $GITHUB_PAT"
+```
+
+See: https://github.com/github/github-mcp-server
+
+### 🔄 Migration
+
+**For existing projects:**
+```bash
+cd your-project
+autopm mcp sync  # Updates with correct packages
+```
+
 ## [1.13.10] - 2025-10-01
 
 ### 🐛 Critical Bug Fix

--- a/autopm/.claude/mcp-servers.json
+++ b/autopm/.claude/mcp-servers.json
@@ -26,20 +26,11 @@
     },
     "playwright-mcp": {
       "command": "npx",
-      "args": ["@playwright/mcp-server"],
+      "args": ["@playwright/mcp"],
       "env": {
         "PLAYWRIGHT_BROWSER": "chromium",
         "PLAYWRIGHT_HEADLESS": "true"
       }
-    },
-    "github-mcp": {
-      "command": "npx",
-      "args": ["@modelcontextprotocol/server-github"],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN:-}",
-        "GITHUB_API_URL": "https://api.github.com"
-      },
-      "envFile": ".claude/.env"
     }
   },
   "contextPools": {
@@ -82,9 +73,9 @@
     "devops-context": {
       "type": "shared",
       "agents": ["github-operations-specialist", "kubernetes-orchestrator", "azure-devops-specialist"],
-      "sources": ["context7-docs", "github-mcp"],
+      "sources": ["context7-docs"],
       "filters": ["github-actions", "kubernetes", "ci-cd"],
-      "maxSize": "100MB", 
+      "maxSize": "100MB",
       "retention": "7d",
       "refresh": "daily"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.13.10",
+  "version": "1.13.11",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {
@@ -149,8 +149,7 @@
   },
   "optionalDependencies": {
     "@upstash/context7-mcp": "^1.0.0",
-    "@modelcontextprotocol/server-github": "^1.0.0",
-    "@playwright/mcp-server": "^1.0.0"
+    "@playwright/mcp": "^0.0.40"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## 🐛 Bug Fix: Corrected All MCP Package Names

### Problems Fixed

1. **Playwright MCP** - Wrong package name
   - ❌ Was: `@playwright/mcp-server` (doesn't exist)
   - ✅ Now: `@playwright/mcp` (official package v0.0.40)

2. **GitHub MCP** - Deprecated package
   - ❌ Was: `@modelcontextprotocol/server-github` (deprecated)
   - ✅ Removed from defaults (use Copilot API instead)

### Changes

**autopm/.claude/mcp-servers.json:**
- Fixed Playwright to use `@playwright/mcp`
- Removed deprecated github-mcp server
- Cleaned up contextPools references

**package.json:**
```json
"optionalDependencies": {
  "@upstash/context7-mcp": "^1.0.0",  // v1.13.10
  "@playwright/mcp": "^0.0.40"        // NEW - fixed
  // Removed: @playwright/mcp-server (didn't exist)
  // Removed: @modelcontextprotocol/server-github (deprecated)
}
```

### Default MCP Servers

**After v1.13.11:**
- ✅ `context7-docs` - Documentation (@upstash/context7-mcp)
- ✅ `context7-codebase` - Codebase analysis (@upstash/context7-mcp)
- ✅ `playwright-mcp` - Browser automation (@playwright/mcp) **FIXED**
- ❌ `github-mcp` - **REMOVED** (deprecated)

### GitHub MCP Alternatives

**Option 1: Official GitHub MCP (via Copilot API)**
```bash
claude mcp add --transport http github \
  https://api.githubcopilot.com/mcp \
  -H "Authorization: Bearer $GITHUB_PAT"
```

**Option 2: Community alternatives**
- `github-mcp-server` (npm, v1.8.7)
- `github-mcp-scoped-server` (npm, v1.5.0)

### Testing
- [x] Verified @playwright/mcp exists (v0.0.40) ✅
- [x] Verified package structure ✅
- [x] All Jest tests pass (33/33) ✅
- [x] Removed all github-mcp references ✅

### User Impact

**Before (v1.13.10):**
```
Claude Code MCP:
❯ 1. context7-docs       ✓ running
  2. context7-codebase   ✓ running
  3. playwright-mcp      ✘ failed  ← Wrong package
  4. github-mcp          ⚠️ deprecated
```

**After (v1.13.11):**
```
Claude Code MCP:
❯ 1. context7-docs       ✓ running
  2. context7-codebase   ✓ running
  3. playwright-mcp      ✓ running  ← FIXED!
```

### Migration

**For existing projects:**
```bash
cd your-project
autopm mcp sync  # Updates .mcp.json automatically
```

### Version
1.13.11 (patch release - bug fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)