### PR TITLE
fix: Remove duplicate agent references in ui-framework-selection

### DIFF
--- a/autopm/.claude/agents/decision-matrices/ui-framework-selection.md
+++ b/autopm/.claude/agents/decision-matrices/ui-framework-selection.md
@@ -170,10 +170,10 @@ Ask these questions to determine the best agent:
 4. **What are the performance requirements?**
    - Critical → tailwindcss-expert or react-frontend-engineer
    - Important → react-frontend-engineer (with optimization)
-   - Standard → react-ui-expert or react-ui-expert
+   - Standard → react-ui-expert or react-frontend-engineer
 
 5. **Is accessibility a requirement?**
-   - Critical → react-frontend-engineer or react-frontend-engineer
+   - Critical → react-frontend-engineer or react-ui-expert
    - Important → react-ui-expert
    - Standard → react-ui-expert or tailwindcss-expert (with extra work)
 


### PR DESCRIPTION
## Summary
Fixed duplicate agent references in the UI Framework Selection decision matrix.

## Problems Found
Two questions had duplicate agent references instead of meaningful alternatives:

### 1. Performance Requirements (Line 173)
**Before:**
```
- Standard → react-ui-expert or react-ui-expert
```

**After:**
```
- Standard → react-ui-expert or react-frontend-engineer
```

### 2. Accessibility Requirements (Line 176)
**Before:**
```
- Critical → react-frontend-engineer or react-frontend-engineer
```

**After:**
```
- Critical → react-frontend-engineer or react-ui-expert
```

## Impact
- Provides meaningful agent alternatives for decision-making
- Aligns with the rest of the decision matrix structure
- Helps users choose between component-focused (react-ui-expert) and full-app (react-frontend-engineer) approaches

## Files Changed
- `autopm/.claude/agents/decision-matrices/ui-framework-selection.md` (2 lines)

## Credit
Issue identified by GitHub Copilot code review.
