### PR TITLE
fix: add epic-sync to Epic Management docs

### DIFF
--- a/autopm/.claude/rules/command-pipelines.md
+++ b/autopm/.claude/rules/command-pipelines.md
@@ -35,6 +35,7 @@
 #### Epic Management
 
 - `/pm:epic-decompose` - Break epic into tasks
+- `/pm:epic-sync` - Sync epic/tasks to GitHub as issues
 - `/pm:epic-start` - Launch parallel agents for epic
 - `/pm:epic-status` - Show execution status
 - `/pm:epic-merge` - Merge epic branch

--- a/packages/plugin-core/rules/command-pipelines.md
+++ b/packages/plugin-core/rules/command-pipelines.md
@@ -35,6 +35,7 @@
 #### Epic Management
 
 - `/pm:epic-decompose` - Break epic into tasks
+- `/pm:epic-sync` - Sync epic/tasks to GitHub as issues
 - `/pm:epic-start` - Launch parallel agents for epic
 - `/pm:epic-status` - Show execution status
 - `/pm:epic-merge` - Merge epic branch


### PR DESCRIPTION
Add missing epic-sync command to Epic Management section in command-pipelines.md

The correct workflow is: epic-decompose → epic-sync → epic-start