### PR TITLE
fix: Add mongodb-expert to backend-context pool

### DIFF
--- a/autopm/.claude/rules/agent-coordination.md
+++ b/autopm/.claude/rules/agent-coordination.md
@@ -103,7 +103,7 @@ Notes: Added rate limiting middleware
 
 ```yaml
 backend-context:
-  agents: [python-backend-expert, postgresql-expert]
+  agents: [python-backend-expert, postgresql-expert, mongodb-expert]
   sources: [context7, context7]
   filters: [python, fastapi, flask, django, sqlalchemy, databases]
   persistence: true


### PR DESCRIPTION
## Summary
Fixed inconsistency in backend-context MCP pool definition.

## Problem
The Agent Specialization Matrix (line 26) defines the database agent as:
```
| postgresql-expert / mongodb-expert | Database | ...
```

But the backend-context pool only included `postgresql-expert`:
```yaml
backend-context:
  agents: [python-backend-expert, postgresql-expert]
```

## Solution
Added `mongodb-expert` to the backend-context pool to match the matrix definition:
```yaml
backend-context:
  agents: [python-backend-expert, postgresql-expert, mongodb-expert]
```

## Impact
- Backend context pool now includes both SQL and NoSQL database experts
- Consistent with the Agent Specialization Matrix
- Better coverage for backend development scenarios

## Files Changed
- `autopm/.claude/rules/agent-coordination.md` (1 line)
