### PR TITLE
fix: installer now creates package.json and installs dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.4] - 2025-10-02
+
+### 🐛 Bug Fix: Missing Dependencies After Installation
+
+**Fixed installer not creating package.json or installing dependencies**
+
+The installer was not creating `package.json` in user projects, causing PM scripts like `epic-split.js` to fail with "Cannot find module 'js-yaml'" error.
+
+### 🎯 What Was Fixed
+
+1. **Added package.json.template handling:**
+   - Template now includes `js-yaml` dependency
+   - Installer creates `package.json` from template if it doesn't exist
+   - Auto-fills project name from directory name
+
+2. **Added automatic dependency installation:**
+   - Installer now runs `npm install` after copying files
+   - Only installs if `package.json` has dependencies
+   - Provides helpful error message if installation fails
+
+3. **Fixed PM script requirements:**
+   - `epic-split.js` now has required `js-yaml` dependency
+   - All other PM scripts will have dependencies available
+
+### 📊 Impact
+
+**Before v1.15.4:**
+```bash
+autopm install
+# Creates .claude/ but NO package.json
+# User runs /pm:epic-split
+# ERROR: Cannot find module 'js-yaml'
+```
+
+**After v1.15.4:**
+```bash
+autopm install
+# ✅ Creates package.json with dependencies
+# ✅ Runs npm install automatically
+# ✅ js-yaml installed and ready
+# User runs /pm:epic-split
+# ✅ Works perfectly!
+```
+
+### 🔧 Technical Changes
+
+**Files Modified:**
+- `autopm/scripts/package.json.template` - Added `js-yaml: ^4.1.0`
+- `install/install.js` - Added `installDependencies()` method
+- `install/install.js` - Added package.json creation logic in `installScripts()`
+
+### 📝 Migration Notes
+
+**For existing installations:**
+```bash
+# Add to your project root:
+npm install js-yaml
+
+# Or recreate package.json:
+cp autopm/scripts/package.json.template package.json
+npm install
+```
+
+**For new installations:**
+- Everything works automatically! 🎉
+
 ## [1.13.13] - 2025-10-01
 
 ### 🐛 Critical Bug Fix: MCP Server Definition Files

--- a/autopm/scripts/package.json.template
+++ b/autopm/scripts/package.json.template
@@ -1,30 +1,33 @@
 {
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
   "scripts": {
     "// Safety Scripts": "Safeguards against bad commits",
     "precommit": "npm test && npm run build && npm run lint",
     "verify": "npm test && npm run build && npm run lint && npm run typecheck",
     "safe-commit": "./scripts/safe-commit.sh",
     "prepush": "npm run verify && npm run test:e2e",
-    
+
     "// Quick Checks": "Quick checks",
     "check": "npm run lint && npm run typecheck",
     "check:all": "npm run verify",
-    
+
     "// Git Helpers": "Git helper commands",
     "commit": "npm run precommit && git add -A && git commit",
     "push:safe": "npm run prepush && git push",
-    
+
     "// CI/CD Simulation": "Local CI/CD simulation",
     "ci:local": "npm ci && npm run verify && npm run test:e2e",
     "ci:validate": "npm run ci:local",
-    
+
     "// Emergency": "Emergency",
     "fix": "npm run lint -- --fix && npm run format",
     "format": "prettier --write .",
     "clean:hooks": "rm -f .git/hooks/pre-* && npm run setup:hooks",
     "setup:hooks": "husky install || cp scripts/hooks/* .git/hooks/"
   },
-  
+
   "husky": {
     "hooks": {
       "pre-commit": "npm run precommit",
@@ -32,7 +35,7 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
-  
+
   "// Usage examples": [
     "npm run safe-commit 'feat: add new feature'",
     "npm run verify",


### PR DESCRIPTION
## Problem
User reported: `epic-split.js` failed with `Cannot find module 'js-yaml'`

**Root Cause:**
- Installer didn't create `package.json` in user projects  
- No dependencies were installed
- PM scripts requiring `js-yaml` failed immediately

## Solution

### 1. Added package.json.template with dependencies
```json
{
  "dependencies": {
    "js-yaml": "^4.1.0"
  },
  "scripts": { ... }
}
```

### 2. Installer creates package.json
- Reads `autopm/scripts/package.json.template`
- Auto-fills project name from directory
- Creates `package.json` in project root if missing

### 3. Installer runs npm install
- New `installDependencies()` method
- Runs after all file copying
- Only installs if dependencies exist
- Graceful error handling

## Changes

**Files Modified:**
- `autopm/scripts/package.json.template` - Added js-yaml dependency
- `install/install.js` - Added package.json creation logic
- `install/install.js` - Added installDependencies() method
- `CHANGELOG.md` - Documented changes

## Testing

### Test 1: Clean Installation
```bash
cd /tmp/autopm-test
node install/install.js --scenario=minimal
```

**Results:**
```
✅ Created package.json
✅ Installing npm dependencies...
✅ added 2 packages
✅ Dependencies installed successfully
```

### Test 2: epic-split.js works
```bash
cd /tmp/autopm-test
node .claude/scripts/pm/epic-split.js testapp
```

**Results:**
```
✅ No "Cannot find module" error
✅ Epic split completed successfully
✅ 4 epics created
```

## Impact

**Before:**
```bash
autopm install
# No package.json created ❌
# /pm:epic-split fails ❌
```

**After:**
```bash
autopm install
# Creates package.json ✅
# Installs js-yaml ✅
# /pm:epic-split works ✅
```

## Migration Notes

**For existing installations:**
```bash
npm install js-yaml
```

**For new installations:**
- Everything works automatically! 🎉

Generated with [Claude Code](https://claude.com/claude-code)