### PR TITLE
[docs] Update docs site for v3.14.0

### DIFF
--- a/docs-site/docs/agents/registry.md
+++ b/docs-site/docs/agents/registry.md
@@ -1,567 +1,152 @@
 # Agent Registry
 
-Complete registry of all 35+ specialized AI agents available in ClaudeAutoPM. This page provides descriptions, use cases, and examples for each agent to help you choose the right tool for your task.
+ClaudeAutoPM uses a **core + plugin** agent model. 7 core agents are always available. Additional specialized agents (50+) are installed on demand via plugins.
 
-## 🚀 Recent Optimization (v1.2.0)
+## Architecture
 
-### Summary of Changes
-- **Reduced agent count from 50+ to ~35** (Phase 1 complete)
-- **Consolidated similar agents** into parameterized versions
-- **Unified coordination rules** for better efficiency
-- **Maintained all functionality** through parameters
+The agent registry is defined in `.claude/agents/agent-registry.xml`. This XML file:
 
-### Key Consolidations
-1. **UI Frameworks**: 4 agents → 1 `react-ui-expert`
-2. **Python Backend**: 3 agents → 1 `python-backend-expert`
-3. **Docker**: 3 agents → 1 `docker-containerization-expert`
-4. **E2E Testing**: 2 agents → 1 `e2e-test-engineer`
+1. Lists all 7 core agents (always present)
+2. Contains `PLUGIN_AGENTS_START` / `PLUGIN_AGENTS_END` markers
+3. During `autopm install`, the installer injects agents from selected plugins between these markers
+4. CLAUDE.md includes this file via `@include .claude/agents/agent-registry.xml`
 
-## Core Agents
+This means only agents from your installed plugins consume context tokens.
+
+```xml
+<agent-registry version="2.0.0" core-agents="7">
+  <agents category="core">
+    <agent name="agent-manager" path="agents/core/agent-manager.md">...</agent>
+    <!-- ... other core agents ... -->
+  </agents>
+
+  <!-- PLUGIN_AGENTS_START -->
+  <!-- Injected by install.js based on installed plugins -->
+  <!-- PLUGIN_AGENTS_END -->
+</agent-registry>
+```
+
+## Core Agents (Always Available)
+
+These 7 agents are included in every installation scenario, from lite to performance.
 
 ### agent-manager
-**Location**: `.claude/agents/core/agent-manager.md`
-**Purpose**: Agent lifecycle management and creation
-**Use for**: Creating new agents, updating documentation, registry maintenance
-**Example**:
-```markdown
-@agent-manager create a specialized agent for GraphQL development with Apollo Server expertise
-```
+**Path**: `.claude/agents/core/agent-manager.md`
+**Purpose**: Agent lifecycle management, documentation standards, registry maintenance.
+**Use for**: Creating new agents, updating agent definitions, managing the registry.
 
 ### file-analyzer
-**Location**: `.claude/agents/core/file-analyzer.md`
-**Purpose**: Analyze and summarize large files to reduce context usage
-**Use for**: Log analysis, documentation review, test output summarization
-**Example**:
-```markdown
-@file-analyzer summarize the key errors in this 5000-line installation log
-```
+**Path**: `.claude/agents/core/file-analyzer.md`
+**Purpose**: Analyze and summarize large files to reduce context usage.
+**Use for**: Log analysis, documentation review, test output summarization, configuration review.
 
 ### code-analyzer
-**Location**: `.claude/agents/core/code-analyzer.md`
-**Purpose**: Code review, bug detection, and logic flow analysis
-**Use for**: Pre-commit reviews, security scanning, architecture analysis
-**Example**:
-```markdown
-@code-analyzer review this authentication module for security vulnerabilities
-```
+**Path**: `.claude/agents/core/code-analyzer.md`
+**Purpose**: Code review, bug detection, and logic flow analysis.
+**Use for**: Pre-commit reviews, security scanning, architecture analysis, dependency tracing.
 
 ### test-runner
-**Location**: `.claude/agents/core/test-runner.md`
-**Purpose**: Test execution and comprehensive result analysis
-**Use for**: Running test suites, failure analysis, coverage reports
-**Example**:
-```markdown
-@test-runner execute all integration tests and analyze any failures
-```
+**Path**: `.claude/agents/core/test-runner.md`
+**Purpose**: Test execution and comprehensive result analysis.
+**Use for**: Running test suites, failure analysis, coverage reports.
 
 ### parallel-worker
-**Location**: `.claude/agents/core/parallel-worker.md`
-**Purpose**: Coordinate multiple agents working on related tasks
-**Use for**: Complex multi-step workflows, parallel task execution
-**Example**:
-```markdown
-@parallel-worker coordinate testing, building, and deployment tasks
-```
+**Path**: `.claude/agents/core/parallel-worker.md`
+**Purpose**: Coordinate multiple agents working on related tasks in a git branch.
+**Use for**: Complex multi-step workflows, parallel task execution, multi-file operations.
 
 ### mcp-manager
-**Location**: `.claude/agents/core/mcp-manager.md`
-**Purpose**: Manage Model Context Protocol server configurations
-**Use for**: MCP server setup, configuration, troubleshooting
-**Example**:
-```markdown
-@mcp-manager configure Context7 MCP server for documentation indexing
+**Path**: `.claude/agents/core/mcp-manager.md`
+**Purpose**: MCP server install, configuration, process management, health checks.
+**Use for**: MCP server setup, configuration, troubleshooting.
+
+### context-optimizer
+**Path**: `.claude/agents/core/context-optimizer.md`
+**Purpose**: Context window efficiency, compaction, summarization, memory optimization.
+**Use for**: Reducing context usage, optimizing prompt size, managing long conversations.
+
+## Plugin Agents (Installed on Demand)
+
+Plugin agents are only available after installing the corresponding plugin. They are organized across 13 plugins:
+
+| Plugin | Agents | Category |
+|--------|--------|----------|
+| `plugin-languages` | 6 | Node.js, Python, Bash, JavaScript |
+| `plugin-frameworks` | 7 | React, FastAPI, Flask, Tailwind, E2E testing |
+| `plugin-devops` | 8 | Docker, Kubernetes, GitHub Actions, Azure DevOps, SSH, Traefik |
+| `plugin-cloud` | 9 | AWS, Azure, GCP, Terraform, OpenAI, Gemini |
+| `plugin-databases` | 6 | PostgreSQL, MongoDB, Redis, CosmosDB, BigQuery |
+| `plugin-testing` | 1 | Playwright specialist |
+| `plugin-ai` | 8 | AI/ML integration agents |
+| `plugin-data` | 3 | LangGraph, Airflow, Kedro |
+| `plugin-ml` | 10 | Machine learning specialists |
+| `plugin-pm` | 0 | PM commands (no agents) |
+| `plugin-pm-github` | 0 | GitHub provider (no agents) |
+| `plugin-pm-azure` | 0 | Azure provider (no agents) |
+| `plugin-core` | 7 | Core agents (always installed) |
+
+### Installing Plugin Agents
+
+Plugin agents are installed automatically based on your chosen scenario:
+
+```bash
+# Lite: 7 core agents only
+autopm install --scenario=lite
+
+# GitHub: 7 core + 6 language agents
+autopm install --scenario=github
+
+# Full: 7 core + 45+ plugin agents
+autopm install --scenario=full
 ```
 
-## Framework Agents
+### Example Plugin Agents
 
-### react-ui-expert
-**Location**: `.claude/agents/frameworks/react-ui-expert.md`
-**Purpose**: React development with modern patterns (consolidated from 4 UI agents)
-**Expertise**: React 18+, hooks, state management, component patterns
-**Example**:
+**From plugin-languages:**
+- `@python-backend-expert` - Python backend development (FastAPI, Django, Flask)
+- `@nodejs-backend-engineer` - Node.js backend with Express, NestJS
+- `@bash-scripting-expert` - Shell scripting and automation
+
+**From plugin-devops:**
+- `@docker-containerization-expert` - Docker, Compose, multi-stage builds
+- `@kubernetes-orchestrator` - K8s deployments, Helm charts
+- `@github-operations-specialist` - GitHub Actions, CI/CD pipelines
+
+**From plugin-cloud:**
+- `@aws-cloud-architect` - AWS infrastructure design
+- `@azure-cloud-architect` - Azure resources, ARM templates
+- `@terraform-infrastructure-expert` - Infrastructure as Code
+
+**From plugin-databases:**
+- `@postgresql-expert` - Schema design, query optimization
+- `@mongodb-expert` - Document design, aggregation pipelines
+- `@redis-expert` - Caching strategies, data structures
+
+## Agent Usage
+
 ```markdown
