### PR TITLE
[feat][pm] Add local issue tracking for lite scenario

### DIFF
--- a/.claude/providers/local/issue-close.js
+++ b/.claude/providers/local/issue-close.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { findIssueFile } = require('./issue-show');
+const { parseIssueFrontmatter } = require('./issue-list');
+
+async function execute(options = {}) {
+  const id = options.id;
+  if (!id) {
+    return { success: false, error: 'Issue ID is required' };
+  }
+
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+  const filepath = findIssueFile(issuesDir, id);
+
+  if (!filepath) {
+    return { success: false, error: `Issue #${id} not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseIssueFrontmatter(content);
+  const now = new Date().toISOString();
+
+  // Update frontmatter: status, completed, updated
+  const updated = content
+    .replace(/^status:\s*.+$/m, 'status: closed')
+    .replace(/^updated:\s*.+$/m, `updated: ${now}`)
+    .replace(/^completed:\s*.*$/m, `completed: ${now}`);
+
+  fs.writeFileSync(filepath, updated, 'utf8');
+
+  return {
+    success: true,
+    issue: {
+      id: parseInt(fm.number) || parseInt(id),
+      title: fm.name || '',
+      status: 'closed',
+      resolution: options.resolution || 'completed'
+    },
+    actions: [`Closed issue #${id}`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute };

--- a/.claude/providers/local/issue-create.js
+++ b/.claude/providers/local/issue-create.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+function getIssuesDir() {
+  return path.join(process.cwd(), '.claude', 'issues');
+}
+
+function slugify(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50);
+}
+
+function getNextNumber(issuesDir) {
+  if (!fs.existsSync(issuesDir)) return 1;
+  const files = fs.readdirSync(issuesDir).filter(f => f.endsWith('.md'));
+  let max = 0;
+  for (const file of files) {
+    const match = file.match(/^(\d+)/);
+    if (match) max = Math.max(max, parseInt(match[1]));
+  }
+  return max + 1;
+}
+
+async function execute(options = {}) {
+  const title = options.title || options.name || 'Untitled Issue';
+  const labels = options.labels || [];
+  const body = options.body || '';
+
+  const issuesDir = getIssuesDir();
+  if (!fs.existsSync(issuesDir)) {
+    fs.mkdirSync(issuesDir, { recursive: true });
+  }
+
+  const number = getNextNumber(issuesDir);
+  const slug = slugify(title);
+  const filename = `${number}-${slug}.md`;
+  const filepath = path.join(issuesDir, filename);
+  const now = new Date().toISOString();
+
+  const content = `---
+number: ${number}
+name: "${title.replace(/"/g, '\\"')}"
+status: open
+labels: [${labels.join(', ')}]
+assignee: ""
+created: ${now}
+updated: ${now}
+started: ""
+completed: ""
+---
+
+${body || `## Goal\n${title}\n\n## Acceptance Criteria\n- [ ] TODO`}
+`;
+
+  fs.writeFileSync(filepath, content, 'utf8');
+
+  return {
+    success: true,
+    issue: {
+      id: number,
+      title,
+      status: 'open',
+      labels,
+      path: filepath,
+      url: `file://${filepath}`
+    },
+    actions: [`Created local issue #${number}: ${filename}`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute, getNextNumber, slugify, getIssuesDir };

--- a/.claude/providers/local/issue-list.js
+++ b/.claude/providers/local/issue-list.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseIssueFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.+)$/);
+    if (kv) {
+      let value = kv[2].trim();
+      if (value.startsWith('[') && value.endsWith(']')) {
+        value = value.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean);
+      } else if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      fm[kv[1]] = value;
+    }
+  }
+  return fm;
+}
+
+async function execute(options = {}) {
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+
+  if (!fs.existsSync(issuesDir)) {
+    return { success: true, issues: [], count: 0 };
+  }
+
+  const files = fs.readdirSync(issuesDir).filter(f => f.endsWith('.md')).sort();
+  const issues = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(issuesDir, file), 'utf8');
+    const fm = parseIssueFrontmatter(content);
+    if (!fm) continue;
+
+    // Filter by status
+    if (options.status && fm.status !== options.status) continue;
+
+    // Filter by label
+    if (options.label) {
+      const labels = Array.isArray(fm.labels) ? fm.labels : [];
+      if (!labels.includes(options.label)) continue;
+    }
+
+    issues.push({
+      id: parseInt(fm.number) || 0,
+      title: fm.name || file.replace('.md', ''),
+      status: fm.status || 'open',
+      labels: Array.isArray(fm.labels) ? fm.labels : [],
+      assignee: fm.assignee || '',
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      path: path.join(issuesDir, file)
+    });
+  }
+
+  // Sort by number
+  issues.sort((a, b) => a.id - b.id);
+
+  return { success: true, issues, count: issues.length };
+}
+
+module.exports = { execute, parseIssueFrontmatter };

