### PR TITLE
Release v2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.1] - 2025-01-19
+
+### Fixed
+
+#### 🔧 PM Command Instructions Sections
+
+**Fix:** Resolved 17 PM commands failing due to missing `## Instructions` sections.
+
+**Problem:**
+- Commands like `/pm:epic-split` were throwing module resolution errors
+- Missing or malformed `## Instructions` sections prevented script execution
+- Error: `Cannot find module '.claude/scripts/pm/.claude/scripts/pm/...'`
+
+**Fixed Commands:**
+- `pm:epic-split` - Added complete Instructions section
+- 16 others - Added missing `## Instructions` headers:
+  - `pm:blocked`, `pm:context`, `pm:epic-list`, `pm:epic-show`
+  - `pm:epic-status`, `pm:help`, `pm:in-progress`, `pm:init`
+  - `pm:next`, `pm:prd-list`, `pm:prd-status`, `pm:search`
+  - `pm:standup`, `pm:status`, `pm:validate`, `pm:what-next`
+
+**New Tools:**
+- `scripts/fix-command-instructions.js` - Automated fix tool
+  - Detects missing/malformed Instructions sections
+  - Supports plugin, dev, and installed project structures
+  - Provides detailed fix reports
+
+**Documentation:**
+- `docs/COMMAND-INSTRUCTIONS-FIX.md` - Comprehensive analysis
+  - Problem root cause and solution
+  - Standard command format template
+  - Prevention strategies (hooks, tests, templates)
+
+**Impact:**
+- ✅ All 38 PM commands now functional
+- ✅ Consistent command structure
+- ✅ Automated validation available
+
 ### Changed
 
 #### 🔒 Enhanced Agent Usage Enforcement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "2.11.1",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "2.11.1",
+      "version": "2.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -9040,7 +9040,7 @@
     },
     "packages/plugin-pm": {
       "name": "@claudeautopm/plugin-pm",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [

--- a/packages/plugin-pm/package.json
+++ b/packages/plugin-pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-pm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Complete project management plugin with PM workflows, epic management, issue tracking, and release automation for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",


### PR DESCRIPTION
## Release v2.12.1

Version bump for PM command instructions fix.

### Changes

- Main package: 2.12.0 → 2.12.1
- Plugin-pm: 2.1.0 → 2.1.1

### Fixed

- 17 PM commands now have proper `## Instructions` sections
- All PM commands functional
- Added automated fix tool and documentation

See CHANGELOG.md for full details.

### Ready for

- [x] Version bumped
- [x] CHANGELOG updated
- [x] Tag created (v2.12.1)
- [ ] Merge to main
- [ ] Publish to npm