-@react-ui-expert build a data table component with sorting, filtering, and pagination
+# Core agents work in any scenario
+@code-analyzer review this authentication module for security vulnerabilities
+@test-runner execute all integration tests and analyze any failures
+
+# Plugin agents require the corresponding plugin
+@docker-containerization-expert create optimized Docker setup  # Requires plugin-devops
+@postgresql-expert optimize this slow query                     # Requires plugin-databases
 ```
 
-### e2e-test-engineer
-**Location**: `.claude/agents/frameworks/e2e-test-engineer.md`
-**Purpose**: End-to-end testing across platforms (consolidated)
-**Expertise**: Playwright, Cypress, Selenium, cross-browser testing
-**Example**:
-```markdown
-@e2e-test-engineer create Playwright tests for the complete checkout workflow
-```
+## Legacy Agent Support
 
-### tailwindcss-expert
-**Location**: `.claude/agents/frameworks/tailwindcss-expert.md`
-**Purpose**: Tailwind CSS styling and design systems
-**Expertise**: Utility-first CSS, responsive design, component styling
-**Example**:
-```markdown
-@tailwindcss-expert design a responsive dashboard layout with dark mode support
-```
+Deprecated agent names were removed in the v1.1.0 consolidation. Use the consolidated versions:
 
-### mui-react-expert
-**Location**: `.claude/agents/frameworks/mui-react-expert.md`
-**Purpose**: Material-UI React component development
-**Expertise**: MUI components, theming, custom components
-**Example**:
-```markdown
-@mui-react-expert create a Material-UI form with validation and stepper component
-```
-
-### antd-react-expert
-**Location**: `.claude/agents/frameworks/antd-react-expert.md`
-**Purpose**: Ant Design React development
-**Expertise**: Ant Design components, forms, tables, layouts
-**Example**:
-```markdown
-@antd-react-expert build an admin dashboard with Ant Design Pro components
-```
-
-### bootstrap-ui-expert
-**Location**: `.claude/agents/frameworks/bootstrap-ui-expert.md`
-**Purpose**: Bootstrap-based UI development
-**Expertise**: Bootstrap 5, responsive grids, component styling
-**Example**:
-```markdown
-@bootstrap-ui-expert create a responsive landing page with Bootstrap components
-```
-
-### chakra-ui-expert
-**Location**: `.claude/agents/frameworks/chakra-ui-expert.md`
-**Purpose**: Chakra UI component development
-**Expertise**: Chakra UI components, theming, accessibility
-**Example**:
-```markdown
-@chakra-ui-expert build an accessible form system with Chakra UI components
-```
-
-### fastapi-backend-engineer
-**Location**: `.claude/agents/frameworks/fastapi-backend-engineer.md`
-**Purpose**: FastAPI backend development
-**Expertise**: FastAPI, async endpoints, dependency injection, OpenAPI
-**Example**:
-```markdown
-@fastapi-backend-engineer create a REST API with authentication and database integration
-```
-
-### flask-backend-engineer
-**Location**: `.claude/agents/frameworks/flask-backend-engineer.md`
-**Purpose**: Flask web application development
-**Expertise**: Flask, blueprints, extensions, SQLAlchemy
-**Example**:
-```markdown
-@flask-backend-engineer build a web application with user authentication and admin panel
-```
-
-### playwright-test-engineer
-**Location**: `.claude/agents/frameworks/playwright-test-engineer.md`
-**Purpose**: Playwright-specific testing and automation
-**Expertise**: Playwright API, page objects, visual testing
-**Example**:
-```markdown
-@playwright-test-engineer implement visual regression tests for the UI components
-```
-
-### playwright-mcp-frontend-tester
-**Location**: `.claude/agents/frameworks/playwright-mcp-frontend-tester.md`
-**Purpose**: Frontend testing with Playwright MCP integration
-**Expertise**: MCP-enabled testing, automated UI testing
-**Example**:
-```markdown
-@playwright-mcp-frontend-tester create automated tests for the MCP-enabled frontend
-```
-
-### react-frontend-engineer
-**Location**: `.claude/agents/frameworks/react-frontend-engineer.md`
-**Purpose**: React application architecture and development
-**Expertise**: React patterns, state management, routing, performance
-**Example**:
-```markdown
-@react-frontend-engineer architect a scalable React application with proper state management
-```
-
-### ux-design-expert
-**Location**: `.claude/agents/frameworks/ux-design-expert.md`
-**Purpose**: UX design and user experience optimization
-**Expertise**: User flows, wireframing, accessibility, design systems
-**Example**:
-```markdown
-@ux-design-expert design an intuitive user onboarding flow with accessibility considerations
-```
-
-### nats-messaging-expert
-**Location**: `.claude/agents/frameworks/nats-messaging-expert.md`
-**Purpose**: NATS messaging system integration
-**Expertise**: NATS streaming, microservices communication, message patterns
-**Example**:
-```markdown
-@nats-messaging-expert implement event-driven communication between microservices
-```
-
-## Language Specialists
-
-### python-backend-expert
-**Location**: `.claude/agents/languages/python-backend-expert.md`
-**Purpose**: Python backend development (consolidated from 3 agents)
-**Expertise**: FastAPI, Django, Flask, async programming, testing
-**Example**:
-```markdown
-@python-backend-expert create a microservice with FastAPI, database integration, and tests
-```
-
-### python-backend-engineer
-**Location**: `.claude/agents/languages/python-backend-engineer.md`
-**Purpose**: Python backend engineering and architecture
-**Expertise**: System design, API development, database integration
-**Example**:
-```markdown
-@python-backend-engineer design a scalable backend architecture for high-traffic application
-```
-
-### nodejs-backend-engineer
-**Location**: `.claude/agents/languages/nodejs-backend-engineer.md`
-**Purpose**: Node.js backend development
-**Expertise**: Express, NestJS, middleware, real-time features
-**Example**:
-```markdown
-@nodejs-backend-engineer implement a real-time chat system with WebSocket support
-```
-
-### javascript-frontend-engineer
-**Location**: `.claude/agents/languages/javascript-frontend-engineer.md`
-**Purpose**: Frontend JavaScript development
-**Expertise**: Modern JavaScript, DOM manipulation, module systems
-**Example**:
-```markdown
-@javascript-frontend-engineer optimize JavaScript performance and implement lazy loading
-```
-
-### bash-scripting-expert
-**Location**: `.claude/agents/languages/bash-scripting-expert.md`
-**Purpose**: Shell scripting and automation
-**Expertise**: Bash scripting, system administration, automation
-**Example**:
-```markdown
-@bash-scripting-expert create deployment scripts with error handling and logging
-```
-
-## DevOps Agents
-
-### docker-containerization-expert
-**Location**: `.claude/agents/devops/docker-containerization-expert.md`
-**Purpose**: Docker and containerization (consolidated from 3 agents)
-**Expertise**: Dockerfile optimization, multi-stage builds, security, orchestration
-**Example**:
-```markdown
-@docker-containerization-expert create optimized Docker setup for microservices deployment
-```
-
-### kubernetes-orchestrator
-**Location**: `.claude/agents/devops/kubernetes-orchestrator.md`
-**Purpose**: Kubernetes deployment and management
-**Expertise**: K8s manifests, Helm charts, scaling, service mesh
-**Example**:
-```markdown
-@kubernetes-orchestrator design a scalable Kubernetes deployment with auto-scaling
-```
-
-### github-operations-specialist
-**Location**: `.claude/agents/devops/github-operations-specialist.md`
-**Purpose**: GitHub Actions, workflows, and repository management
-**Expertise**: CI/CD pipelines, Actions, release automation
-**Example**:
-```markdown
-@github-operations-specialist create a comprehensive CI/CD pipeline with testing and deployment
-```
-
-### azure-devops-specialist
-**Location**: `.claude/agents/devops/azure-devops-specialist.md`
-**Purpose**: Azure DevOps integration and automation
-**Expertise**: Azure Pipelines, Boards, Repos, deployment
-**Example**:
-```markdown
-@azure-devops-specialist setup Azure DevOps pipeline with multi-environment deployment
-```
-
-### docker-compose-expert
-**Location**: `.claude/agents/devops/docker-compose-expert.md`
-**Purpose**: Docker Compose orchestration
-**Expertise**: Multi-container applications, networking, volumes
-**Example**:
-```markdown
-@docker-compose-expert create development environment with database, cache, and monitoring
-```
-
-### docker-expert
-**Location**: `.claude/agents/devops/docker-expert.md`
-**Purpose**: Advanced Docker techniques and optimization
-**Expertise**: Performance tuning, security, registry management
-**Example**:
-```markdown
-@docker-expert optimize Docker images for production deployment with security scanning
-```
-
-### docker-development-orchestrator
-**Location**: `.claude/agents/devops/docker-development-orchestrator.md`
-**Purpose**: Docker-based development environment setup
-**Expertise**: Development workflows, hot reloading, debugging
-**Example**:
-```markdown
-@docker-development-orchestrator setup development environment with hot reload and debugging
-```
-
-### ssh-operations-expert
-**Location**: `.claude/agents/devops/ssh-operations-expert.md`
-**Purpose**: SSH configuration, security, and automation
-**Expertise**: SSH keys, tunneling, automation, security
-**Example**:
-```markdown
-@ssh-operations-expert setup secure SSH access with key management and automation
-```
-
-### traefik-proxy-expert
-**Location**: `.claude/agents/devops/traefik-proxy-expert.md`
-**Purpose**: Traefik reverse proxy configuration
-**Expertise**: Load balancing, SSL termination, service discovery
-**Example**:
-```markdown
-@traefik-proxy-expert configure Traefik for microservices with automatic SSL certificates
-```
-
-### mcp-context-manager
-**Location**: `.claude/agents/devops/mcp-context-manager.md`
-**Purpose**: Model Context Protocol deployment and management
-**Expertise**: MCP servers, context management, integration
-**Example**:
-```markdown
-@mcp-context-manager deploy and configure MCP servers for development team
-```
-
-## Cloud Architecture Agents
-
-### aws-cloud-architect
-**Location**: `.claude/agents/cloud/aws-cloud-architect.md`
-**Purpose**: AWS infrastructure design and implementation
-**Expertise**: EC2, Lambda, RDS, VPC, CloudFormation, cost optimization
-**Example**:
-```markdown
-@aws-cloud-architect design serverless architecture for image processing with auto-scaling
-```
-
-### azure-cloud-architect
-**Location**: `.claude/agents/cloud/azure-cloud-architect.md`
-**Purpose**: Azure cloud infrastructure and services
-**Expertise**: Azure VMs, AKS, Functions, ARM templates, cost management
-**Example**:
-```markdown
-@azure-cloud-architect create Azure infrastructure with AKS cluster and monitoring
-```
-
-### gcp-cloud-architect
-**Location**: `.claude/agents/cloud/gcp-cloud-architect.md`
-**Purpose**: Google Cloud Platform architecture
-**Expertise**: Compute Engine, GKE, Cloud Functions, Terraform
-**Example**:
-```markdown
-@gcp-cloud-architect implement event-driven architecture with Cloud Run and Pub/Sub
-```
-
-### terraform-infrastructure-expert
-**Location**: `.claude/agents/cloud/terraform-infrastructure-expert.md`
-**Purpose**: Infrastructure as Code with Terraform
-**Expertise**: Terraform modules, state management, multi-cloud deployments
-**Example**:
-```markdown
-@terraform-infrastructure-expert create reusable Terraform modules for multi-environment deployment
-```
-
-### kubernetes-orchestrator
-**Location**: `.claude/agents/cloud/kubernetes-orchestrator.md`
-**Purpose**: Kubernetes orchestration and management
-**Expertise**: K8s deployment, scaling, monitoring, service mesh
-**Example**:
-```markdown
-@kubernetes-orchestrator implement blue-green deployment strategy with monitoring
-```
-
-### openai-python-expert
-**Location**: `.claude/agents/cloud/openai-python-expert.md`
-**Purpose**: OpenAI API integration with Python
-**Expertise**: OpenAI APIs, embeddings, fine-tuning, Python integration
-**Example**:
-```markdown
-@openai-python-expert implement intelligent document processing with OpenAI embeddings
-```
-
-### gemini-api-expert
-**Location**: `.claude/agents/cloud/gemini-api-expert.md`
-**Purpose**: Google Gemini API integration
-**Expertise**: Gemini Pro, multimodal AI, Google AI Studio
-**Example**:
-```markdown
-@gemini-api-expert create multimodal AI application with text and image processing
-```
-
-### gcp-cloud-functions-engineer
-**Location**: `.claude/agents/cloud/gcp-cloud-functions-engineer.md`
-**Purpose**: Google Cloud Functions development
-**Expertise**: Serverless functions, event triggers, HTTP functions
-**Example**:
-```markdown
-@gcp-cloud-functions-engineer create event-driven serverless functions for data processing
-```
-
-## Database Specialists
-
-### postgresql-expert
-**Location**: `.claude/agents/databases/postgresql-expert.md`
-**Purpose**: PostgreSQL database design and optimization
-**Expertise**: Schema design, query optimization, indexes, performance tuning
-**Example**:
-```markdown
-@postgresql-expert optimize database schema for high-performance e-commerce application
-```
-
-### mongodb-expert
-**Location**: `.claude/agents/databases/mongodb-expert.md`
-**Purpose**: MongoDB NoSQL database development
-**Expertise**: Document design, aggregation pipelines, indexing, sharding
-**Example**:
-```markdown
-@mongodb-expert design scalable document schema for user activity tracking
-```
-
-### redis-expert
-**Location**: `.claude/agents/databases/redis-expert.md`
-**Purpose**: Redis caching and data structures
-**Expertise**: Caching strategies, data structures, performance optimization
-**Example**:
-```markdown
-@redis-expert implement distributed caching strategy with Redis cluster
-```
-
-### cosmosdb-expert
-**Location**: `.claude/agents/databases/cosmosdb-expert.md`
-**Purpose**: Azure Cosmos DB development
-**Expertise**: Multi-model database, global distribution, consistency levels
-**Example**:
-```markdown
-@cosmosdb-expert design globally distributed database with optimal consistency model
-```
-
-### bigquery-expert
-**Location**: `.claude/agents/databases/bigquery-expert.md`
-**Purpose**: Google BigQuery analytics and data warehousing
-**Expertise**: SQL optimization, data modeling, analytics, streaming
-**Example**:
-```markdown
-@bigquery-expert create data warehouse with real-time analytics and reporting
-```
-
-## Data Pipeline Agents
-
-### langgraph-workflow-expert
-**Location**: `.claude/agents/data/langgraph-workflow-expert.md`
-**Purpose**: LangGraph workflow orchestration
-**Expertise**: AI workflow design, graph-based processing, state management
-**Example**:
-```markdown
-@langgraph-workflow-expert create intelligent document processing workflow with multiple AI agents
-```
-
-### airflow-orchestration-expert
-**Location**: `.claude/agents/data/airflow-orchestration-expert.md`
-**Purpose**: Apache Airflow data pipeline orchestration
-**Expertise**: DAGs, task scheduling, data pipeline automation
-**Example**:
-```markdown
-@airflow-orchestration-expert design data pipeline for ETL processing with monitoring
-```
-
-### kedro-pipeline-expert
-**Location**: `.claude/agents/data/kedro-pipeline-expert.md`
-**Purpose**: Kedro data science pipeline development
-**Expertise**: ML pipelines, data versioning, experiment tracking
-**Example**:
-```markdown
-@kedro-pipeline-expert create ML pipeline with data versioning and experiment tracking
-```
-
-## Decision Matrix Agents
-
-### playwright-testing-selection
-**Location**: `.claude/agents/decision-matrices/playwright-testing-selection.md`
-**Purpose**: Help choose optimal Playwright testing approach
-**Use for**: Test strategy decisions, framework selection
-**Example**:
-```markdown
-@playwright-testing-selection recommend testing approach for e-commerce application
-```
-
-### python-backend-selection
-**Location**: `.claude/agents/decision-matrices/python-backend-selection.md`
-**Purpose**: Choose optimal Python backend framework
-**Use for**: Architecture decisions, framework selection
-**Example**:
-```markdown
-@python-backend-selection recommend backend stack for high-traffic API
-```
-
-### ui-framework-selection
-**Location**: `.claude/agents/decision-matrices/ui-framework-selection.md`
-**Purpose**: Help choose UI framework and approach
-**Use for**: Frontend technology decisions, component library selection
-**Example**:
-```markdown
-@ui-framework-selection recommend UI stack for enterprise dashboard application
-```
-
-## Agent Usage Tips
-
-### Legacy Agent Support
-Legacy agent names continue to work with deprecation warnings:
-- `@docker-expert` → `@docker-containerization-expert`
-- `@react-expert` → `@react-ui-expert`
-- `@python-expert` → `@python-backend-expert`
-
-### Best Practices
-1. **Use specific agents** for specialized tasks
-2. **Combine agents** for complex workflows
-3. **Provide context** to get better results
-4. **Start with decision matrices** when unsure
-
-### Agent Coordination
-When using multiple agents:
-```markdown
-# Sequential execution
-@code-analyzer review code quality
-THEN @test-runner execute tests
-THEN @docker-containerization-expert prepare deployment
-
-# Parallel execution (when enabled)
-@code-analyzer review backend/
-@test-runner execute unit tests
-@docker-containerization-expert build images
-```
-
-## Migration from Legacy Agents
-
-If you're using deprecated agent names, update to the new consolidated agents:
-
-| Legacy Agent | New Agent | Notes |
-|--------------|-----------|--------|
-| `@react-expert` | `@react-ui-expert` | Unified UI expert |
-| `@vue-expert` | `@react-ui-expert` | Use with Vue parameter |
-| `@angular-expert` | `@react-ui-expert` | Use with Angular parameter |
-| `@docker-expert` | `@docker-containerization-expert` | Consolidated Docker agent |
-| `@kubernetes-expert` | `@kubernetes-orchestrator` | Enhanced K8s capabilities |
-| `@python-expert` | `@python-backend-expert` | Unified Python backend |
+| Deprecated | Current |
+|------------|---------|
+| `@react-expert` | `@react-ui-expert` (plugin-frameworks) |
+| `@docker-expert` | `@docker-containerization-expert` (plugin-devops) |
+| `@python-expert` | `@python-backend-expert` (plugin-languages) |
+| `@kubernetes-expert` | `@kubernetes-orchestrator` (plugin-devops) |
 
 ## Related Pages
 
-- [Agent Selection Guide](Agent-Selection-Guide) - Choose the right agent
-- [Custom Agents](Custom-Agents) - Create your own agents
-- [Configuration Options](Configuration-Options) - Agent configuration
-- [Testing Strategies](Testing-Strategies) - Testing with agents
+- [Agent Selection Guide](./selection-guide) - Choose the right agent
+- [Plugin Development](/developer-guide/plugin-development) - Create your own plugins
+- [Architecture](/developer-guide/architecture) - System design overview

--- a/docs-site/docs/agents/registry.md
+++ b/docs-site/docs/agents/registry.md
@@ -71,10 +71,10 @@ Plugin agents are only available after installing the corresponding plugin. They
 
 | Plugin | Agents | Category |
 |--------|--------|----------|
-| `plugin-languages` | 6 | Node.js, Python, Bash, JavaScript |
-| `plugin-frameworks` | 7 | React, FastAPI, Flask, Tailwind, E2E testing |
-| `plugin-devops` | 8 | Docker, Kubernetes, GitHub Actions, Azure DevOps, SSH, Traefik |
-| `plugin-cloud` | 9 | AWS, Azure, GCP, Terraform, OpenAI, Gemini |
+| `plugin-languages` | 5 | Python, Node.js, JavaScript, Bash (see plugin.json) |
+| `plugin-frameworks` | 4 | React, Tailwind, UX Design (see plugin.json) |
+| `plugin-devops` | 7 | Docker, GitHub Actions, Azure DevOps, Observability, SSH, Traefik (see plugin.json) |
+| `plugin-cloud` | 8 | AWS, Azure, GCP, Kubernetes, Terraform, OpenAI, Gemini (see plugin.json) |
 | `plugin-databases` | 6 | PostgreSQL, MongoDB, Redis, CosmosDB, BigQuery |
 | `plugin-testing` | 1 | Playwright specialist |
 | `plugin-ai` | 8 | AI/ML integration agents |
@@ -93,7 +93,7 @@ Plugin agents are installed automatically based on your chosen scenario:
 # Lite: 7 core agents only
 autopm install --scenario=lite
 
-# GitHub: 7 core + 6 language agents
+# GitHub: 7 core + 5 language agents
 autopm install --scenario=github
 
 # Full: 7 core + 45+ plugin agents
@@ -109,12 +109,12 @@ autopm install --scenario=full
 
 **From plugin-devops:**
 - `@docker-containerization-expert` - Docker, Compose, multi-stage builds
-- `@kubernetes-orchestrator` - K8s deployments, Helm charts
 - `@github-operations-specialist` - GitHub Actions, CI/CD pipelines
 
 **From plugin-cloud:**
 - `@aws-cloud-architect` - AWS infrastructure design
 - `@azure-cloud-architect` - Azure resources, ARM templates
+- `@kubernetes-orchestrator` - K8s deployments, Helm charts
 - `@terraform-infrastructure-expert` - Infrastructure as Code
 
 **From plugin-databases:**
@@ -143,7 +143,7 @@ Deprecated agent names were removed in the v1.1.0 consolidation. Use the consoli
 | `@react-expert` | `@react-ui-expert` (plugin-frameworks) |
 | `@docker-expert` | `@docker-containerization-expert` (plugin-devops) |
 | `@python-expert` | `@python-backend-expert` (plugin-languages) |
-| `@kubernetes-expert` | `@kubernetes-orchestrator` (plugin-devops) |
+| `@kubernetes-expert` | `@kubernetes-orchestrator` (plugin-cloud) |
 
 ## Related Pages
 

--- a/docs-site/docs/agents/selection-guide.md
+++ b/docs-site/docs/agents/selection-guide.md
@@ -30,7 +30,7 @@ ClaudeAutoPM provides 7 core agents (always available) plus 50+ specialized plug
 | Python Backend | `@python-backend-expert` | plugin-languages |
 | Node.js Backend | `@nodejs-backend-engineer` | plugin-languages |
 | Docker | `@docker-containerization-expert` | plugin-devops |
-| Kubernetes | `@kubernetes-orchestrator` | plugin-devops |
+| Kubernetes | `@kubernetes-orchestrator` | plugin-cloud |
 | GitHub Actions | `@github-operations-specialist` | plugin-devops |
 | AWS | `@aws-cloud-architect` | plugin-cloud |
 | Azure | `@azure-cloud-architect` | plugin-cloud |
@@ -38,7 +38,7 @@ ClaudeAutoPM provides 7 core agents (always available) plus 50+ specialized plug
 | PostgreSQL | `@postgresql-expert` | plugin-databases |
 | MongoDB | `@mongodb-expert` | plugin-databases |
 | Terraform | `@terraform-infrastructure-expert` | plugin-cloud |
-| Playwright | `@e2e-test-engineer` | plugin-frameworks |
+| Frontend Testing | `@frontend-testing-engineer` | plugin-testing |
 
 ### By Task Type
 
@@ -95,7 +95,7 @@ Testing?                → Use @test-runner (core)
 @test-runner execute all tests                          # Core
 @docker-containerization-expert dockerize application   # plugin-devops
 @github-operations-specialist setup GitHub Actions      # plugin-devops
-@kubernetes-orchestrator deploy to K8s                  # plugin-devops
+@kubernetes-orchestrator deploy to K8s                  # plugin-cloud
 ```
 
 ### Testing Suite
@@ -103,7 +103,7 @@ Testing?                → Use @test-runner (core)
 ```markdown
 @test-runner create unit tests             # Core
 @code-analyzer verify test coverage        # Core
-@e2e-test-engineer create end-to-end tests # plugin-frameworks
+@frontend-testing-engineer create end-to-end tests # plugin-testing
 ```
 
 ## Checking Available Agents
@@ -113,8 +113,8 @@ Your available agents depend on your installation scenario:
 | Scenario | Core Agents | Plugin Agents |
 |----------|-------------|---------------|
 | lite | 7 | 0 |
-| github | 7 | 6 (languages) |
-| azure | 7 | 6 (languages) |
+| github | 7 | 5 (languages) |
+| azure | 7 | 5 (languages) |
 | docker | 7 | ~22 |
 | full | 7 | ~45 |
 | performance | 7 | ~50 |

--- a/docs-site/docs/agents/selection-guide.md
+++ b/docs-site/docs/agents/selection-guide.md
@@ -1,316 +1,81 @@
 # Agent Selection Guide
 
-ClaudeAutoPM provides over 35 specialized AI agents to assist with different aspects of software development. This guide helps you choose the right agent for your task based on technology stack, use case, and project requirements.
+ClaudeAutoPM provides 7 core agents (always available) plus 50+ specialized plugin agents. This guide helps you choose the right agent for your task.
+
+## Core vs Plugin Agents
+
+**Core agents** are available in every installation scenario, including lite. They handle fundamental development tasks.
+
+**Plugin agents** require the corresponding plugin to be installed. If you try to use a plugin agent that is not installed, it will not be available in the agent registry.
 
 ## Quick Selection Matrix
 
-### By Technology Stack
+### Core Agents (Always Available)
 