--- a/.claude/providers/local/issue-show.js
+++ b/.claude/providers/local/issue-show.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const { parseIssueFrontmatter } = require('./issue-list');
+
+function findIssueFile(issuesDir, id) {
+  if (!fs.existsSync(issuesDir)) return null;
+  const files = fs.readdirSync(issuesDir).filter(f => f.endsWith('.md'));
+  const numId = String(id);
+
+  // Exact match: {id}-*.md or {id}.md
+  for (const file of files) {
+    if (file.startsWith(numId + '-') || file === numId + '.md') {
+      return path.join(issuesDir, file);
+    }
+  }
+  return null;
+}
+
+async function execute(options = {}) {
+  const id = options.id;
+  if (!id) {
+    return { success: false, error: 'Issue ID is required' };
+  }
+
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+  const filepath = findIssueFile(issuesDir, id);
+
+  if (!filepath) {
+    return { success: false, error: `Issue #${id} not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseIssueFrontmatter(content);
+
+  // Extract body (after frontmatter)
+  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  return {
+    success: true,
+    issue: {
+      id: parseInt(fm.number) || parseInt(id),
+      title: fm.name || '',
+      status: fm.status || 'open',
+      labels: Array.isArray(fm.labels) ? fm.labels : [],
+      assignee: fm.assignee || '',
+      body,
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      startedAt: fm.started || '',
+      completedAt: fm.completed || '',
+      path: filepath
+    }
+  };
+}
+
+module.exports = { execute, findIssueFile };

--- a/.claude/providers/local/issue-start.js
+++ b/.claude/providers/local/issue-start.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { findIssueFile } = require('./issue-show');
+const { parseIssueFrontmatter } = require('./issue-list');
+
+async function execute(options = {}) {
+  const id = options.id;
+  if (!id) {
+    return { success: false, error: 'Issue ID is required' };
+  }
+
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+  const filepath = findIssueFile(issuesDir, id);
+
+  if (!filepath) {
+    return { success: false, error: `Issue #${id} not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseIssueFrontmatter(content);
+  const now = new Date().toISOString();
+  const actions = [];
+
+  // Update frontmatter: status, started, updated
+  let updated = content
+    .replace(/^status:\s*.+$/m, 'status: in_progress')
+    .replace(/^updated:\s*.+$/m, `updated: ${now}`)
+    .replace(/^started:\s*.*$/m, `started: ${now}`);
+
+  fs.writeFileSync(filepath, updated, 'utf8');
+  actions.push(`Updated issue #${id} status to in_progress`);
+
+  // Create branch unless --no-branch
+  let branch = null;
+  if (!options.no_branch) {
+    const slug = path.basename(filepath, '.md').replace(/^\d+-/, '');
+    branch = `feature/${id}-${slug}`;
+    try {
+      execSync(`git checkout -b ${branch}`, { stdio: 'pipe' });
+      actions.push(`Created branch: ${branch}`);
+    } catch (e) {
+      actions.push(`Branch creation skipped: ${e.message.split('\n')[0]}`);
+    }
+  }
+
+  return {
+    success: true,
+    issue: {
+      id: parseInt(fm.number) || parseInt(id),
+      title: fm.name || '',
+      status: 'in_progress',
+      branch,
+      assignee: fm.assignee || '',
+      url: `file://${filepath}`
+    },
+    actions,
+    timestamp: now
+  };
+}
+
+module.exports = { execute };

--- a/.claude/providers/router.js
+++ b/.claude/providers/router.js
@@ -41,8 +41,8 @@ class ProviderRouter {
       return this.config.projectManagement.provider;
     }
 
-    // Default to GitHub if not configured
-    return 'github';
+    // Default to local if not configured (works without gh CLI or Azure)
+    return 'local';
   }
 
   /**

--- a/autopm/.claude/providers/local/issue-close.js
+++ b/autopm/.claude/providers/local/issue-close.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { findIssueFile } = require('./issue-show');
+const { parseIssueFrontmatter } = require('./issue-list');
+
+async function execute(options = {}) {
+  const id = options.id;
+  if (!id) {
+    return { success: false, error: 'Issue ID is required' };
+  }
+
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+  const filepath = findIssueFile(issuesDir, id);
+
+  if (!filepath) {
+    return { success: false, error: `Issue #${id} not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseIssueFrontmatter(content);
+  const now = new Date().toISOString();
+
+  // Update frontmatter: status, completed, updated
+  const updated = content
+    .replace(/^status:\s*.+$/m, 'status: closed')
+    .replace(/^updated:\s*.+$/m, `updated: ${now}`)
+    .replace(/^completed:\s*.*$/m, `completed: ${now}`);
+
+  fs.writeFileSync(filepath, updated, 'utf8');
+
+  return {
+    success: true,
+    issue: {
+      id: parseInt(fm.number) || parseInt(id),
+      title: fm.name || '',
+      status: 'closed',
+      resolution: options.resolution || 'completed'
+    },
+    actions: [`Closed issue #${id}`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute };

--- a/autopm/.claude/providers/local/issue-create.js
+++ b/autopm/.claude/providers/local/issue-create.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+function getIssuesDir() {
+  return path.join(process.cwd(), '.claude', 'issues');
+}
+
+function slugify(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50);
+}
+
+function getNextNumber(issuesDir) {
+  if (!fs.existsSync(issuesDir)) return 1;
+  const files = fs.readdirSync(issuesDir).filter(f => f.endsWith('.md'));
+  let max = 0;
+  for (const file of files) {
+    const match = file.match(/^(\d+)/);
+    if (match) max = Math.max(max, parseInt(match[1]));
+  }
+  return max + 1;
+}
+
+async function execute(options = {}) {
+  const title = options.title || options.name || 'Untitled Issue';
+  const labels = options.labels || [];
+  const body = options.body || '';
+
+  const issuesDir = getIssuesDir();
+  if (!fs.existsSync(issuesDir)) {
+    fs.mkdirSync(issuesDir, { recursive: true });
+  }
+
+  const number = getNextNumber(issuesDir);
+  const slug = slugify(title);
+  const filename = `${number}-${slug}.md`;
+  const filepath = path.join(issuesDir, filename);
+  const now = new Date().toISOString();
+
+  const content = `---
+number: ${number}
+name: "${title.replace(/"/g, '\\"')}"
+status: open
+labels: [${labels.join(', ')}]
+assignee: ""
+created: ${now}
+updated: ${now}
+started: ""
+completed: ""
+---
+
+${body || `## Goal\n${title}\n\n## Acceptance Criteria\n- [ ] TODO`}
+`;
+
+  fs.writeFileSync(filepath, content, 'utf8');
+
+  return {
+    success: true,
+    issue: {
+      id: number,
+      title,
+      status: 'open',
+      labels,
+      path: filepath,
+      url: `file://${filepath}`
+    },
+    actions: [`Created local issue #${number}: ${filename}`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute, getNextNumber, slugify, getIssuesDir };

--- a/autopm/.claude/providers/local/issue-list.js
+++ b/autopm/.claude/providers/local/issue-list.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseIssueFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.+)$/);
+    if (kv) {
+      let value = kv[2].trim();
+      if (value.startsWith('[') && value.endsWith(']')) {
+        value = value.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean);
+      } else if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      fm[kv[1]] = value;
+    }
+  }
+  return fm;
+}
+
+async function execute(options = {}) {
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+
+  if (!fs.existsSync(issuesDir)) {
+    return { success: true, issues: [], count: 0 };
+  }
+
+  const files = fs.readdirSync(issuesDir).filter(f => f.endsWith('.md')).sort();
+  const issues = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(issuesDir, file), 'utf8');
+    const fm = parseIssueFrontmatter(content);
+    if (!fm) continue;
+
+    // Filter by status
+    if (options.status && fm.status !== options.status) continue;
+
+    // Filter by label
+    if (options.label) {
+      const labels = Array.isArray(fm.labels) ? fm.labels : [];
+      if (!labels.includes(options.label)) continue;
+    }
+
+    issues.push({
+      id: parseInt(fm.number) || 0,
+      title: fm.name || file.replace('.md', ''),
+      status: fm.status || 'open',
+      labels: Array.isArray(fm.labels) ? fm.labels : [],
+      assignee: fm.assignee || '',
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      path: path.join(issuesDir, file)
+    });
+  }
+
+  // Sort by number
+  issues.sort((a, b) => a.id - b.id);
+
+  return { success: true, issues, count: issues.length };
+}
+
+module.exports = { execute, parseIssueFrontmatter };

--- a/autopm/.claude/providers/local/issue-show.js
+++ b/autopm/.claude/providers/local/issue-show.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const { parseIssueFrontmatter } = require('./issue-list');
+
+function findIssueFile(issuesDir, id) {
+  if (!fs.existsSync(issuesDir)) return null;
+  const files = fs.readdirSync(issuesDir).filter(f => f.endsWith('.md'));
+  const numId = String(id);
+
+  // Exact match: {id}-*.md or {id}.md
+  for (const file of files) {
+    if (file.startsWith(numId + '-') || file === numId + '.md') {
+      return path.join(issuesDir, file);
+    }
+  }
+  return null;
+}
+
+async function execute(options = {}) {
+  const id = options.id;
+  if (!id) {
+    return { success: false, error: 'Issue ID is required' };
+  }
+
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+  const filepath = findIssueFile(issuesDir, id);
+
+  if (!filepath) {
+    return { success: false, error: `Issue #${id} not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseIssueFrontmatter(content);
+
+  // Extract body (after frontmatter)
+  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  return {
+    success: true,
+    issue: {
+      id: parseInt(fm.number) || parseInt(id),
+      title: fm.name || '',
+      status: fm.status || 'open',
+      labels: Array.isArray(fm.labels) ? fm.labels : [],
+      assignee: fm.assignee || '',
+      body,
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      startedAt: fm.started || '',
+      completedAt: fm.completed || '',
+      path: filepath
+    }
+  };
+}
+
+module.exports = { execute, findIssueFile };

--- a/autopm/.claude/providers/local/issue-start.js
+++ b/autopm/.claude/providers/local/issue-start.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { findIssueFile } = require('./issue-show');
+const { parseIssueFrontmatter } = require('./issue-list');
+
+async function execute(options = {}) {
+  const id = options.id;
+  if (!id) {
+    return { success: false, error: 'Issue ID is required' };
+  }
+
+  const issuesDir = path.join(process.cwd(), '.claude', 'issues');
+  const filepath = findIssueFile(issuesDir, id);
+
+  if (!filepath) {
+    return { success: false, error: `Issue #${id} not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseIssueFrontmatter(content);
+  const now = new Date().toISOString();
+  const actions = [];
+
+  // Update frontmatter: status, started, updated
+  let updated = content
+    .replace(/^status:\s*.+$/m, 'status: in_progress')
+    .replace(/^updated:\s*.+$/m, `updated: ${now}`)
+    .replace(/^started:\s*.*$/m, `started: ${now}`);
+
+  fs.writeFileSync(filepath, updated, 'utf8');
+  actions.push(`Updated issue #${id} status to in_progress`);
+
+  // Create branch unless --no-branch
+  let branch = null;
+  if (!options.no_branch) {
+    const slug = path.basename(filepath, '.md').replace(/^\d+-/, '');
+    branch = `feature/${id}-${slug}`;
+    try {
+      execSync(`git checkout -b ${branch}`, { stdio: 'pipe' });
+      actions.push(`Created branch: ${branch}`);
+    } catch (e) {
+      actions.push(`Branch creation skipped: ${e.message.split('\n')[0]}`);
+    }
+  }
+
+  return {
+    success: true,
+    issue: {
+      id: parseInt(fm.number) || parseInt(id),
+      title: fm.name || '',
+      status: 'in_progress',
+      branch,
+      assignee: fm.assignee || '',
+      url: `file://${filepath}`
+    },
+    actions,
+    timestamp: now
+  };
+}
+
+module.exports = { execute };

--- a/autopm/.claude/providers/router.js
+++ b/autopm/.claude/providers/router.js
@@ -41,8 +41,8 @@ class ProviderRouter {
       return this.config.projectManagement.provider;
     }
 
-    // Default to GitHub if not configured
-    return 'github';
+    // Default to local if not configured (works without gh CLI or Azure)
+    return 'local';
   }
 
   /**

--- a/autopm/.claude/scripts/setup-local-mode.js
+++ b/autopm/.claude/scripts/setup-local-mode.js
@@ -13,8 +13,9 @@ async function setupLocalDirectories() {
   const directories = [
     'prds',       // Product Requirements Documents
     'epics',      // Epic definitions and task breakdowns
-    'context',    // Project context files (NEW)
-    'logs'        // Verification and operation logs (NEW)
+    'issues',     // Local issue tracking
+    'context',    // Project context files
+    'logs'        // Verification and operation logs
   ];
 
   for (const dir of directories) {

--- a/test/local-mode/local-issues.test.js
+++ b/test/local-mode/local-issues.test.js
@@ -1,0 +1,202 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const issueCreate = require('../../autopm/.claude/providers/local/issue-create');
+const issueList = require('../../autopm/.claude/providers/local/issue-list');
+const issueShow = require('../../autopm/.claude/providers/local/issue-show');
+const issueStart = require('../../autopm/.claude/providers/local/issue-start');
+const issueClose = require('../../autopm/.claude/providers/local/issue-close');
+
+let tempDir;
+let originalCwd;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'local-issues-'));
+  fs.mkdirSync(path.join(tempDir, '.claude', 'issues'), { recursive: true });
+  originalCwd = process.cwd();
+  process.chdir(tempDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('issue-create', () => {
+  test('creates file with correct frontmatter', async () => {
+    const result = await issueCreate.execute({ title: 'Fix login bug', labels: ['bug'] });
+
+    expect(result.success).toBe(true);
+    expect(result.issue.id).toBe(1);
+    expect(result.issue.title).toBe('Fix login bug');
+    expect(result.issue.status).toBe('open');
+
+    const content = fs.readFileSync(result.issue.path, 'utf8');
+    expect(content).toContain('number: 1');
+    expect(content).toContain('name: "Fix login bug"');
+    expect(content).toContain('status: open');
+    expect(content).toContain('labels: [bug]');
+  });
+
+  test('auto-increments number', async () => {
+    await issueCreate.execute({ title: 'First issue' });
+    const second = await issueCreate.execute({ title: 'Second issue' });
+
+    expect(second.issue.id).toBe(2);
+  });
+
+  test('generates slug from title', async () => {
+    const result = await issueCreate.execute({ title: 'Fix Login Bug & Auth' });
+    const filename = path.basename(result.issue.path);
+
+    expect(filename).toBe('1-fix-login-bug-auth.md');
+  });
+
+  test('creates issues dir if missing', async () => {
+    fs.rmSync(path.join(tempDir, '.claude', 'issues'), { recursive: true });
+    const result = await issueCreate.execute({ title: 'Test' });
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(result.issue.path)).toBe(true);
+  });
+});
+
+describe('issue-list', () => {
+  beforeEach(async () => {
+    await issueCreate.execute({ title: 'Bug A', labels: ['bug'] });
+    await issueCreate.execute({ title: 'Feature B', labels: ['enhancement'] });
+    await issueCreate.execute({ title: 'Bug C', labels: ['bug'] });
+  });
+
+  test('returns all issues', async () => {
+    const result = await issueList.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(3);
+    expect(result.issues[0].id).toBe(1);
+    expect(result.issues[2].id).toBe(3);
+  });
+
+  test('filters by status', async () => {
+    // Close one issue
+    await issueClose.execute({ id: 2 });
+
+    const open = await issueList.execute({ status: 'open' });
+    expect(open.count).toBe(2);
+
+    const closed = await issueList.execute({ status: 'closed' });
+    expect(closed.count).toBe(1);
+  });
+
+  test('returns empty for no issues dir', async () => {
+    fs.rmSync(path.join(tempDir, '.claude', 'issues'), { recursive: true });
+    const result = await issueList.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(0);
+  });
+});
+
+describe('issue-show', () => {
+  test('returns issue by id', async () => {
+    await issueCreate.execute({ title: 'Test Issue', labels: ['test'] });
+    const result = await issueShow.execute({ id: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.issue.id).toBe(1);
+    expect(result.issue.title).toBe('Test Issue');
+    expect(result.issue.status).toBe('open');
+    expect(result.issue.body).toContain('Test Issue');
+  });
+
+  test('handles not-found', async () => {
+    const result = await issueShow.execute({ id: 999 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  test('requires id', async () => {
+    const result = await issueShow.execute({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+describe('issue-start', () => {
+  test('updates status to in_progress', async () => {
+    await issueCreate.execute({ title: 'Start test' });
+    const result = await issueStart.execute({ id: 1, no_branch: true });
+
+    expect(result.success).toBe(true);
+    expect(result.issue.status).toBe('in_progress');
+    expect(result.actions).toContain('Updated issue #1 status to in_progress');
+
+    // Verify file
+    const show = await issueShow.execute({ id: 1 });
+    expect(show.issue.status).toBe('in_progress');
+    expect(show.issue.startedAt).not.toBe('');
+  });
+
+  test('handles not-found', async () => {
+    const result = await issueStart.execute({ id: 999, no_branch: true });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('issue-close', () => {
+  test('updates status to closed', async () => {
+    await issueCreate.execute({ title: 'Close test' });
+    const result = await issueClose.execute({ id: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.issue.status).toBe('closed');
+
+    // Verify file
+    const show = await issueShow.execute({ id: 1 });
+    expect(show.issue.status).toBe('closed');
+    expect(show.issue.completedAt).not.toBe('');
+  });
+
+  test('sets completed timestamp', async () => {
+    await issueCreate.execute({ title: 'Timestamp test' });
+    const before = new Date().toISOString();
+    await issueClose.execute({ id: 1 });
+
+    const show = await issueShow.execute({ id: 1 });
+    expect(show.issue.completedAt >= before).toBe(true);
+  });
+});
+
+describe('Full Lifecycle', () => {
+  test('create → list → start → close', async () => {
+    // Create
+    const created = await issueCreate.execute({ title: 'Lifecycle test', labels: ['test'] });
+    expect(created.success).toBe(true);
+
+    // List
+    const listed = await issueList.execute();
+    expect(listed.count).toBe(1);
+
+    // Start
+    const started = await issueStart.execute({ id: 1, no_branch: true });
+    expect(started.issue.status).toBe('in_progress');
+
+    // Verify in-progress in list
+    const inProgress = await issueList.execute({ status: 'in_progress' });
+    expect(inProgress.count).toBe(1);
+
+    // Close
+    const closed = await issueClose.execute({ id: 1 });
+    expect(closed.issue.status).toBe('closed');
+
+    // Verify closed in list
+    const closedList = await issueList.execute({ status: 'closed' });
+    expect(closedList.count).toBe(1);
+
+    const openList = await issueList.execute({ status: 'open' });
+    expect(openList.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## 🎯 Goal
Enable issue tracking without GitHub/Azure. Issues stored as markdown in \`.claude/issues/\` with YAML frontmatter. Lite scenario users get full issue lifecycle locally.

## 📋 Context
- Provider system had github/ and azure/ but no local/ provider
- Router defaulted to 'github' — broken for users without \`gh\` CLI
- setup-local-mode.js created prds/, epics/ but not issues/

## ✅ Changes
- 5 new local provider commands: issue-create, issue-list, issue-show, issue-start, issue-close
- Router default changed: 'github' → 'local'
- setup-local-mode.js: adds .claude/issues/ directory
- 15 new tests covering full lifecycle

## 📁 Affected Files
- \`autopm/.claude/providers/local/*.js\` — 5 NEW provider commands
- \`autopm/.claude/providers/router.js\` — default provider → local
- \`autopm/.claude/scripts/setup-local-mode.js\` — +issues/ dir
- \`test/local-mode/local-issues.test.js\` — 15 tests

## 🚫 Out of Scope
- No sync between local and GitHub/Azure
- No local epic/PRD tracking (already partially exists)

Closes #447