### PR TITLE
[fix][ci] Remove --provenance from npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,6 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci --legacy-peer-deps
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🎯 Goal
Fix npm-publish.yml that fails with --provenance flag (same issue as plugin-publish.yml fixed in #454).

## 📁 Affected Files
- \`.github/workflows/npm-publish.yml\` — removed \`--provenance\`

## After merge
Delete tag v3.14.0, re-tag, push to trigger publish:
\`\`\`
git tag -d v3.14.0 && git push origin :refs/tags/v3.14.0
git tag v3.14.0 && git push --tags
\`\`\`