-| Technology | Recommended Agent | Use Case |
-|------------|------------------|----------|
-| **React** | `@react-ui-expert` | React components, hooks, state management |
-| **Python Backend** | `@python-backend-expert` | FastAPI, Django, Flask development |
-| **Docker** | `@docker-containerization-expert` | Containerization, Docker Compose |
-| **Kubernetes** | `@kubernetes-orchestrator` | K8s deployments, Helm charts |
-| **AWS** | `@aws-cloud-architect` | AWS services, infrastructure |
-| **Azure** | `@azure-cloud-architect` | Azure resources, ARM templates |
-| **PostgreSQL** | `@postgresql-expert` | Database design, queries, optimization |
-| **MongoDB** | `@mongodb-expert` | NoSQL schemas, aggregations |
-| **Testing** | `@e2e-test-engineer` | End-to-end testing, test automation |
+| Task | Agent | When to Use |
+|------|-------|-------------|
+| Code review / bugs | `@code-analyzer` | Pre-commit reviews, security scanning, architecture analysis |
+| Run tests | `@test-runner` | Test execution, failure analysis, coverage reports |
+| Analyze files | `@file-analyzer` | Large log files, documentation review, config analysis |
+| Parallel work | `@parallel-worker` | Multi-file operations, complex workflows |
+| Create agents | `@agent-manager` | New agent creation, registry maintenance |
+| MCP servers | `@mcp-manager` | MCP setup, configuration, health checks |
+| Context optimization | `@context-optimizer` | Reduce context usage, prompt optimization |
+
+### Plugin Agents by Technology
+
+| Technology | Agent | Plugin Required |
+|------------|-------|-----------------|
+| React | `@react-ui-expert` | plugin-frameworks |
+| Python Backend | `@python-backend-expert` | plugin-languages |
+| Node.js Backend | `@nodejs-backend-engineer` | plugin-languages |
+| Docker | `@docker-containerization-expert` | plugin-devops |
+| Kubernetes | `@kubernetes-orchestrator` | plugin-devops |
+| GitHub Actions | `@github-operations-specialist` | plugin-devops |
+| AWS | `@aws-cloud-architect` | plugin-cloud |
+| Azure | `@azure-cloud-architect` | plugin-cloud |
+| GCP | `@gcp-cloud-architect` | plugin-cloud |
+| PostgreSQL | `@postgresql-expert` | plugin-databases |
+| MongoDB | `@mongodb-expert` | plugin-databases |
+| Terraform | `@terraform-infrastructure-expert` | plugin-cloud |
+| Playwright | `@e2e-test-engineer` | plugin-frameworks |
 
 ### By Task Type
 
-| Task | Agent | Description |
-|------|-------|-------------|
-| **Code Review** | `@code-analyzer` | Find bugs, security issues, optimizations |
-| **Create Tests** | `@test-runner` | Generate and execute test suites |
-| **Build UI** | `@react-ui-expert` | Create React components with modern patterns |
-| **API Development** | `@python-backend-expert` | Design and implement REST/GraphQL APIs |
-| **DevOps Setup** | `@github-operations-specialist` | CI/CD pipelines, GitHub Actions |
-| **Database Design** | `@postgresql-expert` | Schema design, migrations, optimization |
-| **Cloud Architecture** | `@aws-cloud-architect` | Design scalable cloud solutions |
-| **Container Setup** | `@docker-containerization-expert` | Dockerize applications |
-| **Security Audit** | `@code-analyzer` | Security vulnerability scanning |
+| Task | Agent | Core? |
+|------|-------|-------|
+| Code review | `@code-analyzer` | Yes |
+| Run tests | `@test-runner` | Yes |
+| Build UI | `@react-ui-expert` | No (plugin-frameworks) |
+| API development | `@python-backend-expert` | No (plugin-languages) |
+| DevOps/CI | `@github-operations-specialist` | No (plugin-devops) |
+| Database design | `@postgresql-expert` | No (plugin-databases) |
+| Cloud architecture | `@aws-cloud-architect` | No (plugin-cloud) |
+| Containerization | `@docker-containerization-expert` | No (plugin-devops) |
 
-## Core Agents
+## Decision Flowchart
 
-### agent-manager
-**Location**: `.claude/agents/core/agent-manager.md`
-**Purpose**: Manage agent lifecycle and creation
-**When to use**:
-- Creating new custom agents
-- Analyzing agent performance
-- Updating agent registry
+### Choosing by Scope
 
-```markdown
-@agent-manager create a new agent for GraphQL development
+```
+1. Is this a code review, test, or file analysis?
+   YES → Use core agents (always available)
+
+2. Is this framework/language-specific?
+   YES → Check if the required plugin is installed
+   NO  → Use @code-analyzer as fallback
+
+3. Is this infrastructure/cloud work?
+   YES → Requires plugin-devops or plugin-cloud
 ```
 
-### code-analyzer
-**Location**: `.claude/agents/core/code-analyzer.md`
-**Purpose**: Analyze code for issues and improvements
-**When to use**:
-- Pre-commit code review
-- Security vulnerability scanning
-- Performance optimization analysis
-- Bug investigation
+### Choosing by Role
 
-```markdown
-@code-analyzer review this file for security issues and performance problems
 ```
-
-### test-runner
-**Location**: `.claude/agents/core/test-runner.md`
-**Purpose**: Execute and analyze test results
-**When to use**:
-- Running test suites
-- Analyzing test failures
-- Generating test reports
-- Creating new tests
-
-```markdown
-@test-runner execute all tests and provide detailed failure analysis
-```
-
-### file-analyzer
-**Location**: `.claude/agents/core/file-analyzer.md`
-**Purpose**: Summarize large files to reduce context
-**When to use**:
-- Analyzing large log files
-- Summarizing documentation
-- Processing test outputs
-- Reviewing configuration files
-
-```markdown
-@file-analyzer summarize the key issues in this 5000-line log file
-```
-
-## Frontend Development Agents
-
-### react-ui-expert
-**Purpose**: React development with modern patterns
-**Expertise**:
-- React 18+ features
-- Hooks and custom hooks
-- State management (Redux, Zustand, Context)
-- Component patterns
-- Performance optimization
-
-```markdown
-@react-ui-expert build a data table component with sorting and filtering
-```
-
-### javascript-frontend-engineer
-**Purpose**: General JavaScript frontend development
-**Expertise**:
-- Vanilla JavaScript
-- DOM manipulation
-- Browser APIs
-- Module systems
-- Build tools
-
-```markdown
-@javascript-frontend-engineer optimize this JavaScript for performance
-```
-
-## Backend Development Agents
-
-### python-backend-expert
-**Purpose**: Python backend development
-**Expertise**:
-- FastAPI, Django, Flask
-- Async programming
-- Database integration
-- REST/GraphQL APIs
-- Testing with pytest
-
-```markdown
-@python-backend-expert create a FastAPI endpoint with authentication
-```
-
-### nodejs-backend-engineer
-**Purpose**: Node.js backend development
-**Expertise**:
-- Express, NestJS, Koa
-- Middleware patterns
-- Database integration
-- Real-time features
-- Microservices
-
-```markdown
-@nodejs-backend-engineer implement WebSocket server with Socket.io
-```
-
-## Database Agents
-
-### postgresql-expert
-**Purpose**: PostgreSQL database management
-**Expertise**:
-- Schema design
-- Query optimization
-- Indexes and performance
-- Migrations
-- Advanced features (JSONB, full-text search)
-
-```markdown
-@postgresql-expert optimize this slow query with proper indexes
-```
-
-### mongodb-expert
-**Purpose**: MongoDB NoSQL development
-**Expertise**:
-- Document design
-- Aggregation pipelines
-- Indexing strategies
-- Sharding
-- Performance tuning
-
-```markdown
-@mongodb-expert design schema for user activity tracking
-```
-
-## DevOps Agents
-
-### docker-containerization-expert
-**Purpose**: Docker and containerization
-**Expertise**:
-- Dockerfile optimization
-- Docker Compose
-- Multi-stage builds
-- Security best practices
-- Volume management
-
-```markdown
-@docker-containerization-expert create optimized Dockerfile for Python app
-```
-
-### kubernetes-orchestrator
-**Purpose**: Kubernetes deployment and management
-**Expertise**:
-- Deployment configurations
-- Service mesh
-- Helm charts
-- Scaling strategies
-- Security policies
-
-```markdown
-@kubernetes-orchestrator create Helm chart for microservices deployment
-```
-
-### github-operations-specialist
-**Purpose**: GitHub Actions and CI/CD
-**Expertise**:
-- Workflow creation
-- Actions marketplace
-- Release automation
-- Security scanning
-- Matrix testing
-
-```markdown
-@github-operations-specialist create CI/CD pipeline with testing and deployment
-```
-
-## Cloud Architecture Agents
-
-### aws-cloud-architect
-**Purpose**: AWS infrastructure design
-**Expertise**:
-- EC2, Lambda, ECS/EKS
-- S3, RDS, DynamoDB
-- VPC, Security Groups
-- CloudFormation, CDK
-- Cost optimization
-
-```markdown
-@aws-cloud-architect design serverless architecture for image processing
-```
-
-### azure-cloud-architect
-**Purpose**: Azure infrastructure design
-**Expertise**:
-- Azure VMs, AKS, Functions
-- Storage accounts, SQL Database
-- Virtual Networks, NSGs
-- ARM templates, Bicep
-- Azure DevOps integration
-
-```markdown
-@azure-cloud-architect setup AKS cluster with monitoring
-```
-
-### gcp-cloud-architect
-**Purpose**: Google Cloud Platform design
-**Expertise**:
-- Compute Engine, GKE, Cloud Run
-- Cloud Storage, Cloud SQL
-- VPC, Firewall rules
-- Terraform, Deployment Manager
-- BigQuery, Pub/Sub
-
-```markdown
-@gcp-cloud-architect implement event-driven architecture with Pub/Sub
-```
-
-## Testing Agents
-
-### e2e-test-engineer
-**Purpose**: End-to-end testing
-**Expertise**:
-- Playwright, Cypress, Selenium
-- Test automation frameworks
-- CI/CD integration
-- Cross-browser testing
-- Performance testing
-
-```markdown
-@e2e-test-engineer create Playwright tests for checkout flow
-```
-
-### playwright-test-engineer
-**Purpose**: Playwright-specific testing
-**Expertise**:
-- Playwright API
-- Page object model
-- Visual testing
-- API testing
-- Mobile testing
-
-```markdown
-@playwright-test-engineer implement visual regression tests
-```
-
-## Decision Matrices
-
-### Choosing a UI Framework Agent
-
-```mermaid
-graph TD
-    A[UI Development] --> B{Framework?}
-    B -->|React| C[@react-ui-expert]
-    B -->|Vue| D[@javascript-frontend-engineer]
-    B -->|Angular| D
-    B -->|Vanilla JS| D
-    C --> E{Styling?}
-    E -->|Tailwind| F[@tailwindcss-expert]
-    E -->|Material UI| G[@mui-react-expert]
-    E -->|Ant Design| H[@antd-react-expert]
-```
-
-### Choosing a Backend Agent
-
-```mermaid
-graph TD
-    A[Backend Development] --> B{Language?}
-    B -->|Python| C[@python-backend-expert]
-    B -->|Node.js| D[@nodejs-backend-engineer]
-    B -->|Go| E[@code-analyzer + Custom]
-    C --> F{Framework?}
-    F -->|FastAPI| G[Use @python-backend-expert]
-    F -->|Django| G
-    F -->|Flask| G
-    D --> H{Framework?}
-    H -->|Express| I[Use @nodejs-backend-engineer]
-    H -->|NestJS| I
+Planning/designing?     → Use "expert" or "architect" agents (plugins)
+Building/coding?        → Use "engineer" agents (plugins)
+Reviewing/analyzing?    → Use core agents
+Testing?                → Use @test-runner (core)
 ```
 
 ## Agent Combinations
@@ -318,142 +83,75 @@ graph TD
 ### Full Stack Development
 
 ```markdown
-# Frontend + Backend + Database
-@react-ui-expert create user dashboard
-@python-backend-expert create API endpoints
-@postgresql-expert design database schema
+@code-analyzer review code quality          # Core
+@react-ui-expert create user dashboard      # plugin-frameworks
+@python-backend-expert create API endpoints # plugin-languages
+@postgresql-expert design database schema   # plugin-databases
 ```
 
 ### DevOps Pipeline
 
 ```markdown
-# Containerization + CI/CD + Cloud
-@docker-containerization-expert dockerize application
-@github-operations-specialist setup GitHub Actions
-@kubernetes-orchestrator deploy to K8s
+@test-runner execute all tests                          # Core
+@docker-containerization-expert dockerize application   # plugin-devops
+@github-operations-specialist setup GitHub Actions      # plugin-devops
+@kubernetes-orchestrator deploy to K8s                  # plugin-devops
 ```
 
 ### Testing Suite
 
 ```markdown
-# Unit + Integration + E2E
-@test-runner create unit tests
-@code-analyzer verify test coverage
-@e2e-test-engineer create end-to-end tests
+@test-runner create unit tests             # Core
+@code-analyzer verify test coverage        # Core
+@e2e-test-engineer create end-to-end tests # plugin-frameworks
 ```
 
-## Custom Agent Creation
+## Checking Available Agents
 
-When existing agents don't meet your needs:
+Your available agents depend on your installation scenario:
 
-```markdown
-@agent-manager create a custom agent for [specific technology/task]
+| Scenario | Core Agents | Plugin Agents |
+|----------|-------------|---------------|
+| lite | 7 | 0 |
+| github | 7 | 6 (languages) |
+| azure | 7 | 6 (languages) |
+| docker | 7 | ~22 |
+| full | 7 | ~45 |
+| performance | 7 | ~50 |
 
-# Example:
-@agent-manager create a GraphQL specialist agent with:
-- Apollo Server expertise
-- Schema design patterns
-- Resolver optimization
-- Subscription handling
+To see which agents are available, check your `agent-registry.xml`:
+
+```bash
+cat .claude/agents/agent-registry.xml
 ```
 
 ## Best Practices
 
-### 1. Start Specific
+### 1. Start with Core Agents
+Always try core agents first. They handle most common tasks without needing plugins.
+
+### 2. Be Specific
 Choose the most specific agent for your task:
-- ❌ `@code-analyzer` for React component
-- ✅ `@react-ui-expert` for React component
+- Use `@react-ui-expert` for React work, not `@code-analyzer`
+- Use `@postgresql-expert` for database queries, not a generic agent
 
-### 2. Combine Agents
-Use multiple agents for complex tasks:
-```markdown
-@code-analyzer review for issues
-@test-runner verify with tests
-@docker-containerization-expert prepare for deployment
-```
-
-### 3. Context Matters
-Provide context to agents:
+### 3. Provide Context
 ```markdown
 # Good
-@postgresql-expert optimize query for table with 10M rows
+@postgresql-expert optimize query for table with 10M rows, joining users and orders
 
-# Better
-@postgresql-expert optimize this e-commerce order query:
-- Orders table: 10M rows
-- Needs to join with users and products
-- Used for real-time dashboard
+# Better than
+@postgresql-expert optimize this query
 ```
 
