### PR TITLE
chore: bump version to 1.15.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.15.4",
+      "version": "1.15.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
Version bump to 1.15.5

Includes installer fix for package.json creation and dependency installation.

Published to npm: https://www.npmjs.com/package/claude-autopm/v/1.15.5