### PR TITLE
release: v2.1.0 - ML/AI Plugin Expansions

### DIFF
--- a/packages/plugin-ai/package.json
+++ b/packages/plugin-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-ai",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Complete AI/ML plugin with OpenAI, Gemini, LangChain agents, RAG systems, model deployment, prompt engineering, and MLOps patterns for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-ml/package.json
+++ b/packages/plugin-ml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-ml",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Comprehensive Machine Learning plugin with 10 specialist agents: TensorFlow/Keras, PyTorch, RL, Scikit-learn, Neural Architecture, Gradient Boosting, Computer Vision, NLP Transformers, Time Series, and AutoML. Context7-verified patterns.",
   "main": "plugin.json",
   "scripts": {


### PR DESCRIPTION
## Release v2.1.0

Version bump for npm publication of expanded ML/AI plugins.

### Changes in This Release

#### plugin-ai v2.1.0
- Added 5 new agents: anthropic-claude-expert, azure-openai-expert, langchain-expert, google-a2a-expert, huggingface-expert
- Added 4 new commands: anthropic-optimize, langchain-optimize, a2a-setup, huggingface-deploy
- Expanded from 3 to 8 agents (167% growth)
- Complete Context7 integration
- Production-ready patterns

#### plugin-ml v2.1.0
- Expanded neural-network-architect (+823 lines, 203% growth)
- Expanded reinforcement-learning-expert (+1,560 lines, 295% growth)
- Added 2024 best practices
- Complete algorithm selection guides
- Production deployment patterns

### Ready for npm Publication

Both packages ready to publish to npm registry.