### PR TITLE
fix: resolve issue-start --analyze flag and epic-decompose path errors (v3.1.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [

--- a/packages/plugin-pm/commands/pm:epic-decompose.md
+++ b/packages/plugin-pm/commands/pm:epic-decompose.md
@@ -6,6 +6,11 @@ allowed-tools: Bash, Read, Write, LS, Task
 
 Break epic into concrete, actionable tasks.
 
+**⚠️ IMPORTANT**: This is a Claude Code command file, not a standalone script.
+- Execute via Claude Code as: `/pm:epic-decompose <feature_name>`
+- Do NOT run as: `node .claude/scripts/pm/epic-decompose.js`
+- This command has no standalone script equivalent
+
 ## Usage
 
 **Single Epic:**

--- a/packages/plugin-pm/commands/pm:issue-start.md
+++ b/packages/plugin-pm/commands/pm:issue-start.md
@@ -24,14 +24,10 @@ Begin work on a GitHub issue with parallel agents based on work stream analysis.
    - If not found, search for file containing `github:.*issues/$ARGUMENTS` in frontmatter (old naming)
    - If not found: "❌ No local task for issue #$ARGUMENTS. This issue may have been created outside the PM system."
 
-3. **Check for analysis:**
-   ` ``bash
-   test -f .claude/epics/*/$ARGUMENTS-analysis.md || echo "❌ No analysis found for issue #$ARGUMENTS
-   
-   Run: /pm:issue-analyze $ARGUMENTS first
-   Or: /pm:issue-start $ARGUMENTS --analyze to do both"
-   ` ``
-   If no analysis exists and no --analyze flag, stop execution.
+3. **Check for analysis (when NOT using --analyze flag):**
+   - If user didn't use `--analyze` flag, check if analysis file exists
+   - Analysis file location: `.claude/epics/{epic_name}/$ARGUMENTS-analysis.md`
+   - If no analysis AND no `--analyze` flag: Stop and suggest using `--analyze` flag
 
 ## Required Documentation Access
 
@@ -71,7 +67,25 @@ See `.claude/rules/tdd.enforcement.md` for complete TDD requirements.
 
 ## Instructions
 
-### 1. Ensure Branch Exists
+### 0. Handle --analyze Flag (if provided)
+
+If user provided `--analyze` flag, delegate to the Node.js script:
+` ``bash
+node packages/plugin-pm/scripts/pm/issue-start.cjs $ARGUMENTS --analyze
+` ``
+
+This script will:
+1. Find the task file for the issue
+2. Generate analysis file with parallel work streams
+3. Create workspace structure
+4. Launch parallel agents based on analysis
+5. Handle all subsequent steps automatically
+
+**STOP HERE** if using `--analyze` flag - the script handles everything.
+
+---
+
+### 1. Ensure Branch Exists (Non-analyze workflow)
 
 Check if epic branch exists:
 ` ``bash


### PR DESCRIPTION
## Summary
Fixed two critical command issues in ClaudeAutoPM v3.1.1:

## Issues Fixed

### 1. issue-start --analyze flag not working
**Problem**: The `--analyze` flag was not properly handled, and the command referenced a non-existent `/pm:issue-analyze` command.

**Solution**:
- Updated `pm:issue-start.md` to properly delegate to Node.js script when `--analyze` flag is provided
- Added explicit Step 0 to handle the flag
- The underlying script (`issue-start.cjs`) already has full analyze functionality (lines 203-315)
- Removed reference to non-existent `/pm:issue-analyze` command

**Usage**: `/pm:issue-start 123 --analyze`

### 2. epic-decompose hardcoded script path error
**Problem**: Users were getting `Cannot find module '.claude/scripts/pm/epic-decompose.js'` errors because something was trying to execute epic-decompose as a standalone script.

**Solution**:
- Added clarification in `pm:epic-decompose.md` that this is a Claude Code command file, not a standalone script
- Explicitly documented correct usage: `/pm:epic-decompose <feature_name>`
- Prevents incorrect invocation via `node .claude/scripts/pm/epic-decompose.js`

## Files Modified
- `packages/plugin-pm/commands/pm:issue-start.md` - Added --analyze flag handling
- `packages/plugin-pm/commands/pm:epic-decompose.md` - Added command vs script clarification
- `package.json` - Version bump 3.1.0 → 3.1.1
- `package-lock.json` - Updated lock file

## Testing
- ✅ Pre-commit path validation passed
- ✅ Git hooks executed successfully
- ✅ No hardcoded `autopm/` paths found

## Version
3.1.0 → 3.1.1 (patch release)

## Checklist
- [x] Fixed issue-start --analyze flag
- [x] Fixed epic-decompose path error
- [x] Updated command documentation
- [x] Version bumped
- [x] Pre-commit checks passed
- [ ] Ready to merge and release to npm