### PR TITLE
ci: npm publish on version tags with provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,19 +1,35 @@
 name: Publish to npm
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
-  release:
-    types: [published]
 
 jobs:
-  publish:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - run: npm ci --legacy-peer-deps
+      - run: npm test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
+      - run: npm ci --legacy-peer-deps
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Trigger publish on `v*` tags (not just GitHub releases)
- Add test job before publish
- Enable OIDC provenance for supply chain security
- Usage: `git tag v3.13.1 && git push --tags`

**Note**: NPM_TOKEN secret must be set in repo settings. For full Trusted Publishing without token, configure on npmjs.com → Package Settings → Publishing access → Link GitHub Actions.

Closes #438