### PR TITLE
fix: Remove duplicate agent references (Copilot review fixes)

### DIFF
--- a/autopm/.claude/agents/decision-matrices/python-backend-selection.md
+++ b/autopm/.claude/agents/decision-matrices/python-backend-selection.md
@@ -1,8 +1,8 @@
-# Python Backend Agent Decision Matrix
+# Python Backend Framework Selection Guide
 
 ## Quick Selection Guide
 
-Choose between `python-backend-engineer` and `python-backend-engineer` based on your project requirements:
+The `python-backend-engineer` agent supports both **FastAPI** and **Flask** frameworks. Use this guide to choose the right framework for your project:
 
 | Requirement | FastAPI | Flask |
 |-------------|---------|-------|
@@ -27,9 +27,9 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - ⚙️ **Moderate/Possible**: Doable with some effort
 - ⚠️ **Limited**: Has constraints or limitations
 
-## Detailed Agent Comparison
+## Detailed Framework Comparison
 
-### python-backend-engineer
+### FastAPI (use python-backend-engineer with framework=fastapi)
 
 **Best For:**
 - **Modern APIs**: REST/GraphQL APIs with auto-documentation
@@ -55,7 +55,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - IoT data ingestion APIs
 - Modern single-page app backends
 
-### python-backend-engineer
+### Flask (use python-backend-engineer with framework=flask)
 
 **Best For:**
 - **Traditional Web Applications**: Server-rendered applications
@@ -86,7 +86,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### 1. What type of application are you building?
 
 #### API-Only Applications
-→ **python-backend-engineer**
+→ **FastAPI** (python-backend-engineer with framework=fastapi)
 **Reasoning:**
 - Auto-generated API documentation
 - Built-in request/response validation
@@ -94,7 +94,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - Native async support for database operations
 
 #### Web Applications with Templates
-→ **python-backend-engineer**
+→ **Flask** (python-backend-engineer with framework=flask)
 **Reasoning:**
 - Mature template engine (Jinja2)
 - Server-side rendering capabilities
@@ -103,13 +103,13 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 
 #### Hybrid (API + Web)
 → **Consider both or choose based on primary focus:**
-- API-heavy → python-backend-engineer
-- Web-heavy → python-backend-engineer
+- API-heavy → FastAPI (python-backend-engineer with framework=fastapi)
+- Web-heavy → Flask (python-backend-engineer with framework=flask)
 
 ### 2. What are your performance requirements?
 
 #### High Performance Required
-→ **python-backend-engineer**
+→ **FastAPI** (python-backend-engineer with framework=fastapi)
 **Use When:**
 - 1000+ requests per second expected
 - Low latency requirements (< 100ms)
@@ -117,7 +117,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - Concurrent user handling important
 
 #### Standard Performance Acceptable
-→ **python-backend-engineer**
+→ **Flask** (python-backend-engineer with framework=flask)
 **Use When:**
 - < 1000 requests per second
 - Response time requirements moderate
@@ -127,7 +127,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### 3. What is your team's experience level?
 
 #### Python Beginners to Intermediate
-→ **python-backend-engineer**
+→ **Flask** (python-backend-engineer with framework=flask)
 **Reasoning:**
 - Simpler concepts and patterns
 - Extensive tutorials and examples
@@ -135,7 +135,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - Gradual learning curve
 
 #### Python Advanced or Performance-Focused Teams
-→ **python-backend-engineer**
+→ **FastAPI** (python-backend-engineer with framework=fastapi)
 **Reasoning:**
 - Leverages advanced Python features
 - Type hints and modern patterns
@@ -145,7 +145,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### 4. What are your integration requirements?
 
 #### Modern Stack (React, Vue, Mobile Apps)
-→ **python-backend-engineer**
+→ **FastAPI** (python-backend-engineer with framework=fastapi)
 **Features:**
 - Auto-generated API clients
 - OpenAPI specification
@@ -153,7 +153,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - CORS handling built-in
 
 #### Traditional Stack (Server-rendered, jQuery)
