### PR TITLE
fix: Replace grep -oP with portable grep for macOS

### DIFF
--- a/packages/plugin-pm/scripts/pm/epic-sync/create-epic-issue.sh
+++ b/packages/plugin-pm/scripts/pm/epic-sync/create-epic-issue.sh
@@ -67,7 +67,7 @@ epic_number=$(gh issue create \
 - Created: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 " \
     --label "$labels" \
-    2>&1 | grep -oP '(?<=#)[0-9]+' | head -1)
+    2>&1 | grep -o '#[0-9]\+' | head -1 | sed 's/#//')
 
 if [[ -z "$epic_number" ]]; then
     echo "❌ Error: Failed to create epic issue"

--- a/packages/plugin-pm/scripts/pm/epic-sync/create-task-issues.sh
+++ b/packages/plugin-pm/scripts/pm/epic-sync/create-task-issues.sh
@@ -66,7 +66,7 @@ for task_file in $task_files; do
 - Created: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 " \
         --label "task,epic:$EPIC_NAME" \
-        2>&1 | grep -oP '(?<=#)[0-9]+' | head -1)
+        2>&1 | grep -o '#[0-9]\+' | head -1 | sed 's/#//')
 
     if [[ -n "$issue_number" ]]; then
         echo "#$issue_number ✓"


### PR DESCRIPTION
Fixes epic-sync scripts failing on macOS due to grep -oP incompatibility