### PR TITLE
fix: restore Documentation Retrieval Protocol

### DIFF
--- a/autopm/.claude/agents/languages/nodejs-backend-engineer.md
+++ b/autopm/.claude/agents/languages/nodejs-backend-engineer.md
@@ -38,6 +38,13 @@ Before starting any implementation, you have access to live documentation throug
 - `mcp://context7/fastify/latest` - Fastify framework
 - `mcp://context7/typescript/node` - TypeScript for Node.js
 
+### Documentation Retrieval Protocol
+
+1. **Check Framework Docs**: Query context7 for specific framework patterns
+2. **Database Integration**: Verify latest ORM/ODM best practices
+3. **Security Standards**: Access current security recommendations
+4. **Performance Patterns**: Get latest Node.js optimization techniques
+
 ## Core Expertise
 
 ### Node.js Mastery

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.20.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.20.0",
+      "version": "1.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## Issue

GitHub Copilot correctly identified that valuable protocol documentation was removed during Context7 standardization in PR #215.

The removed section provided important guidance on **when and how** to query Context7, complementing the standardized MCP links.

## Changes

**Restored in `nodejs-backend-engineer.md`:**
```markdown
### Documentation Retrieval Protocol

1. **Check Framework Docs**: Query context7 for specific framework patterns
2. **Database Integration**: Verify latest ORM/ODM best practices
3. **Security Standards**: Access current security recommendations
4. **Performance Patterns**: Get latest Node.js optimization techniques
```

## Why Both Sections Matter

1. **`Documentation Queries:`** (standardized)
   - Required MCP links for enforcement hooks
   - Machine-readable format
   - Consistent across all agents

2. **`Documentation Retrieval Protocol`** (guidance)
   - Human-readable workflow steps
   - Context on WHEN to query
   - Specific use cases for each query

## Impact

- ✅ Preserves valuable contextual guidance
- ✅ Maintains standardized enforcement format
- ✅ Improves developer experience
- ✅ No breaking changes

## Related

- PR #215 - Context7 standardization
- Release v1.22.0 - Context7 Enforcement Framework