-### 4. Iterative Refinement
-Work iteratively with agents:
-```markdown
-1. @python-backend-expert create initial API
-2. @code-analyzer review for improvements
-3. @test-runner add test coverage
-4. @docker-containerization-expert containerize
+### 4. Check Plugin Availability
+If an agent does not respond, verify the plugin is installed:
+```bash
+cat .claude/config.json | grep plugins
 ```
-
-## Performance Considerations
-
-### Agent Efficiency Ranking
-
-| Agent | Context Usage | Speed | Best For |
-|-------|---------------|-------|----------|
-| `@file-analyzer` | Low | Fast | Large files |
-| `@code-analyzer` | Medium | Medium | Code review |
-| `@react-ui-expert` | Medium | Fast | React development |
-| `@kubernetes-orchestrator` | High | Slow | Complex deployments |
-| `@aws-cloud-architect` | High | Slow | Infrastructure design |
-
-### Parallel vs Sequential
-
-**Parallel Execution** (when enabled):
-```markdown
-# These run simultaneously
-@code-analyzer review backend/
-@test-runner execute tests
-@docker-containerization-expert build images
-```
-
-**Sequential Execution**:
-```markdown
-# These run one after another
-@code-analyzer review and fix issues
-THEN @test-runner verify fixes
-THEN @docker-containerization-expert deploy
-```
-
-## Troubleshooting
-
-### Agent Not Responding
-
-```markdown
-# Check if agent exists
-ls .claude/agents/ | grep agent-name
-
-# Try core agent instead
-@code-analyzer [fallback for specialized agent]
-```
-
-### Wrong Agent Selected
-
-```markdown
-# Be more specific
-@python-backend-expert for FastAPI development
-NOT @code-analyzer for FastAPI development
-```
-
-### Agent Limitations
-
-Some agents have specific limitations:
-- Cloud agents need credentials configured
-- Test agents need test framework installed
-- DevOps agents need tools (Docker, kubectl)
 
 ## Related Pages
 
-- [Custom Agents](Custom-Agents)
-- [Testing Strategies](Testing-Strategies)
-- [Docker First Development](Docker-First-Development)
-- [PM Commands](PM-Commands)
+- [Agent Registry](./registry) - Complete agent listing
+- [Plugin Development](/developer-guide/plugin-development) - Create plugins
+- [Installation](/getting-started/installation) - Scenario selection

--- a/docs-site/docs/developer-guide/architecture.md
+++ b/docs-site/docs/developer-guide/architecture.md
@@ -1,17 +1,17 @@
 ---
 title: Architecture
-description: ClaudeAutoPM project architecture, directory structure, and system design
+description: ClaudeAutoPM v3.14.0 project architecture, plugin system, providers, and XML rules
 ---
 
 # Project Architecture
 
-ClaudeAutoPM follows a modular architecture designed for extensibility, maintainability, and clear separation of concerns. This document explains the project structure and key architectural decisions.
+ClaudeAutoPM v3.14.0 follows a plugin-based architecture with 13 npm packages, a provider router for issue tracking, and an XML rules system for token-efficient context loading.
 
 ## High-Level Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                         ClaudeAutoPM                            │
+│                     ClaudeAutoPM v3.14.0                        │
 ├─────────────────────────────────────────────────────────────────┤
 │  CLI Layer (bin/)                                               │
 │  ├── autopm.js (main entry point)                               │
@@ -27,341 +27,223 @@ ClaudeAutoPM follows a modular architecture designed for extensibility, maintain
 │  Plugin System (lib/plugins/)                                   │
 │  └── PluginManager (discovery, loading, installation)           │
 ├─────────────────────────────────────────────────────────────────┤
-│  Provider Layer (lib/providers/)                                │
-│  ├── GitHubProvider (issues, PRs, workflows)                    │
-│  └── AzureDevOpsProvider (work items, boards)                   │
+│  Provider Router (.claude/providers/router.js)                  │
+│  ├── LocalProvider   (providers/local/)    ← default            │
+│  ├── GitHubProvider  (lib/providers/)      ← plugin-pm-github   │
+│  └── AzureProvider   (lib/providers/)      ← plugin-pm-azure   │
 ├─────────────────────────────────────────────────────────────────┤
-│  Packages (packages/)                                           │
-│  ├── plugin-core       │ plugin-pm                              │
-│  ├── plugin-languages  │ plugin-frameworks                      │
-│  ├── plugin-devops     │ plugin-cloud                           │
-│  └── ... additional plugins                                     │
+│  13 Plugin Packages (packages/@claudeautopm/)                   │
+│  ├── plugin-core (7 agents)    │ plugin-pm (commands)           │
+│  ├── plugin-languages (6)      │ plugin-frameworks (7)          │
+│  ├── plugin-devops (8)         │ plugin-cloud (9)               │
+│  ├── plugin-databases (6)      │ plugin-testing (1)             │
+│  ├── plugin-ai (8)             │ plugin-ml (10)                 │
+│  ├── plugin-data (3)           │ plugin-pm-github               │
+│  └── plugin-pm-azure                                            │
 ├─────────────────────────────────────────────────────────────────┤
-│  Framework Resources (autopm/.claude/)                          │
-│  ├── agents/           │ commands/                              │
-│  ├── rules/            │ hooks/                                 │
-│  ├── scripts/          │ templates/                             │
-│  └── mcp/              │ examples/                              │
+│  Rules System (8 XML auto-loaded + 3 MD reference)              │
+│  ├── tdd.enforcement.xml       │ coverage-thresholds.xml        │
+│  ├── agent-mandatory.xml       │ context7.xml                   │
+│  ├── github-operations.xml     │ naming-conventions.xml         │
+│  ├── command-pipelines.xml     │ issue-structure.xml            │
+│  └── standard-patterns.md, datetime.md, git-strategy.md        │
+├─────────────────────────────────────────────────────────────────┤
+│  Dynamic Agent Registry (agent-registry.xml)                    │
+│  ├── 7 core agents (always present)                             │
+│  └── PLUGIN_AGENTS_START/END markers for injected agents        │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-## Directory Structure
+## Plugin System
 
-### `/lib` - Core Library
+### 13 Plugin Packages
 
-The core library contains all business logic and system functionality.
-
-```
-lib/
-├── cli/
-│   └── commands/           # CLI command implementations
-│       ├── agent.js        # Agent-related commands
-│       ├── config.js       # Configuration commands
-│       ├── context.js      # Context management
-│       ├── epic.js         # Epic management
-│       ├── issue.js        # Issue management
-│       ├── pm.js           # Project management
-│       ├── prd.js          # PRD operations
-│       └── task.js         # Task operations
-├── plugins/
-│   └── PluginManager.js    # Plugin lifecycle management
-├── providers/
-│   ├── GitHubProvider.js   # GitHub API integration
-│   └── AzureDevOpsProvider.js # Azure DevOps API
-├── services/
-│   ├── AgentService.js     # Agent operations
-│   ├── ContextService.js   # Context management
-│   ├── EpicService.js      # Epic operations
-│   ├── IssueService.js     # Issue operations
-│   ├── PRDService.js       # PRD operations
-│   ├── TaskService.js      # Task operations
-│   ├── UtilityService.js   # Helper utilities
-│   ├── WorkflowService.js  # Workflow orchestration
-│   └── interfaces.js       # Service interfaces
-├── config/
-│   └── ConfigManager.js    # Configuration management
-├── utils/
-│   ├── CircuitBreaker.js   # Fault tolerance
-│   ├── Encryption.js       # Security utilities
-│   ├── RateLimiter.js      # API rate limiting
-│   └── ServiceFactory.js   # Dependency injection
-├── ai-providers/
-│   ├── AbstractAIProvider.js  # Base AI provider
-│   ├── ClaudeProvider.js      # Claude API integration
-│   └── TemplateProvider.js    # Template-based responses
-└── *.js                    # Additional utilities
-```
-
-### `/packages` - Plugin Packages
-
-ClaudeAutoPM uses npm workspaces for modular plugin architecture.
+All plugins are published under the `@claudeautopm` scope on npm and managed via npm workspaces:
 
 ```
 packages/
-├── plugin-core/            # Core framework functionality
-│   ├── agents/             # Core agents
-│   │   └── core/           # agent-manager, code-analyzer, etc.
-│   ├── commands/           # Core commands
-│   ├── rules/              # Framework rules
-│   ├── hooks/              # Enforcement hooks
-│   ├── scripts/            # Utility scripts
-│   └── plugin.json         # Plugin manifest
-├── plugin-pm/              # Project management features
-│   ├── agents/
-│   ├── commands/
-│   └── plugin.json
-├── plugin-languages/       # Language-specific agents
-│   ├── agents/
-│   │   └── languages/      # nodejs, python, bash experts
-│   └── plugin.json
-├── plugin-frameworks/      # Framework specialists
-├── plugin-devops/          # DevOps and CI/CD
-├── plugin-cloud/           # Cloud platform agents
-├── plugin-databases/       # Database specialists
-├── plugin-testing/         # Testing specialists
-├── plugin-data/            # Data engineering
-├── plugin-ai/              # AI/ML integration
-└── plugin-ml/              # Machine learning
+├── plugin-core/         # 7 core agents, core commands, rules, hooks
+├── plugin-pm/           # PM commands (prd, epic, issue, workflow)
+├── plugin-pm-github/    # GitHub provider integration
+├── plugin-pm-azure/     # Azure DevOps provider integration
+├── plugin-languages/    # 6 language specialist agents
+├── plugin-frameworks/   # 7 framework specialist agents
+├── plugin-devops/       # 8 DevOps agents (Docker, K8s, CI/CD)
+├── plugin-cloud/        # 9 cloud architect agents (AWS, Azure, GCP)
+├── plugin-databases/    # 6 database specialist agents
+├── plugin-testing/      # 1 Playwright specialist agent
+├── plugin-ai/           # 8 AI/ML integration agents
+├── plugin-data/         # 3 data pipeline agents
+└── plugin-ml/           # 10 machine learning agents
 ```
 
-### `/autopm` - Framework Resources
+### Plugin Manifest (plugin.json)
 
-Resources copied to user projects during installation.
-
-```
-autopm/
-└── .claude/
-    ├── agents/              # Agent definitions
-    │   ├── core/            # Essential agents
-    │   ├── languages/       # Language experts
-    │   ├── frameworks/      # Framework specialists
-    │   ├── cloud/           # Cloud architects
-    │   ├── devops/          # DevOps specialists
-    │   ├── databases/       # Database experts
-    │   ├── data/            # Data engineering
-    │   ├── testing/         # Testing specialists
-    │   ├── decision-matrices/ # Decision tools
-    │   └── AGENT-REGISTRY.md  # Agent catalog
-    ├── commands/            # Command definitions
-    │   ├── config/          # Configuration commands
-    │   ├── context/         # Context commands
-    │   └── mcp/             # MCP commands
-    ├── rules/               # Development rules
-    │   ├── tdd.enforcement.md
-    │   ├── naming-conventions.md
-    │   └── ...
-    ├── hooks/               # Enforcement hooks
-    ├── scripts/             # Utility scripts
-    │   └── lib/             # Script libraries
-    ├── templates/           # File templates
-    │   ├── claude-templates/
-    │   ├── prds/
-    │   └── strategies-templates/
-    ├── mcp/                 # MCP server configs
-    ├── examples/            # Usage examples
-    ├── guides/              # User guides
-    ├── quick-ref/           # Quick reference docs
-    └── providers/           # Provider configs
-```
-
-### `/.claude` - Project Maintenance
-
-The project's own Claude configuration for self-maintenance.
-
-```
-.claude/
-├── agents/                  # Project-specific agents
-│   ├── core/                # Maintenance agents
-│   └── project-maintenance/ # Custom agents
-├── commands/                # Maintenance commands
-├── rules/                   # Development rules
-├── hooks/                   # Pre-commit hooks
-└── DEVELOPMENT-STANDARDS.md # Standards reference
-```
-
-## Key Architectural Components
-
-### Plugin Manager
-
-The `PluginManager` class handles the complete plugin lifecycle:
-
-```javascript
-// lib/plugins/PluginManager.js
-class PluginManager extends EventEmitter {
-  constructor(options = {}) {
-    this.plugins = new Map();    // Discovered plugins
-    this.agents = new Map();     // Registered agents
-    this.hooks = new Map();      // Plugin hooks
-  }
-
-  async initialize() {
-    await this.discoverPlugins();  // Find plugins in node_modules
-    await this.validatePlugins();  // Check compatibility
-  }
-
-  async loadPlugin(pluginName) {
-    // Load and register plugin agents
-  }
-
-  async installPlugin(pluginName) {
-    // Install agents, commands, rules, hooks, scripts
-  }
-}
-```
-
-### Service Layer
-
-Services encapsulate business logic with consistent interfaces:
-
-```javascript
-// lib/services/interfaces.js
-class IEpicService {
-  async list(options) { }
-  async show(id) { }
-  async create(data) { }
-  async update(id, data) { }
-  async sync(id) { }
-}
-```
-
-### Provider Pattern
-
-Providers abstract external service integrations:
-
-```javascript
-// lib/providers/GitHubProvider.js
-class GitHubProvider {
-  constructor(config) {
-    this.octokit = new Octokit({ auth: config.token });
-  }
-
-  async getIssue(owner, repo, number) { }
-  async createIssue(owner, repo, data) { }
-  async updateIssue(owner, repo, number, data) { }
-}
-```
-
-## Plugin Schema (v2.0)
-
-Plugins use a standardized JSON schema:
+Each plugin defines its contents in a `plugin.json` file using Schema v2.0:
 
 ```json
 {
   "name": "@claudeautopm/plugin-core",
   "version": "2.0.0",
   "displayName": "Core Framework",
-  "description": "Core framework functionality",
   "schemaVersion": "2.0",
   "metadata": {
     "category": "Core Framework",
-    "author": "ClaudeAutoPM Team",
-    "keywords": ["core", "framework", "agents"],
     "required": true
   },
   "agents": [
     {
       "name": "agent-manager",
       "file": "agents/core/agent-manager.md",
-      "category": "core",
-      "description": "Agent lifecycle management",
-      "version": "1.0.0",
-      "tags": ["core", "agents"]
+      "category": "core"
     }
   ],
   "commands": [...],
   "rules": [...],
   "hooks": [...],
   "scripts": [...],
-  "dependencies": {
-    "required": [],
-    "optional": []
-  },
-  "features": {
-    "tdd_enforcement": { "enabled": true }
-  },
+  "dependencies": { "required": [], "optional": [] },
   "compatibleWith": ">=3.0.0"
 }
 ```
 
-## Agent Architecture
+### Plugin Manager
 
-Agents follow a standardized structure with frontmatter and markdown:
+```javascript
+class PluginManager extends EventEmitter {
+  async initialize() {
+    await this.discoverPlugins();   // Scan node_modules/@claudeautopm/
+    await this.validatePlugins();   // Check version compatibility
+  }
 
-```markdown
----
-name: code-analyzer
-description: Code analysis and bug detection
-tools: Glob, Grep, LS, Read, Task, Agent
-model: inherit
-color: blue
----
-
-# Code Analyzer
-
-You are a senior code analyst...
-
-## TDD Methodology (MANDATORY)
-...
-
-## Documentation Queries
-- `mcp://context7/analysis/patterns`
-
-## Core Expertise
-...
-
-## Self-Verification Protocol
-...
+  async installPlugin(pluginName) {
+    // Install agents, commands, rules, hooks, scripts to .claude/
+  }
+}
 ```
 
-## Command Architecture
+## Provider System
 
-Commands use a template structure:
+ClaudeAutoPM supports three issue tracking providers, selected by installation scenario.
+
+### Provider Router
+
+The provider router (`providers/router.js`) auto-selects the active provider based on `.claude/config.json`:
+
+```
+config.json → PROVIDER: "local" | "github" | "azure"
+    │
+    ▼
+router.js → delegates to appropriate provider
+    │
+    ├── local/   → File-based issue tracking (no external service)
+    ├── github/  → GitHub Issues via gh CLI
+    └── azure/   → Azure DevOps work items via az CLI
+```
+
+### Local Provider (Default)
+
+The local provider stores issues as files in `.claude/providers/local/`:
+
+- `issue-create.js` - Create local issues
+- `issue-list.js` - List issues from local store
+- `issue-show.js` - Display issue details
+- `issue-start.js` - Mark issue as in-progress
+- `issue-close.js` - Close completed issues
+
+No external service or authentication required. This is the default for the `lite` scenario.
+
+### Provider Selection by Scenario
+
+| Scenario | Provider |
+|----------|----------|
+| lite | local |
+| github | github |
+| azure | azure |
+| docker | github |
+| full | github |
+| full-azure | github + azure |
+| performance | github |
+
+## XML Rules System
+
+ClaudeAutoPM uses 8 XML rules that are auto-loaded into the system prompt via `@include` directives in CLAUDE.md:
 
 ```markdown
----
-allowed-tools: Bash, Read, Write, LS
----
-
-# Command Name
-
-## Usage
-/namespace:command [arguments]
-
-## Quick Check
-[Prerequisites validation]
-
-## Instructions
-[Step-by-step execution]
-
-## Output
-[Expected output format]
+# CLAUDE.md
+@include .claude/rules/tdd.enforcement.xml
+@include .claude/rules/coverage-thresholds.xml
+@include .claude/rules/agent-mandatory.xml
+@include .claude/rules/context7.xml
+@include .claude/rules/github-operations.xml
+@include .claude/rules/naming-conventions.xml
+@include .claude/rules/command-pipelines.xml
+@include .claude/rules/issue-structure.xml
 ```
+
+XML format was chosen over markdown for rules because:
+- Stronger enforcement by the model (XML tags are treated as structured instructions)
+- More compact representation (fewer tokens)
+- Clear nesting and hierarchy
+
+Three additional MD rules are available as reference but not auto-loaded:
+- `standard-patterns.md` - Output formats, error messages
+- `datetime.md` - ISO 8601 timestamps
+- `git-strategy.md` - Branch-based workflow
+
+## Dynamic Agent Registry
+
+The `agent-registry.xml` file is the single source of truth for available agents:
+
+```xml
+<agent-registry version="2.0.0" core-agents="7">
+  <agents category="core">
+    <agent name="agent-manager" path="agents/core/agent-manager.md">...</agent>
+    <agent name="file-analyzer" path="agents/core/file-analyzer.md">...</agent>
+    <agent name="code-analyzer" path="agents/core/code-analyzer.md">...</agent>
+    <agent name="test-runner" path="agents/core/test-runner.md">...</agent>
+    <agent name="parallel-worker" path="agents/core/parallel-worker.md">...</agent>
+    <agent name="mcp-manager" path="agents/core/mcp-manager.md">...</agent>
+    <agent name="context-optimizer" path="agents/core/context-optimizer.md">...</agent>
+  </agents>
+
+  <!-- PLUGIN_AGENTS_START -->
+  <!-- Injected by install.js based on installed plugins -->
+  <!-- PLUGIN_AGENTS_END -->
+</agent-registry>
+```
+
+During installation, `install.js` reads each plugin's `plugin.json`, extracts agent definitions, and injects them between the markers. This means a lite install has zero plugin agent entries (saving tokens), while a full install has 45+ entries.
 
 ## Data Flow
 
 ### Installation Flow
 
 ```
