### PR TITLE
fix: Replace deprecated docker-expert with docker-containerization-expert

### DIFF
--- a/autopm/.claude/agents/frameworks/nats-messaging-expert.md
+++ b/autopm/.claude/agents/frameworks/nats-messaging-expert.md
@@ -130,7 +130,7 @@ Use these queries:
 
 ## Integration Points
 
-- Works with: kubernetes-orchestrator, docker-expert, nodejs-backend-engineer, python-backend-engineer, github-operations-specialist
+- Works with: kubernetes-orchestrator, docker-containerization-expert, nodejs-backend-engineer, python-backend-engineer, github-operations-specialist
 - Provides to: Microservices, event systems, real-time apps, distributed systems
 - Client libraries: Go, Python, Node.js, Java, C#, Rust
 

--- a/autopm/.claude/commands/infrastructure/traefik-setup.md
+++ b/autopm/.claude/commands/infrastructure/traefik-setup.md
@@ -38,5 +38,5 @@ Parameters: environment=production, ssl=letsencrypt, discovery=docker, features=
 ```
 
 ## Related Agents
-- docker-expert: For container configuration
+- docker-containerization-expert: For container configuration
 - kubernetes-orchestrator: For K8s integration

--- a/autopm/.claude/hooks/docker-first-enforcement.sh
+++ b/autopm/.claude/hooks/docker-first-enforcement.sh
@@ -89,7 +89,7 @@ check_docker_files() {
     if [[ ${#missing_files[@]} -gt 0 ]]; then
         echo ""
         echo "📝 MISSING FILES: ${missing_files[*]}"
-        echo "💡 TIP: Use docker-expert agent to create Docker files:"
+        echo "💡 TIP: Use docker-containerization-expert agent to create Docker files:"
         echo "   Task: Create Docker development environment for this project"
         echo ""
     fi

--- a/autopm/.claude/rules/docker-first-development.md
+++ b/autopm/.claude/rules/docker-first-development.md
@@ -43,7 +43,7 @@ project/
 ```bash
 # 1. Check if Docker files exist
 if [ ! -f "Dockerfile" ]; then
-  Use docker-expert agent to create Dockerfile
+  Use docker-containerization-expert agent to create Dockerfile
 fi
 
 # 2. Build development image

--- a/autopm/.claude/rules/infrastructure-pipeline.md
+++ b/autopm/.claude/rules/infrastructure-pipeline.md
@@ -23,7 +23,7 @@
 **Sequence**:
 
 ```
-1. docker-expert → Optimize Dockerfile
+1. docker-containerization-expert → Optimize Dockerfile
 2. Security scan with Trivy/Snyk
 3. Build multi-stage image
 4. test-runner → Test container functionality

--- a/autopm/.claude/templates/claude-templates/addons/devops-agents.md
+++ b/autopm/.claude/templates/claude-templates/addons/devops-agents.md
@@ -20,7 +20,7 @@ Use specialized agents for Docker + Kubernetes workflows:
 
 ### Container Specialists
 
-#### docker-expert
+#### docker-containerization-expert
 **Use for**: Production-grade images
 - Multi-stage builds
 - Security hardening

--- a/autopm/.claude/templates/claude-templates/addons/docker-agents.md
+++ b/autopm/.claude/templates/claude-templates/addons/docker-agents.md
@@ -4,7 +4,7 @@ Use Docker-aware agents for containerized development:
 
 ### Docker Specialists (PRIMARY)
 
-#### docker-expert
+#### docker-containerization-expert
 **Use for**: Dockerfile optimization, multi-stage builds, security
 - Container best practices
 - Image size optimization


### PR DESCRIPTION
## 🐛 Bug Fix: Agent Not Found Error

Fixes the error: `Agent type 'docker-expert' not found`

### Problem

The `docker-expert` agent was deprecated and replaced with `docker-containerization-expert`, but several files still referenced the old agent name.

### Changes

Updated all references from `docker-expert` to `docker-containerization-expert` in:

1. **Commands**
   - `autopm/.claude/commands/infrastructure/traefik-setup.md`

2. **Hooks**
   - `autopm/.claude/hooks/docker-first-enforcement.sh`

3. **Rules**
   - `autopm/.claude/rules/docker-first-development.md`
   - `autopm/.claude/rules/infrastructure-pipeline.md`

4. **Templates**
   - `autopm/.claude/templates/claude-templates/addons/devops-agents.md`
   - `autopm/.claude/templates/claude-templates/addons/docker-agents.md`

5. **Agents**
   - `autopm/.claude/agents/frameworks/nats-messaging-expert.md`

### Impact

- ✅ Fixes "Agent type 'docker-expert' not found" error
- ✅ All Docker-related commands now use correct agent name
- ✅ No breaking changes (docker-containerization-expert already exists)
- ✅ Consistent agent naming across framework

### Testing

```bash
# Verify no more docker-expert references (except in migration docs)
grep -r "docker-expert" autopm/.claude/ | grep -v AGENT-REGISTRY | grep -v docker-containerization-expert.md
```

**Result**: Only migration documentation references remain (intentional)