-→ **python-backend-engineer**
+→ **Flask** (python-backend-engineer with framework=flask)
 **Features:**
 - Template inheritance
 - Form handling with WTForms
@@ -165,7 +165,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### API Development
 
 #### RESTful API for Mobile App
-**Choice**: python-backend-engineer
+**Choice**: FastAPI (python-backend-engineer with framework=fastapi)
 **Reasoning:**
 - Auto-generated API documentation
 - Request/response validation
@@ -173,7 +173,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - Easy async database operations
 
 #### Enterprise API with Complex Business Logic
-**Choice**: python-backend-engineer
+**Choice**: FastAPI (python-backend-engineer with framework=fastapi)
 **Reasoning:**
 - Type safety for complex data structures
 - Dependency injection for business services
@@ -183,7 +183,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### Web Applications
 
 #### Content Management System
-**Choice**: python-backend-engineer
+**Choice**: Flask (python-backend-engineer with framework=flask)
 **Reasoning:**
 - Server-side rendering capabilities
 - Admin interface patterns
@@ -191,7 +191,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - Traditional web architecture
 
 #### E-commerce Platform
-**Choice**: python-backend-engineer
+**Choice**: Flask (python-backend-engineer with framework=flask)
 **Reasoning:**
 - Complex form handling (checkout, admin)
 - Server-side rendering for SEO
@@ -201,7 +201,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### Hybrid Applications
 
 #### SaaS Platform (Web + API)
-**Primary Choice**: python-backend-engineer
+**Primary Choice**: FastAPI (python-backend-engineer with framework=fastapi)
 **Reasoning:**
 - API-first for modern frontend
 - WebSocket for real-time features
@@ -215,7 +215,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 ### Specific Scenarios
 
 #### Microservices Architecture
-**Choice**: python-backend-engineer
+**Choice**: FastAPI (python-backend-engineer with framework=fastapi)
 **Features:**
 - Smaller, focused services
 - Async communication between services
@@ -223,7 +223,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - High performance per service
 
 #### Machine Learning API
-**Choice**: python-backend-engineer
+**Choice**: FastAPI (python-backend-engineer with framework=fastapi)
 **Features:**
 - Async model inference
 - Request validation for ML inputs
@@ -231,7 +231,7 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 - WebSocket for real-time predictions
 
 #### Legacy System Integration
-**Choice**: python-backend-engineer
+**Choice**: Flask (python-backend-engineer with framework=flask)
 **Features:**
 - Established integration patterns
 - Flexible architecture for custom needs
@@ -240,8 +240,8 @@ Choose between `python-backend-engineer` and `python-backend-engineer` based on 
 
 #### Startup MVP
 **Choice**: Depends on team and product
-- **Technical team building API**: python-backend-engineer
-- **Mixed team building web app**: python-backend-engineer
+- **Technical team building API**: FastAPI (python-backend-engineer with framework=fastapi)
+- **Mixed team building web app**: Flask (python-backend-engineer with framework=flask)
 
 ## Performance Comparison
 

--- a/autopm/.claude/agents/frameworks/ux-design-expert.md
+++ b/autopm/.claude/agents/frameworks/ux-design-expert.md
@@ -153,8 +153,8 @@ Access UX design and accessibility documentation:
 
 ### Works With
 - **react-frontend-engineer**: Implementation of designs
-- **react-frontend-engineer**, **react-frontend-engineer**, **antd-react-expert**: Component styling
-- **tailwindcss-expert**, **bootstrap-ui-expert**: CSS frameworks
+- **react-ui-expert**: Component styling and design systems
+- **tailwindcss-expert**: Utility-first CSS framework
 - **frontend-testing-engineer**: Usability testing automation
 - **javascript-frontend-engineer**: Interactive features
 