-User runs: autopm install
+User runs: autopm install --scenario=github
     │
     ▼
-bin/autopm.js (CLI entry)
+install.js → selectScenario() → generateConfig()
     │
     ▼
 PluginManager.initialize()
     │
-    ├─► discoverPlugins() ─► Scan node_modules/@claudeautopm/
-    │
-    ├─► validatePlugins() ─► Check version compatibility
+    ├── discoverPlugins() → Scan packages/@claudeautopm/
+    ├── validatePlugins() → Check compatibility
     │
     ▼
-PluginManager.installPlugin()
+For each plugin in scenario:
+    ├── installAgents()   → Copy to .claude/agents/
+    ├── installCommands() → Copy to .claude/commands/
+    ├── installRules()    → Copy to .claude/rules/
+    ├── installHooks()    → Copy to .claude/hooks/
+    └── installScripts()  → Copy to scripts/
     │
-    ├─► installAgents()   ─► Copy to .claude/agents/
-    ├─► installCommands() ─► Copy to .claude/commands/
-    ├─► installRules()    ─► Copy to .claude/rules/
-    ├─► installHooks()    ─► Copy to .claude/hooks/
-    └─► installScripts()  ─► Copy to scripts/
+    ▼
+Generate agent-registry.xml with plugin agents injected
+    │
+    ▼
+Generate CLAUDE.md with @include directives
 ```
 
 ### Command Execution Flow
@@ -376,73 +258,57 @@ Claude reads: .claude/commands/pm/epic-list.md
 Validates prerequisites (Quick Check)
     │
     ▼
+Provider router selects: local | github | azure
+    │
+    ▼
 Executes instructions using allowed-tools
     │
     ▼
 Formats output per command specification
 ```
 
-### Agent Delegation Flow
+## Token Optimization
 
-```
-User requests: "Analyze this code for bugs"
-    │
-    ▼
-Claude identifies: Use @code-analyzer agent
-    │
-    ▼
-Invokes via Task tool with agent specification
-    │
-    ▼
-Agent executes with permitted tools
-    │
-    ▼
-Returns summarized results (<20% of context)
-```
+The architecture is designed to minimize context window usage:
+
+1. **Plugin-based agents** - Only installed agents are in the registry
+2. **XML rules** - More compact than markdown equivalents
+3. **Dynamic registry** - `PLUGIN_AGENTS_START/END` markers avoid loading unused agents
+4. **Core-only default** - Lite scenario loads only 7 agent definitions
+
+Result: Lite installs use 73% fewer agent tokens than full installs.
 
 ## Design Decisions
 
-### Why npm Workspaces?
+### Why Plugin Architecture?
+- Selective installation reduces context footprint
+- Independent versioning per plugin
+- CI-only npm publish ensures quality
+- PR-only workflow for all changes
 
-- Modular plugin architecture
-- Independent versioning
-- Selective installation
-- Clear dependency boundaries
+### Why XML for Rules?
+- Stronger model adherence to structured XML
+- More token-efficient than markdown
+- Clear hierarchy for nested rules
 
-### Why Markdown for Agents/Commands?
+### Why Local Provider Default?
+- Zero external dependencies for new users
+- Works offline
+- Easy upgrade path to GitHub/Azure later
 
-- Human-readable specifications
-- Easy to modify and extend
-- Version control friendly
-- No compilation required
-
-### Why Event Emitters in PluginManager?
-
-- Decoupled logging and monitoring
-- Easy to add telemetry
-- Non-blocking operations
-- Flexible event handling
-
-### Why Service Layer Pattern?
-
-- Testable business logic
-- Provider abstraction
-- Consistent interfaces
-- Dependency injection support
+### Why Dynamic Agent Registry?
+- Single source of truth for agent availability
+- Install-time generation avoids runtime overhead
+- Marker-based injection is simple and reliable
 
 ## Security Considerations
 
-1. **Token Management**: API tokens stored in environment variables
+1. **Token Management**: API tokens in environment variables only
 2. **Input Validation**: All user inputs validated before processing
 3. **Rate Limiting**: Built-in rate limiter for API calls
 4. **Circuit Breaker**: Fault tolerance for external services
-
-## Performance Considerations
-
-1. **Context Efficiency**: Agents return <20% of processed data
-2. **Lazy Loading**: Plugins loaded on demand
-3. **Caching**: Provider responses cached where appropriate
-4. **Parallel Execution**: Agents can work in parallel streams
+5. **PR-only workflow**: All changes require pull request review
+6. **CI-only publish**: npm packages published only through GitHub Actions
 
 ## Next Steps
 

--- a/docs-site/docs/developer-guide/architecture.md
+++ b/docs-site/docs/developer-guide/architecture.md
@@ -32,10 +32,10 @@ ClaudeAutoPM v3.14.0 follows a plugin-based architecture with 13 npm packages, a
 │  ├── GitHubProvider  (lib/providers/)      ← plugin-pm-github   │
 │  └── AzureProvider   (lib/providers/)      ← plugin-pm-azure   │
 ├─────────────────────────────────────────────────────────────────┤
-│  13 Plugin Packages (packages/@claudeautopm/)                   │
+│  13 Plugin Packages (packages/plugin-*)                          │
 │  ├── plugin-core (7 agents)    │ plugin-pm (commands)           │
-│  ├── plugin-languages (6)      │ plugin-frameworks (7)          │
-│  ├── plugin-devops (8)         │ plugin-cloud (9)               │
+│  ├── plugin-languages (5)      │ plugin-frameworks (4)          │
+│  ├── plugin-devops (7)         │ plugin-cloud (8)               │
 │  ├── plugin-databases (6)      │ plugin-testing (1)             │
 │  ├── plugin-ai (8)             │ plugin-ml (10)                 │
 │  ├── plugin-data (3)           │ plugin-pm-github               │
@@ -46,7 +46,8 @@ ClaudeAutoPM v3.14.0 follows a plugin-based architecture with 13 npm packages, a
 │  ├── agent-mandatory.xml       │ context7.xml                   │
 │  ├── github-operations.xml     │ naming-conventions.xml         │
 │  ├── command-pipelines.xml     │ issue-structure.xml            │
-│  └── standard-patterns.md, datetime.md, git-strategy.md        │
+│  └── standard-patterns.md, git-strategy.md,                    │
+│       frontmatter-operations.md                                 │
 ├─────────────────────────────────────────────────────────────────┤
 │  Dynamic Agent Registry (agent-registry.xml)                    │
 │  ├── 7 core agents (always present)                             │
@@ -66,12 +67,12 @@ packages/
 ├── plugin-pm/           # PM commands (prd, epic, issue, workflow)
 ├── plugin-pm-github/    # GitHub provider integration
 ├── plugin-pm-azure/     # Azure DevOps provider integration
-├── plugin-languages/    # 6 language specialist agents
-├── plugin-frameworks/   # 7 framework specialist agents
-├── plugin-devops/       # 8 DevOps agents (Docker, K8s, CI/CD)
-├── plugin-cloud/        # 9 cloud architect agents (AWS, Azure, GCP)
+├── plugin-languages/    # 5 language specialist agents (see plugin.json)
+├── plugin-frameworks/   # 4 framework specialist agents (see plugin.json)
+├── plugin-devops/       # 7 DevOps agents: Docker, CI/CD, observability (see plugin.json)
+├── plugin-cloud/        # 8 cloud/infra agents: AWS, Azure, GCP, K8s, Terraform (see plugin.json)
 ├── plugin-databases/    # 6 database specialist agents
-├── plugin-testing/      # 1 Playwright specialist agent
+├── plugin-testing/      # 1 frontend testing engineer agent (see plugin.json)
 ├── plugin-ai/           # 8 AI/ML integration agents
 ├── plugin-data/         # 3 data pipeline agents
 └── plugin-ml/           # 10 machine learning agents
@@ -112,7 +113,7 @@ Each plugin defines its contents in a `plugin.json` file using Schema v2.0:
 ```javascript
 class PluginManager extends EventEmitter {
   async initialize() {
-    await this.discoverPlugins();   // Scan node_modules/@claudeautopm/
+    await this.discoverPlugins();   // Monorepo: scan packages/; installed projects: scan node_modules/@claudeautopm/
     await this.validatePlugins();   // Check version compatibility
   }
 
@@ -143,7 +144,7 @@ router.js → delegates to appropriate provider
 
 ### Local Provider (Default)
 
-The local provider stores issues as files in `.claude/providers/local/`:
+The local provider stores issue data in `.claude/issues/` and provider scripts in `.claude/providers/local/`:
 
 - `issue-create.js` - Create local issues
 - `issue-list.js` - List issues from local store
@@ -188,8 +189,8 @@ XML format was chosen over markdown for rules because:
 
 Three additional MD rules are available as reference but not auto-loaded:
 - `standard-patterns.md` - Output formats, error messages
-- `datetime.md` - ISO 8601 timestamps
 - `git-strategy.md` - Branch-based workflow
+- `frontmatter-operations.md` - YAML frontmatter read/write
 
 ## Dynamic Agent Registry
 
@@ -228,7 +229,7 @@ install.js → selectScenario() → generateConfig()
     ▼
 PluginManager.initialize()
     │
-    ├── discoverPlugins() → Scan packages/@claudeautopm/
+    ├── discoverPlugins() → Scan packages/ (monorepo) or node_modules/@claudeautopm/
     ├── validatePlugins() → Check compatibility
     │
     ▼

--- a/docs-site/docs/developer-guide/plugin-development.md
+++ b/docs-site/docs/developer-guide/plugin-development.md
@@ -5,27 +5,24 @@ description: Guide to creating ClaudeAutoPM plugins with plugin.json, agents, co
 
 # Plugin Development
 
-Plugins are the primary extension mechanism for ClaudeAutoPM. They package agents, commands, rules, hooks, and scripts into installable modules that extend the framework's capabilities.
+Plugins are the primary extension mechanism for ClaudeAutoPM. They package agents, commands, rules, hooks, and scripts into installable npm modules under the `@claudeautopm` scope. There are currently 13 plugins in the monorepo.
 
 ## Plugin Structure
-
-A complete plugin follows this directory structure:
 
 ```
 packages/plugin-example/
 ├── package.json          # npm package configuration
-├── plugin.json           # Plugin manifest (required)
+├── plugin.json           # Plugin manifest (required, Schema v2.0)
 ├── README.md             # Plugin documentation
-├── agents/               # Agent definitions
+├── agents/               # Agent definitions (.md files)
 │   └── category/
 │       └── agent-name.md
 ├── commands/             # Command definitions
 │   └── command-name.md
-├── rules/                # Rule definitions
-│   └── rule-name.md
-├── hooks/                # Hook implementations
-│   ├── hook-name.js
-│   └── hook-name.sh
+├── rules/                # Rule definitions (.xml or .md)
+│   └── rule-name.xml
+├── hooks/                # Hook implementations (.js, .sh)
+│   └── hook-name.js
 └── scripts/              # Utility scripts
     └── lib/
         └── utility.sh
@@ -33,7 +30,7 @@ packages/plugin-example/
 
 ## The plugin.json Manifest
 
-The `plugin.json` file defines your plugin's contents and metadata. It uses Schema v2.0:
+The `plugin.json` file defines your plugin's contents and metadata using Schema v2.0:
 
 ```json
 {
@@ -47,7 +44,7 @@ The `plugin.json` file defines your plugin's contents and metadata. It uses Sche
     "author": "Your Name",
     "license": "MIT",
     "homepage": "https://github.com/your-repo",
-    "keywords": ["example", "demo", "tutorial"],
+    "keywords": ["example", "demo"],
     "size": "5 KB (gzipped)",
     "required": false
   },
@@ -69,9 +66,19 @@ The `plugin.json` file defines your plugin's contents and metadata. It uses Sche
 }
 ```
 
+### Key Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | npm package name under `@claudeautopm` scope |
+| `schemaVersion` | Yes | Must be `"2.0"` |
+| `metadata.required` | No | If `true`, plugin is always installed (only `plugin-core`) |
+| `agents` | No | Array of agent definitions |
+| `compatibleWith` | Yes | Semver range for ClaudeAutoPM compatibility |
+
 ## Defining Agents
 
-Agents are AI specialists with defined expertise. Add them to the `agents` array:
+Agents are AI specialists injected into `agent-registry.xml` during installation. Add them to the `agents` array:
 
 ```json
 {
@@ -82,18 +89,18 @@ Agents are AI specialists with defined expertise. Add them to the `agents` array
       "category": "example",
       "description": "Expert in example domain",
       "version": "1.0.0",
-      "tags": ["example", "demo", "tutorial"]
+      "tags": ["example", "demo"]
     }
   ]
 }
 ```
 
-Create the corresponding agent file:
+The agent markdown file:
 
 ```markdown
 ---
 name: example-expert
-description: Expert in example domain. Use for demo and tutorial tasks.
+description: Expert in example domain
 tools: Glob, Grep, LS, Read, Edit, Write, Bash, Task, Agent
 model: inherit
 color: green
@@ -112,19 +119,12 @@ You are a senior specialist in example domain.
 
 ## Documentation Queries
 
-**Documentation Queries:**
 - `mcp://context7/example/patterns` - Example patterns
-- `mcp://context7/example/best-practices` - Best practices
 
 ## Core Expertise
 
-### Domain Mastery
-- **Skill 1**: Description of capability
-- **Skill 2**: Description of capability
-
-## Development Patterns
-
-[Include specific patterns and code examples]
+- **Skill 1**: Description
+- **Skill 2**: Description
 
 ## Self-Verification Protocol
 
@@ -134,9 +134,19 @@ Before delivering any solution, verify:
 - [ ] Best practices followed
 ```
 
+### How Agents Are Installed
+
+During `autopm install`, the installer:
+
+1. Reads each plugin's `plugin.json`
+2. Copies agent `.md` files to `.claude/agents/{category}/`
+3. Injects agent entries into `agent-registry.xml` between `PLUGIN_AGENTS_START` and `PLUGIN_AGENTS_END` markers
+
+This means agent availability is determined at install time, not runtime.
+
 ## Defining Commands
 
-Commands are user-invokable actions. Add them to the `commands` array:
+Commands are user-invokable actions. Add to the `commands` array:
 
 ```json
 {
@@ -146,13 +156,13 @@ Commands are user-invokable actions. Add them to the `commands` array:
       "file": "commands/example-action.md",
       "description": "Perform an example action",
       "category": "example",
-      "tags": ["example", "demo"]
+      "tags": ["example"]
     }
   ]
 }
 ```
 
-Create the command file:
+Command markdown file:
 
 ```markdown
 ---
@@ -161,134 +171,50 @@ allowed-tools: Bash, Read, Write, LS
 
 # Example Action
 
-Perform an example action with specified parameters.
-
 ## Usage
-
-```
 /example:action [name] [--flag]
-```
 
 ## Quick Check
-
-```bash
-# Verify prerequisites
-test -d .claude || echo "Missing .claude directory. Run: autopm init"
-```
+test -d .claude || echo "Missing .claude directory. Run: autopm install"
 
 ## Instructions
-
-### 1. Validate Input
-
-Check that required arguments are provided:
-- `name`: Required - the target name
-- `--flag`: Optional - enable extra behavior
-
-### 2. Execute Action
-
-[Step-by-step instructions for Claude]
-
-### 3. Error Handling
-
-**Common Issues:**
-- **Missing file**: "File not found" - Create it first
-- **Permission denied**: Check write permissions
+1. Validate input
+2. Execute action
+3. Handle errors
 
 ## Output
