### PR TITLE
fix: update conflict resolver test for resolved storagePath

### DIFF
--- a/test/unit/conflict-resolver-jest.test.js
+++ b/test/unit/conflict-resolver-jest.test.js
@@ -584,11 +584,13 @@ describe('ConflictHistory - Constructor and Configuration', () => {
   });
 
   test('should create instance with custom storage path', () => {
+    const path = require('path');
     const history = new ConflictHistory({
       storagePath: 'custom/conflict-history.json'
     });
 
-    expect(history.options.storagePath).toBe('custom/conflict-history.json');
+    // After merge, storagePath is resolved to absolute path
+    expect(history.options.storagePath).toBe(path.resolve(process.cwd(), 'custom/conflict-history.json'));
   });
 
   test('should support in-memory storage mode', () => {


### PR DESCRIPTION
Fixes test that broke after merge due to improved path validation.

## Issue
After merging #281, the ConflictHistory path validation was improved to use path.resolve() which returns absolute paths instead of relative paths. This broke one test that expected relative path.

## Fix
Updated test expectation to match new behavior using path.resolve(process.cwd(), ...).

## Test Results
- Before: 41/44 passing
- After: 42/44 passing (2 pre-existing failures unrelated to this fix)

## Impact
- No production code changes
- Test-only fix
- Maintains test coverage