--- a/autopm/.claude/rules/agent-mandatory.md
+++ b/autopm/.claude/rules/agent-mandatory.md
@@ -17,7 +17,7 @@ Do NOT perform complex tasks yourself. Use the Task tool to delegate to appropri
    - Example: "I need to create an API endpoint" → Use python-backend-engineer
 
 2. **Testing**
-   - Use: `test-runner`, `frontend-testing-engineer`, `frontend-testing-engineer`
+   - Use: `test-runner`, `frontend-testing-engineer`, `e2e-test-engineer`
    - Example: "Run the test suite" → Use test-runner
 
 3. **Infrastructure/DevOps**


### PR DESCRIPTION
## Summary
Fixed 4 critical duplicate agent reference issues identified by GitHub Copilot code review in PR #202.

## Problems Fixed

### 1. agent-mandatory.md (Line 20)
**Problem**: Duplicate `frontend-testing-engineer` in testing agents list
```diff
- Use: `test-runner`, `frontend-testing-engineer`, `frontend-testing-engineer`
+ Use: `test-runner`, `frontend-testing-engineer`, `e2e-test-engineer`
```

### 2. ux-design-expert.md (Line 156)
**Problem**: Duplicate `react-frontend-engineer` and deprecated `antd-react-expert`
```diff
- **react-frontend-engineer**, **react-frontend-engineer**, **antd-react-expert**: Component styling
- **tailwindcss-expert**, **bootstrap-ui-expert**: CSS frameworks
+ **react-ui-expert**: Component styling and design systems
+ **tailwindcss-expert**: Utility-first CSS framework
```

### 3. python-backend-selection.md (Multiple Issues)

#### Issue A: Confusing title suggesting agent comparison
```diff
- # Python Backend Agent Decision Matrix
- Choose between `python-backend-engineer` and `python-backend-engineer`
+ # Python Backend Framework Selection Guide
+ The `python-backend-engineer` agent supports both **FastAPI** and **Flask** frameworks
```

#### Issue B: Duplicate agent headers
```diff
- ### python-backend-engineer (line 32)
- ### python-backend-engineer (line 58)
+ ### FastAPI (use python-backend-engineer with framework=fastapi)
+ ### Flask (use python-backend-engineer with framework=flask)
```

#### Issue C: Missing framework specifications (~15 instances)
All "Choice: python-backend-engineer" now specify the framework:
- **API scenarios** → FastAPI (framework=fastapi)
  - RESTful API for Mobile App
  - Enterprise API with Complex Business Logic
  - SaaS Platform
  - Microservices Architecture
  - Machine Learning API
  
- **Web scenarios** → Flask (framework=flask)
  - Content Management System
  - E-commerce Platform
  - Legacy System Integration

## Changes Made (3 files, 28 insertions, 28 deletions)

1. **agent-mandatory.md** - Fixed duplicate testing agent (1 line)
2. **ux-design-expert.md** - Removed duplicates and deprecated agents (4 lines)
3. **python-backend-selection.md** - Complete rewrite to compare frameworks not agents (50 lines)

## Impact

✅ **Eliminates confusing duplicate agent references**
- Users now see distinct agent options instead of duplicates
- Clear distinction between unit/integration testing (frontend-testing-engineer) and E2E testing (e2e-test-engineer)

✅ **Clarifies framework selection model**
- Documents that `python-backend-engineer` is ONE agent supporting MULTIPLE frameworks
- Provides clear guidance on when to use FastAPI vs Flask
- Aligns with agent consolidation strategy from AGENT-REGISTRY.md

✅ **Improves decision-making guidance**
- Every recommendation now specifies exact agent + framework parameter
- Users understand both WHICH agent to use AND which framework parameter to pass

## Related

- Addresses issues found in PR #202 (comprehensive agent cleanup)
- Follows agent consolidation model from AGENT-REGISTRY.md v1.1.0
- Credit: Issues identified by GitHub Copilot code review

## Verification

✅ No duplicate agent references remain in modified files
✅ All framework choices clearly specified (FastAPI vs Flask)
✅ Documentation accurately reflects agent consolidation model