-
-```
 Example action complete
   - Result 1: [detail]
-  - Result 2: [detail]
 Next: /example:next-action
-```
-
-## Examples
-
-```bash
-# Basic usage
-/example:action my-name
-
-# With flag
-/example:action my-name --flag
-```
 
 $ARGUMENTS
 ```
 
 ## Defining Rules
 
-Rules enforce mandatory behaviors. Add them to the `rules` array:
+Rules enforce mandatory behaviors. Use XML format for auto-loaded rules (stronger model enforcement) or markdown for reference rules:
 
 ```json
 {
   "rules": [
     {
       "name": "example-rule",
-      "file": "rules/example-rule.md",
+      "file": "rules/example-rule.xml",
       "priority": "medium",
       "description": "Enforce example behavior",
-      "tags": ["example", "enforcement"]
+      "tags": ["enforcement"]
     }
   ]
 }
 ```
 
-Priority levels:
-- `critical` - Must always be followed
-- `high` - Important for quality
-- `medium` - Standard practice
-- `low` - Nice to have
+Priority levels: `critical`, `high`, `medium`, `low`.
 
-Create the rule file:
-
-```markdown
-# Example Rule
-
-> **CRITICAL**: One-line summary of rule importance
-
-## MANDATORY BEHAVIORS
-
-1. Always do this
-2. Always check that
-3. Always verify this
-
-## PROHIBITED ACTIONS
-
-- Never do this
-- Avoid that pattern
-- Do not use this approach
-
-## PATTERNS
-
-### Good Pattern
-
-```javascript
-// Correct approach
-const result = doItRight();
-```
-
-### Bad Pattern
-
-```javascript
-// Wrong approach - DO NOT USE
-const result = doItWrong();
-```
-
-## ENFORCEMENT
-
-- How violations are detected
-- How to fix violations
-- Prevention strategies
-
-## EXAMPLES
-
-[Practical examples of rule application]
-```
+Rules are copied to `.claude/rules/` during installation. To auto-load a rule, add an `@include` directive to CLAUDE.md.
 
 ## Defining Hooks
 
-Hooks intercept operations for enforcement. Add them to the `hooks` array:
+Hooks intercept operations for enforcement:
 
 ```json
 {
@@ -298,210 +224,15 @@ Hooks intercept operations for enforcement. Add them to the `hooks` array:
       "file": "hooks/pre-example-check.js",
       "type": "pre-command",
       "description": "Check conditions before example commands",
-      "blocking": true,
-      "tags": ["example", "validation"]
-    },
-    {
-      "name": "example-enforcer",
-      "files": [
-        "hooks/example-enforcer.js",
-        "hooks/example-enforcer.sh"
-      ],
-      "type": "pre-tool",
-      "description": "Enforce example patterns",
-      "blocking": true,
-      "dual": true,
-      "tags": ["example", "enforcement"]
+      "blocking": true
     }
   ]
 }
 ```
 
-Hook types:
-- `pre-command` - Runs before command execution
-- `pre-agent` - Runs before agent invocation
-- `pre-tool` - Runs before tool usage
-- `wrapper` - Wraps operation execution
-- `testing` - Used for hook validation
-- `documentation` - Non-blocking documentation
+Hook types: `pre-command`, `pre-agent`, `pre-tool`, `wrapper`, `testing`, `documentation`.
 
-Create a JavaScript hook:
-
-```javascript
-#!/usr/bin/env node
-
-/**
- * Hook: pre-example-check.js
- * Purpose: Validate conditions before example commands
- */
-
-class ExampleHookEnforcer {
-  constructor() {
-    this.toolName = process.argv[2] || '';
-    this.toolParams = process.argv[3] || '';
-
-    try {
-      this.parsedParams = JSON.parse(this.toolParams);
-    } catch {
-      this.parsedParams = {};
-    }
-  }
-
-  blockWithMessage(reason, suggestion, example) {
-    console.log(`BLOCKED: ${reason}`);
-    console.log(`INSTEAD: ${suggestion}`);
-    console.log('');
-    console.log('Example:');
-    console.log(`  ${example}`);
-    process.exit(1);
-  }
-
-  check() {
-    // Implement validation logic
-    if (this.toolName === 'Bash') {
-      const command = this.parsedParams.command || '';
-
-      // Example: Block certain patterns
-      if (command.includes('dangerous-command')) {
-        this.blockWithMessage(
-          'Dangerous command detected',
-          'Use safe alternative',
-          'safe-command --with-flags'
-        );
-      }
-    }
-  }
-
-  run() {
-    this.check();
-    process.exit(0); // Allow if no blocks
-  }
-}
-
-const enforcer = new ExampleHookEnforcer();
-enforcer.run();
-```
-
-Create a shell hook (for dual-language support):
-
-```bash
-#!/usr/bin/env bash
-
-# Hook: example-enforcer.sh
-# Purpose: Enforce example patterns (shell version)
-
-set -euo pipefail
-
-TOOL_NAME="${1:-}"
-TOOL_PARAMS="${2:-}"
-
-# Parse parameters
-command=""
-if [[ -n "$TOOL_PARAMS" ]]; then
-  command=$(echo "$TOOL_PARAMS" | jq -r '.command // ""' 2>/dev/null || echo "")
-fi
-
-# Check for violations
-if [[ "$command" == *"dangerous-command"* ]]; then
-  echo "BLOCKED: Dangerous command detected"
-  echo "INSTEAD: Use safe alternative"
-  exit 1
-fi
-
-exit 0
-```
-
-## Defining Scripts
-
-Scripts provide utility functions. Add them to the `scripts` array:
-
-```json
-{
-  "scripts": [
-    {
-      "name": "lib/example-utils",
-      "file": "scripts/lib/example-utils.sh",
-      "description": "Example utility functions",
-      "type": "library",
-      "exported": true,
-      "tags": ["utilities", "example"]
-    },
-    {
-      "name": "example-tools",
-      "subdirectory": "scripts/example/",
-      "files": [
-        "tool1.sh",
-        "tool2.sh",
-        "tool3.sh"
-      ],
-      "description": "Example tool collection",
-      "type": "utility",
-      "tags": ["tools", "example"]
-    }
-  ]
-}
-```
-
-Script types:
-- `library` - Sourced by other scripts
-- `utility` - Standalone executable
-
-Create a library script:
-
-```bash
-#!/usr/bin/env bash
-
-# Script: example-utils.sh
-# Description: Example utility functions
-# Version: 1.0.0
-
-# Source guard
-[[ -n "${EXAMPLE_UTILS_SOURCED:-}" ]] && return
-readonly EXAMPLE_UTILS_SOURCED=1
-
-# Configuration
-readonly EXAMPLE_CONFIG_DIR="${EXAMPLE_CONFIG_DIR:-$HOME/.example}"
-
-# Functions
-
-# Log message with timestamp
-example_log() {
-  local level="${1:-INFO}"
-  shift
-  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [$level] $*"
-}
-
-# Check if required tool exists
-example_require() {
-  local tool="$1"
-  if ! command -v "$tool" &> /dev/null; then
-    example_log "ERROR" "Required tool not found: $tool"
-    return 1
-  fi
-  return 0
-}
-
-# Safe file read with fallback
-example_read_file() {
-  local file="$1"
-  local default="${2:-}"
-
-  if [[ -f "$file" ]]; then
-    cat "$file"
-  else
-    echo "$default"
-  fi
-}
-
-# Export functions
-export -f example_log
-export -f example_require
-export -f example_read_file
-```
-
-## Package.json Configuration
-
-Your plugin needs a proper `package.json`:
+## package.json Configuration
 
 ```json
 {
@@ -510,17 +241,7 @@ Your plugin needs a proper `package.json`:
   "description": "Example plugin for ClaudeAutoPM",
   "main": "index.js",
   "type": "module",
-  "scripts": {
-    "test": "jest",
-    "validate": "node -e \"import('./plugin.json', { with: { type: 'json' } })\""
-  },
-  "keywords": [
-    "claude",
-    "autopm",
-    "plugin",
-    "example"
-  ],
-  "author": "Your Name",
+  "keywords": ["claude", "autopm", "plugin"],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -545,72 +266,34 @@ Your plugin needs a proper `package.json`:
 }
 ```
 
-## Plugin Dependencies
+## Integration with Install Scenarios
 
-Specify plugin dependencies:
+To include your plugin in an installation scenario, add it to the scenario config in `install/install.js`:
 
-```json
-{
-  "dependencies": {
-    "required": [
-      "@claudeautopm/plugin-core"
-    ],
-    "optional": [
-      "@claudeautopm/plugin-testing"
-    ]
-  }
+```javascript
+// In generateConfig()
+docker: {
+  plugins: ['plugin-core', 'plugin-languages', ..., 'plugin-example']
 }
 ```
 
-## Feature Flags
+## Publishing to npm
 
-Define toggleable features:
+Plugins are published under the `@claudeautopm` scope via CI-only workflow (GitHub Actions). Direct `npm publish` is not used.
 
-```json
-{
-  "features": {
-    "example_feature": {
-      "enabled": true,
-      "description": "Enable example feature"
-    },
-    "advanced_mode": {
-      "enabled": false,
-      "description": "Enable advanced mode"
-    }
-  }
-}
+### PR-Only Workflow
+
+1. Create a branch with your plugin changes
+2. Open a pull request to `main`
+3. CI runs tests and validates `plugin.json`
+4. After merge, the GitHub Actions workflow publishes to npm
+
+### Manual Publishing (Development Only)
+
+```bash
+cd packages/plugin-example
+npm publish --access public
 ```
-
-## Installation Hooks
-
-Add post-install actions:
-
-```json
-{
-  "installation": {
-    "message": "Installing example plugin...",
-    "postInstall": [
-      "echo 'Example plugin installed successfully!'",
-      "mkdir -p .example-config"
-    ]
-  }
-}
-```
-
-## Version Compatibility
-
-Specify compatible ClaudeAutoPM versions:
-
-```json
-{
-  "compatibleWith": ">=3.0.0"
-}
-```
-
-Supported formats:
-- `>=3.0.0` - Version 3.0.0 or higher
-- `^3.0.0` - Compatible with 3.x.x
-- `3.0.0` - Exact version only
 
 ## Testing Your Plugin
 
@@ -629,34 +312,10 @@ npm run test:install
 
 # Or manually
 node bin/autopm.js plugin install plugin-example
-```
-
-### Test Agents
-
-```bash
-# Test agent functionality
 node bin/autopm.js plugin info plugin-example
 ```
 
-## Publishing Your Plugin
-
-### Prepare for Publication
-
-1. Update version in `package.json` and `plugin.json`
-2. Run all tests
-3. Update README.md
-4. Verify all files are included
-
-### Publish to npm
-
-```bash
-cd packages/plugin-example
-npm publish --access public
-```
-
-## Complete Example: plugin-example
-
-Here is a complete minimal plugin:
+## Complete Minimal Example
 
 **packages/plugin-example/plugin.json:**
 
@@ -671,7 +330,7 @@ Here is a complete minimal plugin:
     "category": "Examples",
     "author": "ClaudeAutoPM Team",
     "license": "MIT",
-    "keywords": ["example", "minimal"]
+    "keywords": ["example"]
   },
   "agents": [
     {
@@ -683,20 +342,12 @@ Here is a complete minimal plugin:
       "tags": ["example"]
     }
   ],
-  "commands": [
-    {
-      "name": "example-hello",
-      "file": "commands/example-hello.md",
-      "description": "Say hello",
-      "category": "example",
-      "tags": ["example"]
-    }
-  ],
+  "commands": [],
   "rules": [],
   "hooks": [],
   "scripts": [],
   "dependencies": {
-    "required": [],
+    "required": ["@claudeautopm/plugin-core"],
     "optional": []
   },
   "compatibleWith": ">=3.0.0"
@@ -705,16 +356,16 @@ Here is a complete minimal plugin:
 
 ## Best Practices
 
-1. **Follow naming conventions** - Use kebab-case for files, consistent prefixes
-2. **Include TDD in agents** - All agents must have TDD methodology section
-3. **Add Documentation Queries** - Every agent needs Context7 queries
-4. **Keep plugins focused** - One domain per plugin
-5. **Test thoroughly** - Write tests for all functionality
-6. **Document everything** - Clear README and inline comments
-7. **Version carefully** - Follow semantic versioning
+1. **One domain per plugin** - Keep plugins focused on a single area
+2. **Include TDD in agents** - All agents must have a TDD methodology section
+3. **Add Context7 queries** - Every agent needs documentation query references
+4. **Use XML for enforcement rules** - Stronger model adherence
+5. **Test thoroughly** - Write tests for hooks and scripts
+6. **Follow naming conventions** - kebab-case for files, consistent prefixes
+7. **Version carefully** - Follow semantic versioning; CI handles publishing
 
 ## Next Steps
 
 - [Agent Development](./agent-development.md) - Detailed agent creation guide
 - [Command Development](./command-development.md) - Creating commands
-- [Testing](./testing.md) - Testing your plugin
+- [Architecture](./architecture.md) - System design overview

