### PR TITLE
chore: release v1.30.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "bin": {


### PR DESCRIPTION
## Release v1.30.1

### Changes
- Version bump from 1.30.0 to 1.30.1
- Includes fix for template-engine path resolution (#284)

### Summary
This release fixes a critical bug where the `template-engine` module was not found after framework installation, causing `prd-new`, `template-list`, and `template-new` commands to fail.

**Fixed:**
- Template-engine module path resolution with intelligent 3-tier fallback strategy
- Added `lib/` directory to installation items
- Enhanced error messages for missing modules

### Testing
- Tested in fresh installation scenario
- Verified all PM commands work correctly
- Confirmed path resolution fallback strategy

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)