### PR TITLE
[chore][ci] Add issue structure template and enforcement rule

### DIFF
--- a/.claude/rules/issue-structure.xml
+++ b/.claude/rules/issue-structure.xml
@@ -1,0 +1,47 @@
+<rule id="issue-structure" priority="high" enforcement="required">
+  <description>
+    Every GitHub issue created by ClaudeAutoPM MUST follow the standard structure.
+    Issues without proper structure waste AI tokens and lead to scope creep.
+  </description>
+
+  <template>
+    <section name="goal" required="true">One sentence: WHAT and WHY</section>
+    <section name="context" required="true">Architecture location, files, dependencies</section>
+    <section name="acceptance-criteria" required="true">Measurable checkboxes, not prose</section>
+    <section name="technical-constraints" required="false">Stack, patterns, prohibitions</section>
+    <section name="affected-files" required="true">Exact file paths with change description</section>
+    <section name="out-of-scope" required="false">What NOT to touch</section>
+    <section name="suggested-approach" required="false">Brief implementation strategy</section>
+    <section name="definition-of-done" required="false">Quality gates (tests, lint, coverage)</section>
+  </template>
+
+  <title-convention>
+    <format>[type][scope] Imperative description</format>
+    <types>feat, fix, refactor, chore, test, docs, ci</types>
+    <examples>
+      <example>[feat][agent] Add retry logic to ResearcherAgent</example>
+      <example>[fix][api] Handle timeout in /ingest endpoint</example>
+      <example>[refactor][db] Extract VectorStore interface</example>
+      <example>[test][plugin] Add PluginManager install scenario tests</example>
+    </examples>
+  </title-convention>
+
+  <labels>
+    <label-group name="type">feature, bug, refactor, chore</label-group>
+    <label-group name="effort">S, M, L, XL</label-group>
+    <label-group name="ai-ready">true — issue is well-structured for AI execution</label-group>
+  </labels>
+
+  <key-principles>
+    <principle>Acceptance Criteria over narrative — AI understands checkboxes better than prose</principle>
+    <principle>Explicit scope always — say what NOT to touch or AI will "improve" neighbors</principle>
+    <principle>Name files, classes, functions — AI should not guess project structure</principle>
+    <principle>Link related issues — dependencies and blockers must be visible</principle>
+  </key-principles>
+
+  <violations enforcement="auto-reject">
+    <violation>Creating issues without Acceptance Criteria</violation>
+    <violation>Creating issues without Affected Files section</violation>
+    <violation>Vague goal without concrete deliverable</violation>
+  </violations>
+</rule>

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Something isn't working correctly
+title: "[fix][scope] "
+labels: ["bug", "ai-ready"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: "Goal"
+      description: "What's broken and what should happen instead."
+      placeholder: "Fix epicSync.js creating issues without mandatory footer — every issue must include implementation rules."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Context"
+      description: "Where does the bug occur? Steps to reproduce."
+      placeholder: |
+        - File: `autopm/.claude/lib/commands/pm/epicSync.js`
+        - Trigger: running `epicSync.js sync <epic-path>`
+        - Expected: issue body includes footer from `issue-mandatory-footer.md`
+        - Actual: footer is missing
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: "Acceptance Criteria"
+      description: "How to verify the fix."
+      placeholder: |
+        - [ ] epicSync creates issues WITH mandatory footer
+        - [ ] Test reproduces the bug (RED)
+        - [ ] Test passes after fix (GREEN)
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "Affected Files / Scope"
+      description: "Where the fix should be applied."
+      placeholder: |
+        - `autopm/.claude/lib/commands/pm/epicSync.js` — add footer reading
+        - `test/epicSync.test.js` — regression test
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: "Out of Scope"
+      description: "What NOT to change while fixing."
+      placeholder: "Do not refactor epicSync — only fix the footer issue."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,97 @@
+name: Feature / Enhancement
+description: New feature, improvement, or refactoring task
+title: "[feat][scope] "
+labels: ["enhancement", "ai-ready"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: "Goal"
+      description: "One clear sentence: WHAT and WHY."
+      placeholder: "Add retry logic to ResearcherAgent to handle transient API failures and improve reliability."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Context"
+      description: "Where in the architecture? Which files/modules? Dependencies?"
+      placeholder: |
+        - Located in `lib/plugins/PluginManager.js`
+        - Depends on `install/install.js` for scenario configs
+        - Uses `packages/plugin-*/plugin.json` for metadata
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: "Acceptance Criteria"
+      description: "Measurable, concrete checklist. AI works best with checkboxes."
+      placeholder: |
+        - [ ] Function handles timeout after 30s
+        - [ ] Tests cover 3 error scenarios
+        - [ ] No breaking changes to public API
+    validations:
+      required: true
+
+  - type: textarea
+    id: technical-constraints
+    attributes:
+      label: "Technical Constraints"
+      description: "Stack, patterns, what NOT to use."
+      placeholder: |
+        - Stack: Node.js 18+, Jest for testing
+        - Pattern: must follow existing plugin architecture
+        - NOT: no new dependencies, no mocking in tests
+    validations:
+      required: false
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "Affected Files / Scope"
+      description: "Exact file paths with brief description of change."
+      placeholder: |
+        - `lib/plugins/PluginManager.js` — add retry logic to loadPlugin()
+        - `test/core/PluginManager.test.js` — new test cases
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: "Out of Scope"
+      description: "What should NOT be changed. Prevents AI from over-engineering."
+      placeholder: |
+        - Do not refactor existing test structure
+        - Do not modify install.js
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggested-approach
+    attributes:
+      label: "Suggested Approach"
+      description: "Optional: brief implementation strategy."
+      placeholder: |
+        1. Add `retryWithBackoff()` utility
+        2. Wrap `loadPlugin()` calls
+        3. Add tests for 1x, 2x, 3x retry scenarios
+    validations:
+      required: false
+
+  - type: textarea
+    id: definition-of-done
+    attributes:
+      label: "Definition of Done"
+      description: "Standard quality gates."
+      value: |
+        - [ ] Tests passing (`npm test`)
+        - [ ] No lint errors
+        - [ ] Coverage thresholds met (80/75/80/80)
+        - [ ] PR description contains design decisions
+        - [ ] CLAUDE.md updated if architecture changes
+    validations:
+      required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 @include .claude/rules/github-operations.xml
 @include .claude/rules/naming-conventions.xml
 @include .claude/rules/command-pipelines.xml
+@include .claude/rules/issue-structure.xml
 
 ## COMMANDS
 

--- a/autopm/.claude/rules/issue-structure.xml
+++ b/autopm/.claude/rules/issue-structure.xml
@@ -1,0 +1,47 @@
+<rule id="issue-structure" priority="high" enforcement="required">
+  <description>
+    Every GitHub issue created by ClaudeAutoPM MUST follow the standard structure.
+    Issues without proper structure waste AI tokens and lead to scope creep.
+  </description>
+
+  <template>
+    <section name="goal" required="true">One sentence: WHAT and WHY</section>
+    <section name="context" required="true">Architecture location, files, dependencies</section>
+    <section name="acceptance-criteria" required="true">Measurable checkboxes, not prose</section>
+    <section name="technical-constraints" required="false">Stack, patterns, prohibitions</section>
+    <section name="affected-files" required="true">Exact file paths with change description</section>
+    <section name="out-of-scope" required="false">What NOT to touch</section>
+    <section name="suggested-approach" required="false">Brief implementation strategy</section>
+    <section name="definition-of-done" required="false">Quality gates (tests, lint, coverage)</section>
+  </template>
+
+  <title-convention>
+    <format>[type][scope] Imperative description</format>
+    <types>feat, fix, refactor, chore, test, docs, ci</types>
+    <examples>
+      <example>[feat][agent] Add retry logic to ResearcherAgent</example>
+      <example>[fix][api] Handle timeout in /ingest endpoint</example>
+      <example>[refactor][db] Extract VectorStore interface</example>
+      <example>[test][plugin] Add PluginManager install scenario tests</example>
+    </examples>
+  </title-convention>
+
+  <labels>
+    <label-group name="type">feature, bug, refactor, chore</label-group>
+    <label-group name="effort">S, M, L, XL</label-group>
+    <label-group name="ai-ready">true — issue is well-structured for AI execution</label-group>
+  </labels>
+
+  <key-principles>
+    <principle>Acceptance Criteria over narrative — AI understands checkboxes better than prose</principle>
+    <principle>Explicit scope always — say what NOT to touch or AI will "improve" neighbors</principle>
+    <principle>Name files, classes, functions — AI should not guess project structure</principle>
+    <principle>Link related issues — dependencies and blockers must be visible</principle>
+  </key-principles>
+
+  <violations enforcement="auto-reject">
+    <violation>Creating issues without Acceptance Criteria</violation>
+    <violation>Creating issues without Affected Files section</violation>
+    <violation>Vague goal without concrete deliverable</violation>
+  </violations>
+</rule>


### PR DESCRIPTION
## 🎯 Goal
Standardize all GitHub issues with a consistent structure that optimizes for AI execution — checkboxes over prose, explicit scope, named files.

## 📋 Context
- No issue templates existed previously
- Issues #442-#444 reformatted as reference examples
- New `issue-structure.xml` rule ensures PM commands follow the template

## ✅ Acceptance Criteria
- [ ] GitHub "New Issue" shows Feature and Bug templates
- [ ] `issue-structure.xml` @included in CLAUDE.md (8 XML rules total)
- [ ] Templates enforce: Goal, Context, Acceptance Criteria, Affected Files
- [ ] Title convention documented: `[type][scope] Description`

## 📁 Affected Files / Scope
- `.github/ISSUE_TEMPLATE/feature.yml` — NEW
- `.github/ISSUE_TEMPLATE/bug.yml` — NEW
- `autopm/.claude/rules/issue-structure.xml` — NEW rule
- `.claude/rules/issue-structure.xml` — copy
- `CLAUDE.md` — +1 @include