### PR TITLE
fix: correct MCP package names in server definition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.13] - 2025-10-01
+
+### 🐛 Critical Bug Fix: MCP Server Definition Files
+
+**Fixed incorrect package names in MCP server definition files**
+
+The v1.13.10 and v1.13.11 releases fixed package names in `mcp-servers.json` but forgot to update the individual server definition files in `autopm/.claude/mcp/`. This caused servers to fail validation and not appear in `autopm mcp list`.
+
+### 🎯 What Was Fixed
+
+**Fixed Files:**
+- `autopm/.claude/mcp/context7-docs.md`: `@context7/mcp-server` → `@upstash/context7-mcp`
+- `autopm/.claude/mcp/context7-codebase.md`: `@context7/mcp-server` → `@upstash/context7-mcp`
+- `autopm/.claude/mcp/context7-codebase.md`: Added missing `https://` to URL defaults
+- `autopm/.claude/mcp/playwright-mcp.md`: `@playwright/mcp-server` → `@playwright/mcp`
+
+### 📊 Impact
+
+**Before v1.13.13:**
+- `autopm mcp list` showed only context7 servers
+- playwright-mcp didn't appear in list
+- Server validation failed silently
+
+**After v1.13.13:**
+- All servers appear in `autopm mcp list`
+- All package names are correct and consistent
+- Server validation works properly
+
+### 🔄 Upgrade
+
+```bash
+npm install -g claude-autopm@latest
+```
+
 ## [1.13.12] - 2025-10-01
 
 ### ✨ Enhancement: Post-Configuration Guidance

--- a/autopm/.claude/mcp/context7-codebase.md
+++ b/autopm/.claude/mcp/context7-codebase.md
@@ -1,11 +1,11 @@
 ---
 name: context7-codebase
 command: npx
-args: ["@context7/mcp-server"]
+args: ["@upstash/context7-mcp"]
 env:
   CONTEXT7_API_KEY: "${CONTEXT7_API_KEY:-}"
-  CONTEXT7_MCP_URL: "${CONTEXT7_MCP_URL:-mcp.context7.com/mcp}"
-  CONTEXT7_API_URL: "${CONTEXT7_API_URL:-context7.com/api/v1}"
+  CONTEXT7_MCP_URL: "${CONTEXT7_MCP_URL:-https://mcp.context7.com/mcp}"
+  CONTEXT7_API_URL: "${CONTEXT7_API_URL:-https://context7.com/api/v1}"
   CONTEXT7_WORKSPACE: "${CONTEXT7_WORKSPACE:-}"
   CONTEXT7_MODE: "codebase"
 envFile: .claude/.env

--- a/autopm/.claude/mcp/context7-docs.md
+++ b/autopm/.claude/mcp/context7-docs.md
@@ -1,7 +1,7 @@
 ---
 name: context7-docs
 command: npx
-args: ["@context7/mcp-server"]
+args: ["@upstash/context7-mcp"]
 env:
   CONTEXT7_API_KEY:
     default: ""

--- a/autopm/.claude/mcp/playwright-mcp.md
+++ b/autopm/.claude/mcp/playwright-mcp.md
@@ -1,7 +1,7 @@
 ---
 name: playwright-mcp
 command: npx
-args: ["@playwright/mcp-server"]
+args: ["@playwright/mcp"]
 env:
   PLAYWRIGHT_BROWSER: "${PLAYWRIGHT_BROWSER:-chromium}"
   PLAYWRIGHT_HEADLESS: "${PLAYWRIGHT_HEADLESS:-true}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.13.12",
+  "version": "1.13.13",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## 🐛 Critical Bug Fix

Fixed incorrect package names in MCP server definition files that were preventing servers from appearing in `autopm mcp list`.

## Problem

The v1.13.10 and v1.13.11 releases fixed package names in `mcp-servers.json` but forgot to update the individual server definition files in `autopm/.claude/mcp/`. This caused:
- Servers to fail validation silently
- playwright-mcp not appearing in `autopm mcp list`
- Inconsistency between config and server definitions

## Changes

**Fixed Files:**
- `autopm/.claude/mcp/context7-docs.md`: `@context7/mcp-server` → `@upstash/context7-mcp`
- `autopm/.claude/mcp/context7-codebase.md`: `@context7/mcp-server` → `@upstash/context7-mcp`
- `autopm/.claude/mcp/context7-codebase.md`: Added missing `https://` prefix to URL defaults
- `autopm/.claude/mcp/playwright-mcp.md`: `@playwright/mcp-server` → `@playwright/mcp`

## Impact

**Before:**
```bash
$ autopm mcp list
📡 Available MCP Servers:

⚪ Inactive context7-codebase
⚪ Inactive context7-docs
# playwright-mcp missing!
```

**After:**
```bash
$ autopm mcp list
📡 Available MCP Servers:

⚪ Inactive context7-codebase
⚪ Inactive context7-docs
⚪ Inactive playwright-mcp
```

## Test Plan
- [x] Fixed all package names in .md files
- [x] Added https:// prefix where missing
- [x] Verified consistency with mcp-servers.json
- [x] All changes are in definition files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)