### PR TITLE
[fix][ci] Remove --provenance from plugin publish workflow

### DIFF
--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -40,7 +40,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Publish ${{ matrix.plugin }}
         working-directory: packages/${{ matrix.plugin }}
-        run: npm publish --provenance --access public || echo "Already published or error"
+        run: npm publish --access public || echo "Already published or error"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -58,6 +58,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Publish ${{ inputs.plugin }}
         working-directory: packages/${{ inputs.plugin }}
-        run: npm publish --provenance --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🎯 Goal
Fix plugin-publish workflow that failed with E404 due to --provenance flag requiring Trusted Publishing config.

## 📁 Affected Files
- `.github/workflows/plugin-publish.yml` — removed `--provenance` flag