### PR TITLE
Release v2.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Release v2.12.3 - Critical Plugin Path Fix

### 🐛 Critical Bug Fix

**Fixed plugin script installation paths** - PM plugin commands now work correctly.

#### Problem
PM plugin commands (like `/pm:epic-decompose`, `/pm:epic-list`, etc.) were failing with:
```
Error: Cannot find module '.claude/scripts/pm/epic-decompose.js'
```

#### Root Cause  
The installer was incorrectly stripping `scripts/` prefix, causing files to be installed in:
- ❌ `.claude/pm/epic-list.js` (wrong)
- ✅ `.claude/scripts/pm/epic-list.js` (correct)

#### Solution
- Fixed `targetDir` path mapping in plugin installer
- Preserved full `scripts/pm/` path structure during installation
- All PM plugin scripts now install to correct location

### 🔧 Changes
- `install/install.js`: Corrected plugin script path mapping logic

### 🧪 Testing
- ✅ All existing tests pass
- ✅ PM plugin scripts install to `.claude/scripts/pm/`
- ✅ Commands successfully locate and execute scripts

### 📥 Upgrade Instructions

**For existing installations:**
```bash
npm install -g claude-autopm@2.12.3
# Then reinstall in your project
cd your-project
autopm install
```

This will fix the script paths in your existing projects.

### 📝 Full Changelog
- fix: correct plugin script installation paths (#375)

---

**Critical for users experiencing PM command failures!**