### PR TITLE
chore: bump version to 2.9.0 for token optimization system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "2.8.9",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "2.8.9",
+      "version": "2.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "2.8.9",
+  "version": "2.9.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
Bumps version to 2.9.0 for the token optimization system release.

This PR updates:
- package.json version to 2.9.0
- Creates git tag v2.9.0

Part of the release process for the comprehensive token optimization system (98.4% reduction).