--- a/docs-site/docs/developer-guide/plugin-development.md
+++ b/docs-site/docs/developer-guide/plugin-development.md
@@ -288,13 +288,6 @@ Plugins are published under the `@claudeautopm` scope via CI-only workflow (GitH
 3. CI runs tests and validates `plugin.json`
 4. After merge, the GitHub Actions workflow publishes to npm
 
-### Manual Publishing (Development Only)
-
-```bash
-cd packages/plugin-example
-npm publish --access public
-```
-
 ## Testing Your Plugin
 
 ### Validate plugin.json

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ description: Complete installation guide for ClaudeAutoPM v3.14.0 with all scena
 
 # Installation Guide
 
-This guide covers all installation methods and configuration options for ClaudeAutoPM v3.14.0.
+This guide covers npm/npx installation methods and configuration options for ClaudeAutoPM v3.14.0. For the shell-based installer, see `install/install.sh`.
 
 ## System Requirements
 
@@ -13,7 +13,7 @@ This guide covers all installation methods and configuration options for ClaudeA
 
 | Requirement | Minimum Version |
 |-------------|-----------------|
-| Node.js | >= 18.0.0 |
+| Node.js | >= 16.0.0 (>= 18.0.0 recommended; plugins require 18+) |
 | npm | >= 8.0.0 |
 | Git | Latest stable |
 
@@ -25,8 +25,8 @@ This guide covers all installation methods and configuration options for ClaudeA
 
 ### Optional Dependencies
 
-- **Docker**: For Docker-first development scenarios (3, 4, 5)
-- **Kubernetes CLI (kubectl)**: For full and performance scenarios (4, 5)
+- **Docker**: For Docker-first development scenarios (3-6: Docker, Full, Full-Azure, Performance)
+- **Kubernetes CLI (kubectl)**: For full, full-azure, and performance scenarios (4-6)
 - **GitHub CLI (gh)**: For GitHub provider sync
 - **Azure CLI (az)**: For Azure DevOps provider sync
 
@@ -67,7 +67,7 @@ autopm install --scenario=full-azure
 
 ## Installation Scenarios
 
-ClaudeAutoPM offers 7 pre-configured scenarios. Each installs a different set of plugins from the `@claudeautopm` npm scope.
+ClaudeAutoPM offers 7 predefined scenarios + Custom. Each installs a different set of plugins from the `@claudeautopm` npm scope.
 
 ### 0. Lite
 
@@ -185,7 +185,7 @@ The dynamic `agent-registry.xml` uses `PLUGIN_AGENTS_START`/`PLUGIN_AGENTS_END` 
 
 ## Local Provider (Default)
 
-The lite scenario uses a **local provider** for issue tracking without any external service. Local issue files are stored in `.claude/providers/local/` and support:
+The lite scenario uses a **local provider** for issue tracking without any external service. Local issue files are stored in `.claude/issues/` and support:
 
 - `issue-create` - Create issues locally
 - `issue-list` - List all local issues
@@ -206,7 +206,7 @@ After installation, complete these setup steps:
 /pm:init
 ```
 
-This creates the `.pm/` directory structure and configures your selected provider.
+This creates the `.claude/` directory tree (prds/, epics/, issues/, etc.) and configures your selected provider.
 
 ### 2. Configure Environment (Optional)
 

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -1,11 +1,11 @@
 ---
 title: Installation
-description: Complete installation guide for ClaudeAutoPM with all scenarios and configuration options
+description: Complete installation guide for ClaudeAutoPM v3.14.0 with all scenarios and configuration options
 ---
 
 # Installation Guide
 
-This guide covers all installation methods and configuration options for ClaudeAutoPM.
+This guide covers all installation methods and configuration options for ClaudeAutoPM v3.14.0.
 
 ## System Requirements
 
@@ -13,7 +13,7 @@ This guide covers all installation methods and configuration options for ClaudeA
 
 | Requirement | Minimum Version |
 |-------------|-----------------|
-| Node.js | >= 16.0.0 |
+| Node.js | >= 18.0.0 |
 | npm | >= 8.0.0 |
 | Git | Latest stable |
 
@@ -25,15 +25,14 @@ This guide covers all installation methods and configuration options for ClaudeA
 
 ### Optional Dependencies
 
-- **Docker**: For Docker-first development scenarios
-- **Kubernetes CLI (kubectl)**: For K8s testing
-- **GitHub CLI (gh)**: Automatically installed during setup if needed
+- **Docker**: For Docker-first development scenarios (3, 4, 5)
+- **Kubernetes CLI (kubectl)**: For full and performance scenarios (4, 5)
+- **GitHub CLI (gh)**: For GitHub provider sync
+- **Azure CLI (az)**: For Azure DevOps provider sync
 
 ## Installation Methods
 
 ### Global Installation (Recommended)
-
-The npm-based global installation is the fastest and most reliable method:
 
 ```bash
 # Install ClaudeAutoPM globally
@@ -45,173 +44,156 @@ autopm --version
 # Navigate to your project
 cd your-project
 
-# Install the framework
+# Install the framework (interactive scenario selection)
 autopm install
 ```
 
 ### Using npx (No Global Install)
 
-If you prefer not to install globally:
-
 ```bash
-# Run directly without installation
 npx claude-autopm install
-
-# Other commands work the same way
 npx claude-autopm merge
 npx claude-autopm setup-env
 ```
 
-### Legacy Shell Installation
+### Non-Interactive Installation
 
-For environments where npm is not available:
-
-**Unix/Linux/macOS:**
 ```bash
-curl -sSL https://raw.githubusercontent.com/rafeekpro/ClaudeAutoPM/main/install/install.sh | bash
+# Install with a specific scenario
+autopm install --scenario=lite
+autopm install --scenario=github
+autopm install --scenario=full-azure
 ```
-
-**Windows PowerShell:**
-```powershell
-iwr -useb https://raw.githubusercontent.com/rafeekpro/ClaudeAutoPM/main/install/install.sh | iex
-```
-
-::: warning Note
-Legacy shell installation is provided for compatibility. npm installation is recommended for better reliability and automatic updates.
-:::
 
 ## Installation Scenarios
 
-During interactive installation, you'll choose from six pre-configured scenarios:
+ClaudeAutoPM offers 7 pre-configured scenarios. Each installs a different set of plugins from the `@claudeautopm` npm scope.
 
 ### 0. Lite
 
-**Best for**: Quick setup, minimal context usage
+**Best for**: Local-first PM, learning, minimal context usage
 
 ```bash
-autopm install --yes --config lite
+autopm install --scenario=lite
 ```
 
-- Core PM essentials only (~50 commands)
-- Minimal context footprint
-- No Docker or Kubernetes
-- Sequential execution strategy
+- Local PM only, no provider sync
+- Core + PM essentials (~32 commands)
+- Lowest context footprint (73% fewer agent tokens vs full)
+- Plugins: `plugin-core`, `plugin-pm` (2 plugins)
 
-### 1. Standard (Default)
+### 1. GitHub (Default)
 
-**Best for**: Most projects, balanced features
+**Best for**: GitHub-based projects
 
 ```bash
-autopm install --yes --config standard
+autopm install --scenario=github
 ```
 
-- Core + languages + PM commands (~55 commands)
-- Native tooling support
-- Sequential or adaptive execution
-- Recommended starting point
+- Core + languages + PM + GitHub sync (~50 commands)
+- Issues, PRs, and workflow sync
+- 59% fewer agent tokens vs full
+- Plugins: `plugin-core`, `plugin-languages`, `plugin-pm`, `plugin-pm-github` (4 plugins)
 
 ### 2. Azure
 
-**Best for**: Teams using Azure DevOps
+**Best for**: Azure DevOps projects
 
 ```bash
-autopm install --yes --config azure
+autopm install --scenario=azure
 ```
 
-- Standard + Azure DevOps integration (~95 commands)
-- Work item synchronization
-- Azure Boards integration
-- Sprint and iteration support
+- Core + languages + PM + Azure sync (~70 commands)
+- Work items, sprints, and feature sync
+- Plugins: `plugin-core`, `plugin-languages`, `plugin-pm`, `plugin-pm-azure` (4 plugins)
 
 ### 3. Docker
 
-**Best for**: Containerized development environments
+**Best for**: Containerized development (requires Docker)
 
 ```bash
-autopm install --yes --config docker
+autopm install --scenario=docker
 ```
 
-- Full PM + Docker-first development
-- 7 plugins enabled
-- Container orchestration support
-- Adaptive execution strategy
+- Adaptive execution (smart sequential/parallel choice)
+- Docker containers for development environment
+- GitHub integration included
+- Plugins: `plugin-core`, `plugin-languages`, `plugin-frameworks`, `plugin-testing`, `plugin-devops`, `plugin-pm`, `plugin-pm-github` (7 plugins)
 
 ### 4. Full DevOps (Recommended for Teams)
 
-**Best for**: Production deployments, enterprise teams
+**Best for**: Production applications, enterprise projects (requires Docker + kubectl)
 
 ```bash
-autopm install --yes --config devops
+autopm install --scenario=full
 ```
 
-- Complete CI/CD pipeline support
-- 10 plugins enabled
-- Kubernetes-native testing
-- Security scanning with Trivy
-- Helm chart support
+- Adaptive execution with Docker-first priority
+- Kubernetes + cloud deployment ready
+- GitHub integration included
+- Plugins: `plugin-core`, `plugin-languages`, `plugin-frameworks`, `plugin-testing`, `plugin-devops`, `plugin-cloud`, `plugin-databases`, `plugin-pm`, `plugin-pm-github`, `plugin-ai` (10 plugins)
 
-### 5. Performance
+### 5. Full Azure
 
-**Best for**: Power users, complex projects
+**Best for**: Enterprise teams using both GitHub and Azure DevOps (requires Docker + kubectl)
 
 ```bash
-autopm install --yes --config performance
+autopm install --scenario=full-azure
 ```
 
-- Maximum parallel execution
-- 12 plugins enabled
-- Hybrid parallel strategy
-- Advanced optimization features
+- Everything in Full DevOps plus Azure DevOps integration
+- Plugins: `plugin-core`, `plugin-languages`, `plugin-frameworks`, `plugin-testing`, `plugin-devops`, `plugin-cloud`, `plugin-databases`, `plugin-pm`, `plugin-pm-github`, `plugin-pm-azure`, `plugin-ai` (11 plugins)
 
-### 6. Custom
+### 6. Performance
+
+**Best for**: Large projects, power users (requires Docker + kubectl)
+
+```bash
+autopm install --scenario=performance
+```
+
+- Hybrid strategy: up to 5 parallel agents
+- Advanced context isolation and security
+- All plugins except Azure (12 plugins including `plugin-data`, `plugin-ml`)
+
+### 7. Custom
 
 **Best for**: Specific requirements
 
-```bash
-autopm install --yes --config custom
-```
-
-Allows you to provide your own configuration file.
+Allows manual configuration of execution strategy, agents, and workflows.
 
 ## Scenario Comparison
 
-| Feature | Lite | Standard | Azure | Docker | DevOps | Performance |
-|---------|------|----------|-------|--------|--------|-------------|
-| Commands | ~50 | ~55 | ~95 | ~85 | ~100 | ~120 |
-| Docker | - | - | - | Yes | Yes | Yes |
-| Kubernetes | - | - | - | - | Yes | Yes |
-| Azure DevOps | - | - | Yes | - | Yes | Yes |
-| Parallel Exec | - | - | - | Adaptive | Adaptive | Hybrid |
+| Feature | Lite | GitHub | Azure | Docker | Full | Full-Azure | Performance |
+|---------|------|--------|-------|--------|------|------------|-------------|
+| Plugins | 2 | 4 | 4 | 7 | 10 | 11 | 12 |
+| Provider | local | github | azure | github | github | github+azure | github |
+| Docker | - | - | - | Yes | Yes | Yes | Yes |
+| Kubernetes | - | - | - | - | Yes | Yes | Yes |
+| Execution | sequential | sequential | sequential | adaptive | adaptive | adaptive | hybrid |
+| Token savings | 73% | 59% | ~59% | ~30% | baseline | baseline | - |
 
-## Non-Interactive Installation
+## Token Savings
 
-For CI/CD pipelines and automated setups:
+ClaudeAutoPM uses a plugin architecture specifically to reduce context window usage. Only installed plugin agents are injected into `agent-registry.xml`:
 
-```bash
-# Minimal setup
-autopm install --yes --config lite --no-env --no-hooks
+- **Lite**: 73% fewer agent tokens than full — ideal for simple PM tasks
+- **GitHub**: 59% fewer tokens — good balance for most projects
+- **Full/Performance**: All agents available, maximum capability
 
-# Standard with GitHub Actions
-autopm install -y -c standard --cicd github-actions
+The dynamic `agent-registry.xml` uses `PLUGIN_AGENTS_START`/`PLUGIN_AGENTS_END` markers. The installer injects only the agents from your selected plugins between these markers.
 
-# DevOps setup
-autopm install -y -c devops --cicd azure-devops
+## Local Provider (Default)
 
-# Skip specific steps
-autopm install -y -c performance --no-env --no-hooks
-```
+The lite scenario uses a **local provider** for issue tracking without any external service. Local issue files are stored in `.claude/providers/local/` and support:
 
-### Available CLI Options
+- `issue-create` - Create issues locally
+- `issue-list` - List all local issues
+- `issue-show` - View issue details
+- `issue-start` - Begin work on an issue
+- `issue-close` - Close a completed issue
 
-| Option | Short | Description |
-|--------|-------|-------------|
-| `--yes` | `-y` | Auto-accept all prompts (non-interactive) |
-| `--config` | `-c` | Preset: `lite`, `standard`, `azure`, `docker`, `devops`, `performance` |
-| `--cicd` | | CI/CD system: `github-actions`, `azure-devops`, `gitlab-ci`, `jenkins`, `none` |
-| `--no-env` | | Skip .env setup |
-| `--no-hooks` | | Skip git hooks installation |
-| `--no-backup` | | Skip creating backups |
-| `--verbose` | | Enable verbose output |
+No GitHub CLI or Azure CLI required. Upgrade to a synced provider later by re-running `autopm install` with a different scenario.
 
 ## Post-Installation Setup
 
@@ -224,33 +206,19 @@ After installation, complete these setup steps:
 /pm:init
 ```
 
-This command will:
-- Install GitHub CLI if needed
-- Authenticate with GitHub
-- Create necessary directories
-- Update `.gitignore`
+This creates the `.pm/` directory structure and configures your selected provider.
 
 ### 2. Configure Environment (Optional)
 
 ```bash
-# Interactive environment setup
 autopm setup-env
-
-# Or configure a specific directory
-autopm setup-env ~/my-project
 ```
 
 ### 3. Enable MCP Servers (Optional)
 
 ```bash
-# List available MCP servers
 autopm mcp list
-
-# Enable recommended servers
 autopm mcp enable context7
-autopm mcp enable github-mcp
-
-# Sync configuration
 autopm mcp sync
 ```
 
@@ -259,22 +227,21 @@ autopm mcp sync
 ### Check Installed Files
 
 ```bash
-# Verify ClaudeAutoPM CLI
 autopm --version
-
-# Check directory structure
 ls -la .claude/
 ```
 
 Expected structure:
 ```
 .claude/
-├── agents/           # AI agent definitions
-├── commands/         # Command definitions
-├── rules/            # Development rules
-├── scripts/          # Utility scripts
-├── checklists/       # Quality checklists
-└── context/          # Project context
+├── agents/              # AI agent definitions
+│   └── agent-registry.xml  # Dynamic registry
+├── commands/            # Command definitions
+├── rules/               # 8 XML rules + MD references
+├── providers/           # Provider scripts (local/)
+├── scripts/             # Utility scripts
+├── hooks/               # Enforcement hooks
+└── config.json          # Scenario configuration
 ```
 
 ### Test Core Commands
@@ -289,7 +256,6 @@ In Claude Code:
 
 ### Permission Denied Errors
 
-**Linux/macOS:**
 ```bash
 # Fix npm permissions
 sudo chown -R $(whoami) ~/.npm
@@ -299,58 +265,22 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 nvm install node
 ```
 
-**Windows:**
-```powershell
-# Run PowerShell as Administrator
-npm install -g claude-autopm
-```
-
 ### Node.js Version Issues
 
 ```bash
-# Check current version
 node --version
-
-# Upgrade using n
 npm install -g n
 n latest
-
-# Or use nvm
-nvm install node
-nvm use node
 ```
 
 ### Installation Hangs
 
 ```bash
-# Clear npm cache
 npm cache clean --force
-
-# Use verbose mode for debugging
 autopm install --verbose
-
-# Skip problematic steps
-autopm install --no-env --no-hooks
 ```
-
-### Git Not Found
-
-**Linux (Ubuntu/Debian):**
-```bash
-sudo apt update && sudo apt install git
-```
-
-**macOS:**
-```bash
-xcode-select --install
-```
-
-**Windows:**
-Download from https://git-scm.com/download/win
 
 ## Updates and Maintenance
-
-### Updating ClaudeAutoPM
 
 ```bash
 # Update global package
@@ -363,24 +293,7 @@ autopm update
 autopm install --no-backup
 ```
 
-### Backup and Recovery
-
-ClaudeAutoPM automatically creates backups during updates:
-
-```bash
-# Backups stored in:
-.claude/.backups/
-
-# Manual backup
-cp -r .claude .claude.backup.$(date +%Y%m%d)
-
-# Restore from backup
-cp -r .claude.backup.20240314 .claude
-```
-
 ## Next Steps
-
-With ClaudeAutoPM installed, proceed to:
 
 - [Your First Project](./first-project.md) - Create your first PRD and start development
 - [Configuration](./configuration.md) - Customize your setup

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -4,8 +4,8 @@ layout: home
 
 hero:
   name: "ClaudeAutoPM"
-  text: "Automated Project Management"
-  tagline: Ship faster and better with spec-driven development and AI agents
+  text: "Plugin-Based AI Project Management"
+  tagline: Ship faster with spec-driven development, 7 core agents, and 13 optional plugins — v3.14.0
   actions:
     - theme: brand
       text: Get Started
@@ -18,24 +18,24 @@ hero:
       link: https://github.com/rafeekpro/ClaudeAutoPM
 
 features:
-  - icon: 🚀
-    title: Quick Setup
-    details: Get started in 5 minutes with our interactive guide. No extensive documentation reading required.
+  - icon: 🔌
+    title: Plugin Architecture
+    details: 13 plugins under @claudeautopm scope on npm. Install only what you need — lite uses 73% fewer tokens than full.
   - icon: 🤖
-    title: AI-Powered Agents
-    details: 96 professional CLI commands with parallel AI agent execution for maximum efficiency.
+    title: 7 Core + 50+ Plugin Agents
+    details: 7 always-available core agents plus 50+ specialized agents installed on demand via plugins.
   - icon: 🔗
-    title: Multi-Provider Support
-    details: Seamless integration with GitHub Issues and Azure DevOps for complete project management.
+    title: Three Providers
+    details: Local issue tracking (default), GitHub Issues, and Azure DevOps. Provider router auto-selects based on config.
   - icon: 📊
     title: Spec-Driven Development
     details: Transform PRDs into epics, epics into issues, and issues into production code with full traceability.
   - icon: ⚡
-    title: Smart Context Management
-    details: Never lose track of your work with intelligent context preservation and optimization.
+    title: Token-Optimized Context
+    details: 8 XML rules auto-loaded via @include. Dynamic agent-registry.xml injects only installed plugin agents.
   - icon: 🔄
-    title: Automated Workflows
-    details: From requirements to deployment - automate your entire development pipeline.
+    title: 7 Install Scenarios
+    details: From lite (2 plugins) to performance (12 plugins). Choose your footprint — no Docker required for basic PM.
 
 ---
 
@@ -105,9 +105,10 @@ autopm guide
 
 ClaudeAutoPM transforms your development workflow by:
 
-- **Automating project management** - From PRD to production with full traceability
+- **Plugin-based architecture** - 13 plugins on npm, install only what you need
+- **Local-first PM** - Default local provider tracks issues without GitHub or Azure
+- **Token-efficient context** - XML rules and dynamic agent registry minimize prompt size
 - **Parallel agent execution** - Multiple specialized AI agents working simultaneously
-- **Provider flexibility** - Works with your existing GitHub or Azure DevOps setup
-- **Context optimization** - Intelligent management prevents information loss
+- **Provider flexibility** - Local, GitHub, or Azure DevOps via a unified provider router
 
 </div>

--- a/docs-site/docs/user-guide/pm-workflow.md
+++ b/docs-site/docs/user-guide/pm-workflow.md
@@ -1,15 +1,13 @@
 ---
 title: PM Workflow
-description: Complete project management workflow from PRD creation to production deployment using ClaudeAutoPM.
+description: Complete project management workflow using ClaudeAutoPM v3.14.0 with local, GitHub, and Azure providers.
 ---
 
 # PM Workflow
 
-This guide walks you through the complete project management workflow in ClaudeAutoPM. You will learn how to take a feature idea from initial concept through to production code, with full traceability at every step.
+This guide walks through the complete project management workflow in ClaudeAutoPM, covering all three providers: local (default), GitHub, and Azure DevOps.
 
 ## The Development Lifecycle
-
-ClaudeAutoPM follows a structured development lifecycle:
 
 ```
 PRD (Product Requirements Document)
@@ -18,7 +16,7 @@ Epic (Technical Breakdown)
     ↓
 Tasks (Atomic Work Units)
     ↓
-GitHub Issues / Azure Work Items
+Issues (Local / GitHub / Azure)
     ↓
 Development & Code
     ↓
@@ -27,29 +25,83 @@ Completion & Sync
 
 Each stage builds on the previous one, maintaining traceability from requirements to implementation.
 
+## Providers
+
+ClaudeAutoPM supports three issue tracking providers. The active provider is set during installation and stored in `.claude/config.json`.
+
+| Provider | Scenario | Requires | Storage |
+|----------|----------|----------|---------|
+| **local** | lite | Nothing | `.claude/providers/local/` |
+| **github** | github, docker, full, performance | `gh` CLI | GitHub Issues |
+| **azure** | azure, full-azure | `az` CLI | Azure DevOps Work Items |
+
+### Switching Providers
+
+Re-run installation with a different scenario:
+
+```bash
+# Switch from local to GitHub
+autopm install --scenario=github
+
+# Add Azure alongside GitHub
+autopm install --scenario=full-azure
+```
+
+## Local Issue Tracking (Default)
+
+The local provider works without any external service. Issues are stored as files.
+
+### Creating Local Issues
+
+```bash
+# In Claude Code:
+/pm:prd-new user-authentication
+/pm:prd-parse user-authentication
+/pm:epic-sync user-authentication    # Creates local issues
+```
+
+### Local Issue Commands
+
+```bash
+/pm:issue-start 1      # Start work on local issue #1
+/pm:issue-show 1       # View issue details
+/pm:issue-close 1      # Close completed issue
+/pm:status              # View all issues and progress
+```
+
+Local issues support the full workflow (create, list, show, start, close) without GitHub or Azure credentials. This is ideal for:
+
+- Solo developers who do not need external sync
+- Learning ClaudeAutoPM before connecting to a provider
+- Offline development
+- Quick prototyping
+
+### Upgrading from Local to GitHub
+
+When you are ready to sync with GitHub:
+
+```bash
+# Re-install with GitHub scenario
+autopm install --scenario=github
+
+# Then sync existing epics
+/pm:epic-sync user-authentication
+```
+
+Existing local issues are preserved. The sync command creates corresponding GitHub Issues.
+
 ## Creating a PRD
-
-A PRD (Product Requirements Document) captures what you want to build and why. It serves as the source of truth for a feature.
-
-### Starting a New PRD
-
-Use the interactive brainstorming session to create a comprehensive PRD:
 
 ```bash
 /pm:prd-new user-authentication
 ```
 
-This command launches an interactive session that helps you define:
+This launches an interactive session to define:
 
-- **Feature overview** - What problem does this solve?
-- **User stories** - Who benefits and how?
-- **Technical requirements** - What constraints exist?
-- **Success criteria** - How do we know it's done?
-- **Dependencies** - What does this rely on?
+- Feature overview, user stories, technical requirements
+- Success criteria and dependencies
 
-### PRD Structure
-
-PRDs are stored in `.claude/prd/` with the following structure:
+PRDs are stored in `.claude/prd/` with YAML frontmatter:
 
 ```markdown
 ---
@@ -60,391 +112,204 @@ updated: 2024-01-15T10:30:00Z
 ---
 
 # User Authentication System
-
-## Overview
-Enable users to securely log in and manage their sessions.
-
-## User Stories
-- As a user, I want to log in with email/password
-- As a user, I want to reset my forgotten password
-- As an admin, I want to view login activity
-
-## Technical Requirements
-- JWT-based authentication
-- Secure password hashing with bcrypt
-- Session management with refresh tokens
-
-## Success Criteria
-- Users can register and log in
-- Password reset flow works end-to-end
-- All auth endpoints have 95%+ test coverage
+...
 ```
 
 ### Managing PRDs
 
-View and manage your PRDs with these commands:
-
 ```bash
-# List all PRDs
-/pm:prd-list
-
-# Show a specific PRD
-/pm:prd-show user-authentication
-
-# Edit an existing PRD
-/pm:prd-edit user-authentication
-
-# Check PRD implementation status
-/pm:prd-status user-authentication
+/pm:prd-list                          # List all PRDs
+/pm:prd-show user-authentication      # Show details
+/pm:prd-edit user-authentication      # Edit
+/pm:prd-status user-authentication    # Check status
 ```
 
 ## Parsing PRD to Epic
-
-Once your PRD is complete, parse it into an actionable epic with technical tasks:
 
 ```bash
 /pm:prd-parse user-authentication
 ```
 
-### What Parsing Does
+This analyzes the PRD and creates:
 
-The parse command:
-
-1. **Analyzes the PRD** - Extracts requirements and constraints
-2. **Creates an Epic** - Technical breakdown of the feature
-3. **Generates Tasks** - Atomic work units with clear deliverables
-4. **Estimates Effort** - Suggests story points or hours
-5. **Identifies Dependencies** - Maps task relationships
-
-### Epic Structure
-
-Epics are created in `.claude/epics/` with linked tasks:
-
-```markdown
----
-name: user-authentication
-prd: user-authentication
-status: backlog
-progress: 0%
-created: 2024-01-15T11:00:00Z
----
-
-# Epic: User Authentication System
-
-## Overview
-Implement complete authentication system based on PRD requirements.
-
-## Tasks
-1. Setup authentication module structure
-2. Implement JWT token generation
-3. Create login endpoint
-4. Create registration endpoint
-5. Implement password reset flow
-6. Add session management
-7. Write integration tests
-8. Security audit and hardening
-```
-
-### Task Files
-
-Each task gets its own file in `.claude/epics/user-authentication/`:
-
-```markdown
----
-name: implement-jwt-tokens
-epic: user-authentication
-status: open
-priority: high
-estimated: 4h
-dependencies: []
----
-
-# Task: Implement JWT Token Generation
-
-## Description
-Create JWT token generation and validation utilities.
-
-## Acceptance Criteria
-- [ ] Token generation with configurable expiry
-- [ ] Token validation with signature verification
-- [ ] Refresh token implementation
-- [ ] Unit tests with 100% coverage
-
-## Technical Notes
-- Use jsonwebtoken library
-- Store secrets in environment variables
-- Implement token rotation for security
-```
+1. An epic file in `.claude/epics/`
+2. Individual task files in `.claude/epics/user-authentication/`
+3. Effort estimates and dependency mapping
 
 ## Starting Work on an Epic
-
-When ready to begin development, start the epic:
 
 ```bash
 /pm:epic-start user-authentication
 ```
 
-### What Epic Start Does
+This command:
 
-1. **Changes epic status** to `in-progress`
-2. **Creates feature branch** from main
-3. **Syncs to provider** (GitHub or Azure)
-4. **Loads context** for development
-5. **Suggests first task** to work on
+1. Changes epic status to `in-progress`
+2. Creates a feature branch from main
+3. Syncs to the active provider (local, GitHub, or Azure)
+4. Loads context for development
+5. Suggests the first task
 
-### Syncing with GitHub
-
-For GitHub users, the epic and tasks sync to Issues:
+### Syncing with Providers
 
 ```bash
-# Initial sync creates GitHub issues
+# Sync to active provider (auto-detected)
 /pm:epic-sync user-authentication
 
-# Shows current sync status
+# View sync status
 /pm:status
 ```
 
-Each task becomes a GitHub Issue with:
-- Labels matching epic name
-- Proper description and acceptance criteria
-- Links back to local files
+**With GitHub provider**: Each task becomes a GitHub Issue with labels, description, and acceptance criteria.
 
-### Syncing with Azure DevOps
+**With Azure provider**: Tasks become Azure DevOps work items with sprint assignment.
 
-For Azure DevOps users, use the Azure-specific commands:
-
-```bash
-# Create feature in Azure DevOps
-/azure:feature-new user-authentication
-
-# Sync tasks as work items
-/azure:sync-all
-
-# View sprint status
-/azure:sprint-status
-```
+**With local provider**: Tasks are stored as local issue files.
 
 ## Working on Tasks
 
 ### Finding Your Next Task
 
 ```bash
-# Get recommended next task
-/pm:next
-
-# See all in-progress items
-/pm:in-progress
-
-# View blocked items
-/pm:blocked
+/pm:next            # Get recommended next task
+/pm:in-progress     # See all in-progress items
+/pm:blocked         # View blocked items
 ```
 
 ### Starting a Task
 
 ```bash
-# Start work on a specific issue
 /pm:issue-start 123
 ```
 
-This command:
-- Assigns the issue to you
-- Changes status to `in-progress`
-- Creates a working branch
-- Loads relevant context
-
-### During Development
-
-While working, keep your task updated:
-
-```bash
-# Update task with progress notes
-/pm:issue-edit 123 --add-comment "Completed JWT generation, starting validation"
-
-# Check overall project status
-/pm:status
-
-# View current task details
-/pm:issue-show 123
-```
+This assigns the issue, changes status to `in-progress`, creates a working branch, and loads context.
 
 ### Completing a Task
 
-When a task is complete:
-
 ```bash
-# Close the issue with a comment
 /pm:issue-close 123 "Implemented JWT tokens with full test coverage"
 ```
 
-The system automatically:
-- Updates local task status to `closed`
-- Syncs completion to GitHub/Azure
-- Links any associated PRs
-- Updates epic progress
+The system automatically updates the local task status, syncs completion to the active provider, and updates epic progress.
 
 ## Tracking Progress
 
 ### Project Status
 
-Get a comprehensive view of your project:
-
 ```bash
 /pm:status
 ```
 
-Output shows:
-- Current sprint information
-- Open vs completed tasks
-- In-progress work
-- Blocked items
-- Epic progress percentages
+Shows current sprint information, open vs completed tasks, in-progress work, blocked items, and epic progress.
 
 ### Daily Standup
-
-Generate a standup report:
 
 ```bash
 /pm:standup
 ```
 
-This produces a formatted report:
-```
-Daily Standup - 2024-01-16
-
-Yesterday:
-- Completed JWT token implementation (#123)
-- Fixed password hashing issue (#124)
-
-Today:
-- Start login endpoint (#125)
-- Code review for auth middleware (#126)
-
-Blockers:
-- Waiting for security team review on token rotation
-```
+Generates a formatted report with yesterday's completions, today's plan, and blockers.
 
 ### Epic Progress
 
-Track progress on specific epics:
-
 ```bash
-# View epic details and progress
 /pm:epic-show user-authentication
-
-# Get detailed status
 /pm:epic-status user-authentication
 ```
 
-## Epic Lifecycle Management
-
-### Refreshing Epic Status
-
-Sync local state with provider:
+## Epic Lifecycle
 
 ```bash
-/pm:epic-refresh user-authentication
-```
-
-### Splitting Large Epics
-
-If an epic becomes too large:
-
-```bash
+/pm:epic-refresh user-authentication    # Sync state with provider
 /pm:epic-split user-authentication --tasks 1,2,3 --new-epic auth-core
-```
-
-### Merging Related Epics
-
-Combine epics that should be together:
-
-```bash
 /pm:epic-merge small-auth-epic user-authentication
+/pm:epic-close user-authentication      # Close when all tasks done
 ```
-
-### Closing Completed Epics
-
-When all tasks are done:
-
-```bash
-/pm:epic-close user-authentication
-```
-
-This:
-- Validates all tasks are complete
-- Updates PRD status
-- Archives the epic
-- Generates completion report
 
 ## Complete Workflow Example
 
-Here is a complete example from start to finish:
+### With Local Provider (Lite)
 
 ```bash
-# 1. Create the PRD
+autopm install --scenario=lite
+
+/pm:init
 /pm:prd-new payment-integration
-
-# 2. Brainstorm and refine (interactive)
-# ... answer prompts about requirements ...
-
-# 3. Parse into epic and tasks
 /pm:prd-parse payment-integration
-
-# 4. Review generated tasks
-/pm:epic-show payment-integration
-
-# 5. Start the epic
 /pm:epic-start payment-integration
-
-# 6. Sync to GitHub
-/pm:epic-sync payment-integration
-
-# 7. Work on first task
-/pm:issue-start 201
-
-# 8. Complete the task
-/pm:issue-close 201 "Payment provider SDK integrated"
-
-# 9. Get next task
+/pm:issue-start 1
+# ... develop ...
+/pm:issue-close 1 "Payment SDK integrated"
 /pm:next
-
-# 10. Continue until epic complete...
-
-# 11. Close the epic
+# ... continue until done ...
 /pm:epic-close payment-integration
+```
 
-# 12. Verify completion
-/pm:prd-status payment-integration
+### With GitHub Provider
+
+```bash
+autopm install --scenario=github
+
+/pm:init                                   # Configures GitHub CLI
+/pm:prd-new payment-integration
+/pm:prd-parse payment-integration
+/pm:epic-sync payment-integration          # Creates GitHub Issues
+/pm:epic-start payment-integration
+/pm:issue-start 201                        # GitHub issue #201
+/pm:issue-close 201 "Payment SDK integrated"
+/pm:next
+/pm:epic-close payment-integration
+```
+
+### With Azure Provider
+
+```bash
+autopm install --scenario=azure
+
+/pm:init
+/pm:prd-new payment-integration
+/pm:prd-parse payment-integration
+/azure:feature-new payment-integration     # Azure Feature
+/azure:sync-all                            # Azure Work Items
+/pm:epic-start payment-integration
+# ... develop ...
+/pm:epic-close payment-integration
 ```
 
 ## Provider-Specific Notes
 
-### GitHub Workflow
+### Local Provider
+- No external service required
+- Issues stored in `.claude/providers/local/`
+- Full workflow support (create, list, show, start, close)
+- No authentication needed
 
-- Issues are created in your repository
+### GitHub Provider
+- Issues created in your repository
 - Labels group issues by epic
 - Milestones can track releases
 - Pull requests link to issues automatically
+- Requires `gh` CLI authenticated
 
-### Azure DevOps Workflow
-
+### Azure DevOps Provider
 - Features map to Azure Features
 - User Stories contain task items
 - Work items track in sprints
 - Boards update automatically
-
-See the [Azure DevOps Integration](/commands/azure-devops) for detailed Azure-specific commands.
+- Requires `az` CLI authenticated
+- Decoupled from Docker/Full scenarios (use `azure` or `full-azure` scenario)
 
 ## Best Practices
 
-1. **Write detailed PRDs** - The better your requirements, the better the generated tasks
-2. **Keep tasks atomic** - Each task should be completable in a day or less
-3. **Update regularly** - Sync status to keep everything accurate
-4. **Use standup reports** - They help you and your team stay aligned
-5. **Close when done** - Completed epics help track velocity
+1. **Start with local** - Use lite scenario to learn the workflow before connecting to GitHub/Azure
+2. **Write detailed PRDs** - Better requirements produce better generated tasks
+3. **Keep tasks atomic** - Each task should be completable in a day or less
+4. **Update regularly** - Sync status to keep everything accurate
+5. **Use standup reports** - They help you and your team stay aligned
+6. **Close when done** - Completed epics help track velocity
 
 ## Next Steps
 
-Now that you understand the workflow:
-- Learn about [available commands](./commands-overview)
-- Explore [AI agents](./agents-overview) for development assistance
-- Review [best practices](./best-practices) for optimal usage
+- [Available Commands](./commands-overview) - Full command reference
+- [AI Agents](/agents/selection-guide) - Agent selection guide
+- [Installation](/getting-started/installation) - Change scenarios

--- a/docs-site/docs/user-guide/pm-workflow.md
+++ b/docs-site/docs/user-guide/pm-workflow.md
@@ -31,7 +31,7 @@ ClaudeAutoPM supports three issue tracking providers. The active provider is set
 
 | Provider | Scenario | Requires | Storage |
 |----------|----------|----------|---------|
-| **local** | lite | Nothing | `.claude/providers/local/` |
+| **local** | lite | Nothing | `.claude/issues/` |
 | **github** | github, docker, full, performance | `gh` CLI | GitHub Issues |
 | **azure** | azure, full-azure | `az` CLI | Azure DevOps Work Items |
 
@@ -57,7 +57,7 @@ The local provider works without any external service. Issues are stored as file
 # In Claude Code:
 /pm:prd-new user-authentication
 /pm:prd-parse user-authentication
-/pm:epic-sync user-authentication    # Creates local issues
+/pm:epic-decompose user-authentication    # Breaks epic into tasks (local files)
 ```
 
 ### Local Issue Commands
@@ -68,6 +68,8 @@ The local provider works without any external service. Issues are stored as file
 /pm:issue-close 1      # Close completed issue
 /pm:status              # View all issues and progress
 ```
+
+Note: `/pm:epic-sync` and `/pm:issue-*` commands that interact with GitHub require the GitHub plugin (scenarios: github, docker, full, performance). The lite scenario uses local-only commands.
 
 Local issues support the full workflow (create, list, show, start, close) without GitHub or Azure credentials. This is ideal for:
 
@@ -101,7 +103,7 @@ This launches an interactive session to define:
 - Feature overview, user stories, technical requirements
 - Success criteria and dependencies
 
-PRDs are stored in `.claude/prd/` with YAML frontmatter:
+PRDs are stored in `.claude/prds/` with YAML frontmatter:
 
 ```markdown
 ---
@@ -236,6 +238,7 @@ autopm install --scenario=lite
 /pm:init
 /pm:prd-new payment-integration
 /pm:prd-parse payment-integration
+/pm:epic-decompose payment-integration
 /pm:epic-start payment-integration
 /pm:issue-start 1
 # ... develop ...
@@ -280,7 +283,7 @@ autopm install --scenario=azure
 
 ### Local Provider
 - No external service required
-- Issues stored in `.claude/providers/local/`
+- Issues stored in `.claude/issues/`
 - Full workflow support (create, list, show, start, close)
 - No authentication needed
 


### PR DESCRIPTION
## 🎯 Goal
Update VitePress docs site to reflect v3.14.0: plugin architecture, XML rules, local issues, 7 scenarios.

## 📁 Updated Pages (7)
- **index.md** — landing page with plugin features
- **installation.md** — 7 scenarios, token savings, local provider
- **agents/registry.md** — core-only + plugin model
- **agents/selection-guide.md** — core vs plugin availability
- **architecture.md** — provider system, XML rules, token optimization
- **plugin-development.md** — @claudeautopm scope, CI-only publish
- **pm-workflow.md** — local issue tracking, provider comparison

Also updated Obsidian vault at /Users/rla/RLA02/PROJEKTY/AutoPM/ (7 new pages).

## 🚫 Out of Scope
- Did not update: azure-devops.md, commands/*.md, reference/*.md (separate PR if needed)