### PR TITLE
[feat][pm] Add local PRD and epic tracking provider

### DIFF
--- a/.claude/providers/local/epic-create.js
+++ b/.claude/providers/local/epic-create.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+function slugify(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50);
+}
+
+function getEpicsDir() {
+  return path.join(process.cwd(), '.claude', 'epics');
+}
+
+async function execute(options = {}) {
+  const title = options.title || options.name;
+  if (!title) {
+    return { success: false, error: 'Title is required' };
+  }
+
+  const prd = options.prd || '';
+  const body = options.body || '';
+
+  const slug = slugify(title);
+  const epicDir = path.join(getEpicsDir(), slug);
+
+  if (!fs.existsSync(epicDir)) {
+    fs.mkdirSync(epicDir, { recursive: true });
+  }
+
+  const filepath = path.join(epicDir, 'epic.md');
+  const now = new Date().toISOString();
+
+  const content = `---
+name: "${title.replace(/"/g, '\\"')}"
+status: backlog
+prd: "${prd}"
+progress: 0
+created: ${now}
+updated: ${now}
+---
+
+${body || `## Overview\n${title}\n\n## Tasks\n- [ ] TODO`}
+`;
+
+  fs.writeFileSync(filepath, content, 'utf8');
+
+  return {
+    success: true,
+    epic: {
+      name: slug,
+      title,
+      status: 'backlog',
+      path: filepath
+    },
+    actions: [`Created epic: ${slug}/epic.md`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute, slugify, getEpicsDir };

--- a/.claude/providers/local/epic-create.js
+++ b/.claude/providers/local/epic-create.js
@@ -19,13 +19,22 @@ async function execute(options = {}) {
   const body = options.body || '';
 
   const slug = slugify(title);
-  const epicDir = path.join(getEpicsDir(), slug);
-
-  if (!fs.existsSync(epicDir)) {
-    fs.mkdirSync(epicDir, { recursive: true });
+  if (!slug) {
+    return { success: false, error: 'Could not generate valid slug from title' };
+  }
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid slug generated: "${slug}"` };
   }
 
+  const epicDir = path.join(getEpicsDir(), slug);
   const filepath = path.join(epicDir, 'epic.md');
+
+  if (fs.existsSync(filepath)) {
+    return { success: false, error: `Epic "${slug}" already exists` };
+  }
+
+  fs.mkdirSync(epicDir, { recursive: true });
+
   const now = new Date().toISOString();
 
   const content = `---

--- a/.claude/providers/local/epic-decompose.js
+++ b/.claude/providers/local/epic-decompose.js
@@ -1,11 +1,15 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
 
 async function execute(options = {}) {
   const name = options.name;
   if (!name) {
     return { success: false, error: 'Epic name is required' };
+  }
+
+  const slug = path.basename(name);
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid epic name: "${name}"` };
   }
 
   const tasks = options.tasks;
@@ -14,19 +18,19 @@ async function execute(options = {}) {
   }
 
   const epicsDir = path.join(process.cwd(), '.claude', 'epics');
-  const epicDir = path.join(epicsDir, name);
+  const epicDir = path.join(epicsDir, slug);
   const epicFile = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(epicFile)) {
-    return { success: false, error: `Epic "${name}" not found` };
+    return { success: false, error: `Epic "${slug}" not found` };
   }
 
   const now = new Date().toISOString();
   const created = [];
 
-  // Find next task number
+  // Find next task number (numbered .md files only)
   const existing = fs.readdirSync(epicDir).filter(f =>
-    f.endsWith('.md') && f !== 'epic.md'
+    /^\d+\.md$/.test(f)
   );
   let nextNum = 1;
   for (const f of existing) {
@@ -57,15 +61,15 @@ ${description || `## Goal\n${title}\n\n## Acceptance Criteria\n- [ ] TODO`}
   // Update epic frontmatter with progress
   const epicContent = fs.readFileSync(epicFile, 'utf8');
   const updatedContent = epicContent
-    .replace(/updated: .+/, `updated: ${now}`)
-    .replace(/progress: \d+/, `progress: 0`);
+    .replace(/^updated:\s*.*/m, `updated: ${now}`)
+    .replace(/^progress:\s*\d+/m, `progress: 0`);
   fs.writeFileSync(epicFile, updatedContent, 'utf8');
 
   return {
     success: true,
     tasks: created,
     count: created.length,
-    actions: [`Decomposed epic "${name}" into ${created.length} tasks`],
+    actions: [`Decomposed epic "${slug}" into ${created.length} tasks`],
     timestamp: now
   };
 }

--- a/.claude/providers/local/epic-decompose.js
+++ b/.claude/providers/local/epic-decompose.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+async function execute(options = {}) {
+  const name = options.name;
+  if (!name) {
+    return { success: false, error: 'Epic name is required' };
+  }
+
+  const tasks = options.tasks;
+  if (!tasks || !Array.isArray(tasks) || tasks.length === 0) {
+    return { success: false, error: 'Tasks array is required' };
+  }
+
+  const epicsDir = path.join(process.cwd(), '.claude', 'epics');
+  const epicDir = path.join(epicsDir, name);
+  const epicFile = path.join(epicDir, 'epic.md');
+
+  if (!fs.existsSync(epicFile)) {
+    return { success: false, error: `Epic "${name}" not found` };
+  }
+
+  const now = new Date().toISOString();
+  const created = [];
+
+  // Find next task number
+  const existing = fs.readdirSync(epicDir).filter(f =>
+    f.endsWith('.md') && f !== 'epic.md'
+  );
+  let nextNum = 1;
+  for (const f of existing) {
+    const n = parseInt(f.replace('.md', ''));
+    if (n >= nextNum) nextNum = n + 1;
+  }
+
+  for (const task of tasks) {
+    const num = nextNum++;
+    const taskFile = path.join(epicDir, `${num}.md`);
+    const title = task.title || `Task ${num}`;
+    const description = task.description || '';
+
+    const content = `---
+name: "${title.replace(/"/g, '\\"')}"
+status: open
+created: ${now}
+updated: ${now}
+---
+
+${description || `## Goal\n${title}\n\n## Acceptance Criteria\n- [ ] TODO`}
+`;
+
+    fs.writeFileSync(taskFile, content, 'utf8');
+    created.push({ number: num, title, path: taskFile });
+  }
+
+  // Update epic frontmatter with progress
+  const epicContent = fs.readFileSync(epicFile, 'utf8');
+  const updatedContent = epicContent
+    .replace(/updated: .+/, `updated: ${now}`)
+    .replace(/progress: \d+/, `progress: 0`);
+  fs.writeFileSync(epicFile, updatedContent, 'utf8');
+
+  return {
+    success: true,
+    tasks: created,
+    count: created.length,
+    actions: [`Decomposed epic "${name}" into ${created.length} tasks`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute };

--- a/.claude/providers/local/epic-list.js
+++ b/.claude/providers/local/epic-list.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 function getEpicsDir() {
   return path.join(process.cwd(), '.claude', 'epics');
@@ -14,6 +14,7 @@ async function execute(options = {}) {
   }
 
   const dirs = fs.readdirSync(epicsDir).filter(d => {
+    if (!/^[a-z0-9-]+$/.test(d)) return false;
     const full = path.join(epicsDir, d);
     return fs.statSync(full).isDirectory();
   }).sort();
@@ -25,15 +26,15 @@ async function execute(options = {}) {
     if (!fs.existsSync(epicFile)) continue;
 
     const content = fs.readFileSync(epicFile, 'utf8');
-    const fm = parseFrontmatter(content);
-    if (!fm) continue;
+    const { frontmatter: fm } = parseFrontmatter(content);
+    if (!fm || Object.keys(fm).length === 0) continue;
 
     if (options.status && fm.status !== options.status) continue;
 
-    // Count task files (numbered .md files, not epic.md)
+    // Count task files (numbered .md files only)
     const epicDirPath = path.join(epicsDir, dir);
     const taskFiles = fs.readdirSync(epicDirPath).filter(f =>
-      f.endsWith('.md') && f !== 'epic.md'
+      /^\d+\.md$/.test(f)
     );
 
     epics.push({

--- a/.claude/providers/local/epic-list.js
+++ b/.claude/providers/local/epic-list.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+function getEpicsDir() {
+  return path.join(process.cwd(), '.claude', 'epics');
+}
+
+async function execute(options = {}) {
+  const epicsDir = getEpicsDir();
+
+  if (!fs.existsSync(epicsDir)) {
+    return { success: true, epics: [], count: 0 };
+  }
+
+  const dirs = fs.readdirSync(epicsDir).filter(d => {
+    const full = path.join(epicsDir, d);
+    return fs.statSync(full).isDirectory();
+  }).sort();
+
+  const epics = [];
+
+  for (const dir of dirs) {
+    const epicFile = path.join(epicsDir, dir, 'epic.md');
+    if (!fs.existsSync(epicFile)) continue;
+
+    const content = fs.readFileSync(epicFile, 'utf8');
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    if (options.status && fm.status !== options.status) continue;
+
+    // Count task files (numbered .md files, not epic.md)
+    const epicDirPath = path.join(epicsDir, dir);
+    const taskFiles = fs.readdirSync(epicDirPath).filter(f =>
+      f.endsWith('.md') && f !== 'epic.md'
+    );
+
+    epics.push({
+      name: dir,
+      title: fm.name || dir,
+      status: fm.status || 'backlog',
+      prd: fm.prd || '',
+      progress: parseInt(fm.progress) || 0,
+      taskCount: taskFiles.length,
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      path: epicFile
+    });
+  }
+
+  return { success: true, epics, count: epics.length };
+}
+
+module.exports = { execute, getEpicsDir };

--- a/.claude/providers/local/epic-show.js
+++ b/.claude/providers/local/epic-show.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 async function execute(options = {}) {
   const name = options.name;
@@ -8,34 +8,36 @@ async function execute(options = {}) {
     return { success: false, error: 'Epic name is required' };
   }
 
+  const slug = path.basename(name);
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid epic name: "${name}"` };
+  }
+
   const epicsDir = path.join(process.cwd(), '.claude', 'epics');
-  const epicDir = path.join(epicsDir, name);
+  const epicDir = path.join(epicsDir, slug);
   const filepath = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(filepath)) {
-    return { success: false, error: `Epic "${name}" not found` };
+    return { success: false, error: `Epic "${slug}" not found` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');
-  const fm = parseFrontmatter(content);
+  const { frontmatter: fm, body } = parseFrontmatter(content);
 
-  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
-  const body = bodyMatch ? bodyMatch[1].trim() : '';
-
-  // List task files
+  // List task files (numbered .md files only)
   const taskFiles = fs.readdirSync(epicDir).filter(f =>
-    f.endsWith('.md') && f !== 'epic.md'
+    /^\d+\.md$/.test(f)
   ).sort();
 
   const tasks = [];
   for (const file of taskFiles) {
     const taskContent = fs.readFileSync(path.join(epicDir, file), 'utf8');
-    const taskFm = parseFrontmatter(taskContent);
+    const { frontmatter: taskFm } = parseFrontmatter(taskContent);
     const num = parseInt(file.replace('.md', '')) || 0;
     tasks.push({
       number: num,
-      title: taskFm ? (taskFm.name || file) : file,
-      status: taskFm ? (taskFm.status || 'open') : 'open',
+      title: taskFm.name || file,
+      status: taskFm.status || 'open',
       path: path.join(epicDir, file)
     });
   }
@@ -45,16 +47,16 @@ async function execute(options = {}) {
   return {
     success: true,
     epic: {
-      name,
-      title: fm ? (fm.name || name) : name,
-      status: fm ? (fm.status || 'backlog') : 'backlog',
-      prd: fm ? (fm.prd || '') : '',
-      progress: fm ? (parseInt(fm.progress) || 0) : 0,
-      body,
+      name: slug,
+      title: fm.name || slug,
+      status: fm.status || 'backlog',
+      prd: fm.prd || '',
+      progress: parseInt(fm.progress) || 0,
+      body: body.trim(),
       tasks,
       taskCount: tasks.length,
-      createdAt: fm ? (fm.created || '') : '',
-      updatedAt: fm ? (fm.updated || '') : '',
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
       path: filepath
     }
   };

--- a/.claude/providers/local/epic-show.js
+++ b/.claude/providers/local/epic-show.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+async function execute(options = {}) {
+  const name = options.name;
+  if (!name) {
+    return { success: false, error: 'Epic name is required' };
+  }
+
+  const epicsDir = path.join(process.cwd(), '.claude', 'epics');
+  const epicDir = path.join(epicsDir, name);
+  const filepath = path.join(epicDir, 'epic.md');
+
+  if (!fs.existsSync(filepath)) {
+    return { success: false, error: `Epic "${name}" not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseFrontmatter(content);
+
+  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  // List task files
+  const taskFiles = fs.readdirSync(epicDir).filter(f =>
+    f.endsWith('.md') && f !== 'epic.md'
+  ).sort();
+
+  const tasks = [];
+  for (const file of taskFiles) {
+    const taskContent = fs.readFileSync(path.join(epicDir, file), 'utf8');
+    const taskFm = parseFrontmatter(taskContent);
+    const num = parseInt(file.replace('.md', '')) || 0;
+    tasks.push({
+      number: num,
+      title: taskFm ? (taskFm.name || file) : file,
+      status: taskFm ? (taskFm.status || 'open') : 'open',
+      path: path.join(epicDir, file)
+    });
+  }
+
+  tasks.sort((a, b) => a.number - b.number);
+
+  return {
+    success: true,
+    epic: {
+      name,
+      title: fm ? (fm.name || name) : name,
+      status: fm ? (fm.status || 'backlog') : 'backlog',
+      prd: fm ? (fm.prd || '') : '',
+      progress: fm ? (parseInt(fm.progress) || 0) : 0,
+      body,
+      tasks,
+      taskCount: tasks.length,
+      createdAt: fm ? (fm.created || '') : '',
+      updatedAt: fm ? (fm.updated || '') : '',
+      path: filepath
+    }
+  };
+}
+
+module.exports = { execute };

--- a/.claude/providers/local/prd-create.js
+++ b/.claude/providers/local/prd-create.js
@@ -19,13 +19,25 @@ async function execute(options = {}) {
   const timeline = options.timeline || '';
   const body = options.body || '';
 
+  const slug = slugify(title);
+  if (!slug) {
+    return { success: false, error: 'Could not generate valid slug from title' };
+  }
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid slug generated: "${slug}"` };
+  }
+
   const prdsDir = getPrdsDir();
   if (!fs.existsSync(prdsDir)) {
     fs.mkdirSync(prdsDir, { recursive: true });
   }
 
-  const slug = slugify(title);
   const filepath = path.join(prdsDir, `${slug}.md`);
+
+  if (fs.existsSync(filepath)) {
+    return { success: false, error: `PRD "${slug}" already exists` };
+  }
+
   const now = new Date().toISOString();
 
   const content = `---

--- a/.claude/providers/local/prd-create.js
+++ b/.claude/providers/local/prd-create.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+
+function slugify(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50);
+}
+
+function getPrdsDir() {
+  return path.join(process.cwd(), '.claude', 'prds');
+}
+
+async function execute(options = {}) {
+  const title = options.title || options.name;
+  if (!title) {
+    return { success: false, error: 'Title is required' };
+  }
+
+  const priority = options.priority || 'P2';
+  const timeline = options.timeline || '';
+  const body = options.body || '';
+
+  const prdsDir = getPrdsDir();
+  if (!fs.existsSync(prdsDir)) {
+    fs.mkdirSync(prdsDir, { recursive: true });
+  }
+
+  const slug = slugify(title);
+  const filepath = path.join(prdsDir, `${slug}.md`);
+  const now = new Date().toISOString();
+
+  const content = `---
+name: "${title.replace(/"/g, '\\"')}"
+status: draft
+priority: ${priority}
+timeline: "${timeline}"
+created: ${now}
+updated: ${now}
+---
+
+${body || `## Overview\n${title}\n\n## Requirements\n- [ ] TODO`}
+`;
+
+  fs.writeFileSync(filepath, content, 'utf8');
+
+  return {
+    success: true,
+    prd: {
+      name: slug,
+      title,
+      status: 'draft',
+      priority,
+      path: filepath
+    },
+    actions: [`Created PRD: ${slug}.md`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute, slugify, getPrdsDir };

--- a/.claude/providers/local/prd-list.js
+++ b/.claude/providers/local/prd-list.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.+)$/);
+    if (kv) {
+      let value = kv[2].trim();
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      fm[kv[1]] = value;
+    }
+  }
+  return fm;
+}
+
+async function execute(options = {}) {
+  const prdsDir = path.join(process.cwd(), '.claude', 'prds');
+
+  if (!fs.existsSync(prdsDir)) {
+    return { success: true, prds: [], count: 0 };
+  }
+
+  const files = fs.readdirSync(prdsDir).filter(f => f.endsWith('.md')).sort();
+  const prds = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(prdsDir, file), 'utf8');
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    if (options.status && fm.status !== options.status) continue;
+
+    prds.push({
+      name: file.replace('.md', ''),
+      title: fm.name || file.replace('.md', ''),
+      status: fm.status || 'draft',
+      priority: fm.priority || 'P2',
+      timeline: fm.timeline || '',
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      path: path.join(prdsDir, file)
+    });
+  }
+
+  return { success: true, prds, count: prds.length };
+}
+
+module.exports = { execute, parseFrontmatter };

--- a/.claude/providers/local/prd-list.js
+++ b/.claude/providers/local/prd-list.js
@@ -1,23 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-
-function parseFrontmatter(content) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-
-  const fm = {};
-  for (const line of match[1].split('\n')) {
-    const kv = line.match(/^(\w+):\s*(.+)$/);
-    if (kv) {
-      let value = kv[2].trim();
-      if (value.startsWith('"') && value.endsWith('"')) {
-        value = value.slice(1, -1);
-      }
-      fm[kv[1]] = value;
-    }
-  }
-  return fm;
-}
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 async function execute(options = {}) {
   const prdsDir = path.join(process.cwd(), '.claude', 'prds');
@@ -31,8 +14,8 @@ async function execute(options = {}) {
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(prdsDir, file), 'utf8');
-    const fm = parseFrontmatter(content);
-    if (!fm) continue;
+    const { frontmatter: fm } = parseFrontmatter(content);
+    if (!fm || Object.keys(fm).length === 0) continue;
 
     if (options.status && fm.status !== options.status) continue;
 
@@ -51,4 +34,4 @@ async function execute(options = {}) {
   return { success: true, prds, count: prds.length };
 }
 
-module.exports = { execute, parseFrontmatter };
+module.exports = { execute };

--- a/.claude/providers/local/prd-show.js
+++ b/.claude/providers/local/prd-show.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+async function execute(options = {}) {
+  const name = options.name;
+  if (!name) {
+    return { success: false, error: 'PRD name is required' };
+  }
+
+  const slug = name.replace(/\.md$/, '');
+  const prdsDir = path.join(process.cwd(), '.claude', 'prds');
+  const filepath = path.join(prdsDir, `${slug}.md`);
+
+  if (!fs.existsSync(filepath)) {
+    return { success: false, error: `PRD "${slug}" not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseFrontmatter(content);
+
+  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  return {
+    success: true,
+    prd: {
+      name: slug,
+      title: fm ? (fm.name || slug) : slug,
+      status: fm ? (fm.status || 'draft') : 'draft',
+      priority: fm ? (fm.priority || 'P2') : 'P2',
+      timeline: fm ? (fm.timeline || '') : '',
+      body,
+      createdAt: fm ? (fm.created || '') : '',
+      updatedAt: fm ? (fm.updated || '') : '',
+      path: filepath
+    }
+  };
+}
+
+module.exports = { execute };

--- a/.claude/providers/local/prd-show.js
+++ b/.claude/providers/local/prd-show.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 async function execute(options = {}) {
   const name = options.name;
@@ -8,7 +8,11 @@ async function execute(options = {}) {
     return { success: false, error: 'PRD name is required' };
   }
 
-  const slug = name.replace(/\.md$/, '');
+  const slug = path.basename(name.replace(/\.md$/, ''));
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid PRD name: "${name}"` };
+  }
+
   const prdsDir = path.join(process.cwd(), '.claude', 'prds');
   const filepath = path.join(prdsDir, `${slug}.md`);
 
@@ -17,22 +21,19 @@ async function execute(options = {}) {
   }
 
   const content = fs.readFileSync(filepath, 'utf8');
-  const fm = parseFrontmatter(content);
-
-  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
-  const body = bodyMatch ? bodyMatch[1].trim() : '';
+  const { frontmatter: fm, body } = parseFrontmatter(content);
 
   return {
     success: true,
     prd: {
       name: slug,
-      title: fm ? (fm.name || slug) : slug,
-      status: fm ? (fm.status || 'draft') : 'draft',
-      priority: fm ? (fm.priority || 'P2') : 'P2',
-      timeline: fm ? (fm.timeline || '') : '',
-      body,
-      createdAt: fm ? (fm.created || '') : '',
-      updatedAt: fm ? (fm.updated || '') : '',
+      title: fm.name || slug,
+      status: fm.status || 'draft',
+      priority: fm.priority || 'P2',
+      timeline: fm.timeline || '',
+      body: body.trim(),
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
       path: filepath
     }
   };

--- a/autopm/.claude/providers/local/epic-create.js
+++ b/autopm/.claude/providers/local/epic-create.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+function slugify(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50);
+}
+
+function getEpicsDir() {
+  return path.join(process.cwd(), '.claude', 'epics');
+}
+
+async function execute(options = {}) {
+  const title = options.title || options.name;
+  if (!title) {
+    return { success: false, error: 'Title is required' };
+  }
+
+  const prd = options.prd || '';
+  const body = options.body || '';
+
+  const slug = slugify(title);
+  const epicDir = path.join(getEpicsDir(), slug);
+
+  if (!fs.existsSync(epicDir)) {
+    fs.mkdirSync(epicDir, { recursive: true });
+  }
+
+  const filepath = path.join(epicDir, 'epic.md');
+  const now = new Date().toISOString();
+
+  const content = `---
+name: "${title.replace(/"/g, '\\"')}"
+status: backlog
+prd: "${prd}"
+progress: 0
+created: ${now}
+updated: ${now}
+---
+
+${body || `## Overview\n${title}\n\n## Tasks\n- [ ] TODO`}
+`;
+
+  fs.writeFileSync(filepath, content, 'utf8');
+
+  return {
+    success: true,
+    epic: {
+      name: slug,
+      title,
+      status: 'backlog',
+      path: filepath
+    },
+    actions: [`Created epic: ${slug}/epic.md`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute, slugify, getEpicsDir };

--- a/autopm/.claude/providers/local/epic-create.js
+++ b/autopm/.claude/providers/local/epic-create.js
@@ -19,13 +19,22 @@ async function execute(options = {}) {
   const body = options.body || '';
 
   const slug = slugify(title);
-  const epicDir = path.join(getEpicsDir(), slug);
-
-  if (!fs.existsSync(epicDir)) {
-    fs.mkdirSync(epicDir, { recursive: true });
+  if (!slug) {
+    return { success: false, error: 'Could not generate valid slug from title' };
+  }
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid slug generated: "${slug}"` };
   }
 
+  const epicDir = path.join(getEpicsDir(), slug);
   const filepath = path.join(epicDir, 'epic.md');
+
+  if (fs.existsSync(filepath)) {
+    return { success: false, error: `Epic "${slug}" already exists` };
+  }
+
+  fs.mkdirSync(epicDir, { recursive: true });
+
   const now = new Date().toISOString();
 
   const content = `---

--- a/autopm/.claude/providers/local/epic-decompose.js
+++ b/autopm/.claude/providers/local/epic-decompose.js
@@ -1,11 +1,15 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
 
 async function execute(options = {}) {
   const name = options.name;
   if (!name) {
     return { success: false, error: 'Epic name is required' };
+  }
+
+  const slug = path.basename(name);
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid epic name: "${name}"` };
   }
 
   const tasks = options.tasks;
@@ -14,19 +18,19 @@ async function execute(options = {}) {
   }
 
   const epicsDir = path.join(process.cwd(), '.claude', 'epics');
-  const epicDir = path.join(epicsDir, name);
+  const epicDir = path.join(epicsDir, slug);
   const epicFile = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(epicFile)) {
-    return { success: false, error: `Epic "${name}" not found` };
+    return { success: false, error: `Epic "${slug}" not found` };
   }
 
   const now = new Date().toISOString();
   const created = [];
 
-  // Find next task number
+  // Find next task number (numbered .md files only)
   const existing = fs.readdirSync(epicDir).filter(f =>
-    f.endsWith('.md') && f !== 'epic.md'
+    /^\d+\.md$/.test(f)
   );
   let nextNum = 1;
   for (const f of existing) {
@@ -57,15 +61,15 @@ ${description || `## Goal\n${title}\n\n## Acceptance Criteria\n- [ ] TODO`}
   // Update epic frontmatter with progress
   const epicContent = fs.readFileSync(epicFile, 'utf8');
   const updatedContent = epicContent
-    .replace(/updated: .+/, `updated: ${now}`)
-    .replace(/progress: \d+/, `progress: 0`);
+    .replace(/^updated:\s*.*/m, `updated: ${now}`)
+    .replace(/^progress:\s*\d+/m, `progress: 0`);
   fs.writeFileSync(epicFile, updatedContent, 'utf8');
 
   return {
     success: true,
     tasks: created,
     count: created.length,
-    actions: [`Decomposed epic "${name}" into ${created.length} tasks`],
+    actions: [`Decomposed epic "${slug}" into ${created.length} tasks`],
     timestamp: now
   };
 }

--- a/autopm/.claude/providers/local/epic-decompose.js
+++ b/autopm/.claude/providers/local/epic-decompose.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+async function execute(options = {}) {
+  const name = options.name;
+  if (!name) {
+    return { success: false, error: 'Epic name is required' };
+  }
+
+  const tasks = options.tasks;
+  if (!tasks || !Array.isArray(tasks) || tasks.length === 0) {
+    return { success: false, error: 'Tasks array is required' };
+  }
+
+  const epicsDir = path.join(process.cwd(), '.claude', 'epics');
+  const epicDir = path.join(epicsDir, name);
+  const epicFile = path.join(epicDir, 'epic.md');
+
+  if (!fs.existsSync(epicFile)) {
+    return { success: false, error: `Epic "${name}" not found` };
+  }
+
+  const now = new Date().toISOString();
+  const created = [];
+
+  // Find next task number
+  const existing = fs.readdirSync(epicDir).filter(f =>
+    f.endsWith('.md') && f !== 'epic.md'
+  );
+  let nextNum = 1;
+  for (const f of existing) {
+    const n = parseInt(f.replace('.md', ''));
+    if (n >= nextNum) nextNum = n + 1;
+  }
+
+  for (const task of tasks) {
+    const num = nextNum++;
+    const taskFile = path.join(epicDir, `${num}.md`);
+    const title = task.title || `Task ${num}`;
+    const description = task.description || '';
+
+    const content = `---
+name: "${title.replace(/"/g, '\\"')}"
+status: open
+created: ${now}
+updated: ${now}
+---
+
+${description || `## Goal\n${title}\n\n## Acceptance Criteria\n- [ ] TODO`}
+`;
+
+    fs.writeFileSync(taskFile, content, 'utf8');
+    created.push({ number: num, title, path: taskFile });
+  }
+
+  // Update epic frontmatter with progress
+  const epicContent = fs.readFileSync(epicFile, 'utf8');
+  const updatedContent = epicContent
+    .replace(/updated: .+/, `updated: ${now}`)
+    .replace(/progress: \d+/, `progress: 0`);
+  fs.writeFileSync(epicFile, updatedContent, 'utf8');
+
+  return {
+    success: true,
+    tasks: created,
+    count: created.length,
+    actions: [`Decomposed epic "${name}" into ${created.length} tasks`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute };

--- a/autopm/.claude/providers/local/epic-list.js
+++ b/autopm/.claude/providers/local/epic-list.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 function getEpicsDir() {
   return path.join(process.cwd(), '.claude', 'epics');
@@ -14,6 +14,7 @@ async function execute(options = {}) {
   }
 
   const dirs = fs.readdirSync(epicsDir).filter(d => {
+    if (!/^[a-z0-9-]+$/.test(d)) return false;
     const full = path.join(epicsDir, d);
     return fs.statSync(full).isDirectory();
   }).sort();
@@ -25,15 +26,15 @@ async function execute(options = {}) {
     if (!fs.existsSync(epicFile)) continue;
 
     const content = fs.readFileSync(epicFile, 'utf8');
-    const fm = parseFrontmatter(content);
-    if (!fm) continue;
+    const { frontmatter: fm } = parseFrontmatter(content);
+    if (!fm || Object.keys(fm).length === 0) continue;
 
     if (options.status && fm.status !== options.status) continue;
 
-    // Count task files (numbered .md files, not epic.md)
+    // Count task files (numbered .md files only)
     const epicDirPath = path.join(epicsDir, dir);
     const taskFiles = fs.readdirSync(epicDirPath).filter(f =>
-      f.endsWith('.md') && f !== 'epic.md'
+      /^\d+\.md$/.test(f)
     );
 
     epics.push({

--- a/autopm/.claude/providers/local/epic-list.js
+++ b/autopm/.claude/providers/local/epic-list.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+function getEpicsDir() {
+  return path.join(process.cwd(), '.claude', 'epics');
+}
+
+async function execute(options = {}) {
+  const epicsDir = getEpicsDir();
+
+  if (!fs.existsSync(epicsDir)) {
+    return { success: true, epics: [], count: 0 };
+  }
+
+  const dirs = fs.readdirSync(epicsDir).filter(d => {
+    const full = path.join(epicsDir, d);
+    return fs.statSync(full).isDirectory();
+  }).sort();
+
+  const epics = [];
+
+  for (const dir of dirs) {
+    const epicFile = path.join(epicsDir, dir, 'epic.md');
+    if (!fs.existsSync(epicFile)) continue;
+
+    const content = fs.readFileSync(epicFile, 'utf8');
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    if (options.status && fm.status !== options.status) continue;
+
+    // Count task files (numbered .md files, not epic.md)
+    const epicDirPath = path.join(epicsDir, dir);
+    const taskFiles = fs.readdirSync(epicDirPath).filter(f =>
+      f.endsWith('.md') && f !== 'epic.md'
+    );
+
+    epics.push({
+      name: dir,
+      title: fm.name || dir,
+      status: fm.status || 'backlog',
+      prd: fm.prd || '',
+      progress: parseInt(fm.progress) || 0,
+      taskCount: taskFiles.length,
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      path: epicFile
+    });
+  }
+
+  return { success: true, epics, count: epics.length };
+}
+
+module.exports = { execute, getEpicsDir };

--- a/autopm/.claude/providers/local/epic-show.js
+++ b/autopm/.claude/providers/local/epic-show.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 async function execute(options = {}) {
   const name = options.name;
@@ -8,34 +8,36 @@ async function execute(options = {}) {
     return { success: false, error: 'Epic name is required' };
   }
 
+  const slug = path.basename(name);
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid epic name: "${name}"` };
+  }
+
   const epicsDir = path.join(process.cwd(), '.claude', 'epics');
-  const epicDir = path.join(epicsDir, name);
+  const epicDir = path.join(epicsDir, slug);
   const filepath = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(filepath)) {
-    return { success: false, error: `Epic "${name}" not found` };
+    return { success: false, error: `Epic "${slug}" not found` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');
-  const fm = parseFrontmatter(content);
+  const { frontmatter: fm, body } = parseFrontmatter(content);
 
-  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
-  const body = bodyMatch ? bodyMatch[1].trim() : '';
-
-  // List task files
+  // List task files (numbered .md files only)
   const taskFiles = fs.readdirSync(epicDir).filter(f =>
-    f.endsWith('.md') && f !== 'epic.md'
+    /^\d+\.md$/.test(f)
   ).sort();
 
   const tasks = [];
   for (const file of taskFiles) {
     const taskContent = fs.readFileSync(path.join(epicDir, file), 'utf8');
-    const taskFm = parseFrontmatter(taskContent);
+    const { frontmatter: taskFm } = parseFrontmatter(taskContent);
     const num = parseInt(file.replace('.md', '')) || 0;
     tasks.push({
       number: num,
-      title: taskFm ? (taskFm.name || file) : file,
-      status: taskFm ? (taskFm.status || 'open') : 'open',
+      title: taskFm.name || file,
+      status: taskFm.status || 'open',
       path: path.join(epicDir, file)
     });
   }
@@ -45,16 +47,16 @@ async function execute(options = {}) {
   return {
     success: true,
     epic: {
-      name,
-      title: fm ? (fm.name || name) : name,
-      status: fm ? (fm.status || 'backlog') : 'backlog',
-      prd: fm ? (fm.prd || '') : '',
-      progress: fm ? (parseInt(fm.progress) || 0) : 0,
-      body,
+      name: slug,
+      title: fm.name || slug,
+      status: fm.status || 'backlog',
+      prd: fm.prd || '',
+      progress: parseInt(fm.progress) || 0,
+      body: body.trim(),
       tasks,
       taskCount: tasks.length,
-      createdAt: fm ? (fm.created || '') : '',
-      updatedAt: fm ? (fm.updated || '') : '',
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
       path: filepath
     }
   };

--- a/autopm/.claude/providers/local/epic-show.js
+++ b/autopm/.claude/providers/local/epic-show.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+async function execute(options = {}) {
+  const name = options.name;
+  if (!name) {
+    return { success: false, error: 'Epic name is required' };
+  }
+
+  const epicsDir = path.join(process.cwd(), '.claude', 'epics');
+  const epicDir = path.join(epicsDir, name);
+  const filepath = path.join(epicDir, 'epic.md');
+
+  if (!fs.existsSync(filepath)) {
+    return { success: false, error: `Epic "${name}" not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseFrontmatter(content);
+
+  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  // List task files
+  const taskFiles = fs.readdirSync(epicDir).filter(f =>
+    f.endsWith('.md') && f !== 'epic.md'
+  ).sort();
+
+  const tasks = [];
+  for (const file of taskFiles) {
+    const taskContent = fs.readFileSync(path.join(epicDir, file), 'utf8');
+    const taskFm = parseFrontmatter(taskContent);
+    const num = parseInt(file.replace('.md', '')) || 0;
+    tasks.push({
+      number: num,
+      title: taskFm ? (taskFm.name || file) : file,
+      status: taskFm ? (taskFm.status || 'open') : 'open',
+      path: path.join(epicDir, file)
+    });
+  }
+
+  tasks.sort((a, b) => a.number - b.number);
+
+  return {
+    success: true,
+    epic: {
+      name,
+      title: fm ? (fm.name || name) : name,
+      status: fm ? (fm.status || 'backlog') : 'backlog',
+      prd: fm ? (fm.prd || '') : '',
+      progress: fm ? (parseInt(fm.progress) || 0) : 0,
+      body,
+      tasks,
+      taskCount: tasks.length,
+      createdAt: fm ? (fm.created || '') : '',
+      updatedAt: fm ? (fm.updated || '') : '',
+      path: filepath
+    }
+  };
+}
+
+module.exports = { execute };

--- a/autopm/.claude/providers/local/prd-create.js
+++ b/autopm/.claude/providers/local/prd-create.js
@@ -19,13 +19,25 @@ async function execute(options = {}) {
   const timeline = options.timeline || '';
   const body = options.body || '';
 
+  const slug = slugify(title);
+  if (!slug) {
+    return { success: false, error: 'Could not generate valid slug from title' };
+  }
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid slug generated: "${slug}"` };
+  }
+
   const prdsDir = getPrdsDir();
   if (!fs.existsSync(prdsDir)) {
     fs.mkdirSync(prdsDir, { recursive: true });
   }
 
-  const slug = slugify(title);
   const filepath = path.join(prdsDir, `${slug}.md`);
+
+  if (fs.existsSync(filepath)) {
+    return { success: false, error: `PRD "${slug}" already exists` };
+  }
+
   const now = new Date().toISOString();
 
   const content = `---

--- a/autopm/.claude/providers/local/prd-create.js
+++ b/autopm/.claude/providers/local/prd-create.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+
+function slugify(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50);
+}
+
+function getPrdsDir() {
+  return path.join(process.cwd(), '.claude', 'prds');
+}
+
+async function execute(options = {}) {
+  const title = options.title || options.name;
+  if (!title) {
+    return { success: false, error: 'Title is required' };
+  }
+
+  const priority = options.priority || 'P2';
+  const timeline = options.timeline || '';
+  const body = options.body || '';
+
+  const prdsDir = getPrdsDir();
+  if (!fs.existsSync(prdsDir)) {
+    fs.mkdirSync(prdsDir, { recursive: true });
+  }
+
+  const slug = slugify(title);
+  const filepath = path.join(prdsDir, `${slug}.md`);
+  const now = new Date().toISOString();
+
+  const content = `---
+name: "${title.replace(/"/g, '\\"')}"
+status: draft
+priority: ${priority}
+timeline: "${timeline}"
+created: ${now}
+updated: ${now}
+---
+
+${body || `## Overview\n${title}\n\n## Requirements\n- [ ] TODO`}
+`;
+
+  fs.writeFileSync(filepath, content, 'utf8');
+
+  return {
+    success: true,
+    prd: {
+      name: slug,
+      title,
+      status: 'draft',
+      priority,
+      path: filepath
+    },
+    actions: [`Created PRD: ${slug}.md`],
+    timestamp: now
+  };
+}
+
+module.exports = { execute, slugify, getPrdsDir };

--- a/autopm/.claude/providers/local/prd-list.js
+++ b/autopm/.claude/providers/local/prd-list.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.+)$/);
+    if (kv) {
+      let value = kv[2].trim();
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      fm[kv[1]] = value;
+    }
+  }
+  return fm;
+}
+
+async function execute(options = {}) {
+  const prdsDir = path.join(process.cwd(), '.claude', 'prds');
+
+  if (!fs.existsSync(prdsDir)) {
+    return { success: true, prds: [], count: 0 };
+  }
+
+  const files = fs.readdirSync(prdsDir).filter(f => f.endsWith('.md')).sort();
+  const prds = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(prdsDir, file), 'utf8');
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    if (options.status && fm.status !== options.status) continue;
+
+    prds.push({
+      name: file.replace('.md', ''),
+      title: fm.name || file.replace('.md', ''),
+      status: fm.status || 'draft',
+      priority: fm.priority || 'P2',
+      timeline: fm.timeline || '',
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
+      path: path.join(prdsDir, file)
+    });
+  }
+
+  return { success: true, prds, count: prds.length };
+}
+
+module.exports = { execute, parseFrontmatter };

--- a/autopm/.claude/providers/local/prd-list.js
+++ b/autopm/.claude/providers/local/prd-list.js
@@ -1,23 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-
-function parseFrontmatter(content) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-
-  const fm = {};
-  for (const line of match[1].split('\n')) {
-    const kv = line.match(/^(\w+):\s*(.+)$/);
-    if (kv) {
-      let value = kv[2].trim();
-      if (value.startsWith('"') && value.endsWith('"')) {
-        value = value.slice(1, -1);
-      }
-      fm[kv[1]] = value;
-    }
-  }
-  return fm;
-}
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 async function execute(options = {}) {
   const prdsDir = path.join(process.cwd(), '.claude', 'prds');
@@ -31,8 +14,8 @@ async function execute(options = {}) {
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(prdsDir, file), 'utf8');
-    const fm = parseFrontmatter(content);
-    if (!fm) continue;
+    const { frontmatter: fm } = parseFrontmatter(content);
+    if (!fm || Object.keys(fm).length === 0) continue;
 
     if (options.status && fm.status !== options.status) continue;
 
@@ -51,4 +34,4 @@ async function execute(options = {}) {
   return { success: true, prds, count: prds.length };
 }
 
-module.exports = { execute, parseFrontmatter };
+module.exports = { execute };

--- a/autopm/.claude/providers/local/prd-show.js
+++ b/autopm/.claude/providers/local/prd-show.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter } = require('./prd-list');
+
+async function execute(options = {}) {
+  const name = options.name;
+  if (!name) {
+    return { success: false, error: 'PRD name is required' };
+  }
+
+  const slug = name.replace(/\.md$/, '');
+  const prdsDir = path.join(process.cwd(), '.claude', 'prds');
+  const filepath = path.join(prdsDir, `${slug}.md`);
+
+  if (!fs.existsSync(filepath)) {
+    return { success: false, error: `PRD "${slug}" not found` };
+  }
+
+  const content = fs.readFileSync(filepath, 'utf8');
+  const fm = parseFrontmatter(content);
+
+  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  return {
+    success: true,
+    prd: {
+      name: slug,
+      title: fm ? (fm.name || slug) : slug,
+      status: fm ? (fm.status || 'draft') : 'draft',
+      priority: fm ? (fm.priority || 'P2') : 'P2',
+      timeline: fm ? (fm.timeline || '') : '',
+      body,
+      createdAt: fm ? (fm.created || '') : '',
+      updatedAt: fm ? (fm.updated || '') : '',
+      path: filepath
+    }
+  };
+}
+
+module.exports = { execute };

--- a/autopm/.claude/providers/local/prd-show.js
+++ b/autopm/.claude/providers/local/prd-show.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./prd-list');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 async function execute(options = {}) {
   const name = options.name;
@@ -8,7 +8,11 @@ async function execute(options = {}) {
     return { success: false, error: 'PRD name is required' };
   }
 
-  const slug = name.replace(/\.md$/, '');
+  const slug = path.basename(name.replace(/\.md$/, ''));
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { success: false, error: `Invalid PRD name: "${name}"` };
+  }
+
   const prdsDir = path.join(process.cwd(), '.claude', 'prds');
   const filepath = path.join(prdsDir, `${slug}.md`);
 
@@ -17,22 +21,19 @@ async function execute(options = {}) {
   }
 
   const content = fs.readFileSync(filepath, 'utf8');
-  const fm = parseFrontmatter(content);
-
-  const bodyMatch = content.match(/^---[\s\S]*?---\r?\n?([\s\S]*)$/);
-  const body = bodyMatch ? bodyMatch[1].trim() : '';
+  const { frontmatter: fm, body } = parseFrontmatter(content);
 
   return {
     success: true,
     prd: {
       name: slug,
-      title: fm ? (fm.name || slug) : slug,
-      status: fm ? (fm.status || 'draft') : 'draft',
-      priority: fm ? (fm.priority || 'P2') : 'P2',
-      timeline: fm ? (fm.timeline || '') : '',
-      body,
-      createdAt: fm ? (fm.created || '') : '',
-      updatedAt: fm ? (fm.updated || '') : '',
+      title: fm.name || slug,
+      status: fm.status || 'draft',
+      priority: fm.priority || 'P2',
+      timeline: fm.timeline || '',
+      body: body.trim(),
+      createdAt: fm.created || '',
+      updatedAt: fm.updated || '',
       path: filepath
     }
   };

--- a/test/local-mode/local-prd-epic.test.js
+++ b/test/local-mode/local-prd-epic.test.js
@@ -1,0 +1,348 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const prdCreate = require('../../autopm/.claude/providers/local/prd-create');
+const prdList = require('../../autopm/.claude/providers/local/prd-list');
+const prdShow = require('../../autopm/.claude/providers/local/prd-show');
+const epicCreate = require('../../autopm/.claude/providers/local/epic-create');
+const epicList = require('../../autopm/.claude/providers/local/epic-list');
+const epicShow = require('../../autopm/.claude/providers/local/epic-show');
+const epicDecompose = require('../../autopm/.claude/providers/local/epic-decompose');
+
+let tempDir;
+let originalCwd;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'local-prd-epic-'));
+  fs.mkdirSync(path.join(tempDir, '.claude', 'prds'), { recursive: true });
+  fs.mkdirSync(path.join(tempDir, '.claude', 'epics'), { recursive: true });
+  originalCwd = process.cwd();
+  process.chdir(tempDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('prd-create', () => {
+  test('creates file with correct frontmatter', async () => {
+    const result = await prdCreate.execute({ title: 'User Authentication', priority: 'P1', timeline: 'Q2 2026' });
+
+    expect(result.success).toBe(true);
+    expect(result.prd.name).toBe('user-authentication');
+    expect(result.prd.status).toBe('draft');
+    expect(result.prd.priority).toBe('P1');
+
+    const content = fs.readFileSync(result.prd.path, 'utf8');
+    expect(content).toContain('name: "User Authentication"');
+    expect(content).toContain('status: draft');
+    expect(content).toContain('priority: P1');
+    expect(content).toContain('timeline: "Q2 2026"');
+  });
+
+  test('generates slug from title', async () => {
+    const result = await prdCreate.execute({ title: 'Multi-Tenant Dashboard & Reports' });
+    expect(result.prd.name).toBe('multi-tenant-dashboard-reports');
+    expect(path.basename(result.prd.path)).toBe('multi-tenant-dashboard-reports.md');
+  });
+
+  test('uses default priority P2', async () => {
+    const result = await prdCreate.execute({ title: 'Simple Feature' });
+    expect(result.prd.priority).toBe('P2');
+
+    const content = fs.readFileSync(result.prd.path, 'utf8');
+    expect(content).toContain('priority: P2');
+  });
+
+  test('creates prds dir if missing', async () => {
+    fs.rmSync(path.join(tempDir, '.claude', 'prds'), { recursive: true });
+    const result = await prdCreate.execute({ title: 'Test' });
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(result.prd.path)).toBe(true);
+  });
+
+  test('returns error without title', async () => {
+    const result = await prdCreate.execute({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+describe('prd-list', () => {
+  beforeEach(async () => {
+    await prdCreate.execute({ title: 'Auth System', priority: 'P1' });
+    await prdCreate.execute({ title: 'Dashboard' });
+  });
+
+  test('returns all PRDs', async () => {
+    const result = await prdList.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(2);
+    expect(result.prds[0].name).toBe('auth-system');
+    expect(result.prds[1].name).toBe('dashboard');
+  });
+
+  test('filters by status', async () => {
+    const result = await prdList.execute({ status: 'draft' });
+    expect(result.count).toBe(2);
+
+    const none = await prdList.execute({ status: 'complete' });
+    expect(none.count).toBe(0);
+  });
+
+  test('returns empty for missing dir', async () => {
+    fs.rmSync(path.join(tempDir, '.claude', 'prds'), { recursive: true });
+    const result = await prdList.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(0);
+  });
+});
+
+describe('prd-show', () => {
+  test('returns PRD by name', async () => {
+    await prdCreate.execute({ title: 'Auth System', body: '## Custom Body\nDetails here' });
+    const result = await prdShow.execute({ name: 'auth-system' });
+
+    expect(result.success).toBe(true);
+    expect(result.prd.title).toBe('Auth System');
+    expect(result.prd.status).toBe('draft');
+    expect(result.prd.body).toContain('Custom Body');
+  });
+
+  test('handles not-found', async () => {
+    const result = await prdShow.execute({ name: 'nonexistent' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  test('returns error without name', async () => {
+    const result = await prdShow.execute({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+describe('epic-create', () => {
+  test('creates dir and epic.md with correct frontmatter', async () => {
+    const result = await epicCreate.execute({ title: 'User Authentication', prd: 'auth-system' });
+
+    expect(result.success).toBe(true);
+    expect(result.epic.name).toBe('user-authentication');
+    expect(result.epic.status).toBe('backlog');
+
+    const content = fs.readFileSync(result.epic.path, 'utf8');
+    expect(content).toContain('name: "User Authentication"');
+    expect(content).toContain('status: backlog');
+    expect(content).toContain('prd: "auth-system"');
+    expect(content).toContain('progress: 0');
+  });
+
+  test('generates slug from title', async () => {
+    const result = await epicCreate.execute({ title: 'API Gateway & Auth' });
+    expect(result.epic.name).toBe('api-gateway-auth');
+  });
+
+  test('returns error without title', async () => {
+    const result = await epicCreate.execute({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+describe('epic-list', () => {
+  beforeEach(async () => {
+    await epicCreate.execute({ title: 'Auth Epic' });
+    await epicCreate.execute({ title: 'Dashboard Epic' });
+  });
+
+  test('returns all epics', async () => {
+    const result = await epicList.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(2);
+  });
+
+  test('filters by status', async () => {
+    const result = await epicList.execute({ status: 'backlog' });
+    expect(result.count).toBe(2);
+
+    const none = await epicList.execute({ status: 'completed' });
+    expect(none.count).toBe(0);
+  });
+
+  test('includes task count', async () => {
+    await epicDecompose.execute({
+      name: 'auth-epic',
+      tasks: [{ title: 'Task 1' }, { title: 'Task 2' }]
+    });
+
+    const result = await epicList.execute();
+    const authEpic = result.epics.find(e => e.name === 'auth-epic');
+    expect(authEpic.taskCount).toBe(2);
+  });
+
+  test('returns empty for missing dir', async () => {
+    fs.rmSync(path.join(tempDir, '.claude', 'epics'), { recursive: true });
+    const result = await epicList.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(0);
+  });
+});
+
+describe('epic-show', () => {
+  test('returns epic with task count', async () => {
+    await epicCreate.execute({ title: 'Auth Epic', body: '## Epic Details\nContent' });
+    await epicDecompose.execute({
+      name: 'auth-epic',
+      tasks: [{ title: 'Login', description: 'Implement login' }]
+    });
+
+    const result = await epicShow.execute({ name: 'auth-epic' });
+
+    expect(result.success).toBe(true);
+    expect(result.epic.title).toBe('Auth Epic');
+    expect(result.epic.taskCount).toBe(1);
+    expect(result.epic.tasks[0].title).toBe('Login');
+    expect(result.epic.tasks[0].status).toBe('open');
+    expect(result.epic.body).toContain('Epic Details');
+  });
+
+  test('handles not-found', async () => {
+    const result = await epicShow.execute({ name: 'nonexistent' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  test('returns error without name', async () => {
+    const result = await epicShow.execute({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+describe('epic-decompose', () => {
+  beforeEach(async () => {
+    await epicCreate.execute({ title: 'Auth Epic' });
+  });
+
+  test('creates task files', async () => {
+    const result = await epicDecompose.execute({
+      name: 'auth-epic',
+      tasks: [
+        { title: 'Setup DB', description: 'Create tables' },
+        { title: 'Build API', description: 'REST endpoints' }
+      ]
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(2);
+    expect(result.tasks[0].number).toBe(1);
+    expect(result.tasks[1].number).toBe(2);
+
+    const content1 = fs.readFileSync(result.tasks[0].path, 'utf8');
+    expect(content1).toContain('name: "Setup DB"');
+    expect(content1).toContain('status: open');
+    expect(content1).toContain('Create tables');
+  });
+
+  test('auto-increments task numbers', async () => {
+    await epicDecompose.execute({
+      name: 'auth-epic',
+      tasks: [{ title: 'First' }]
+    });
+    const result = await epicDecompose.execute({
+      name: 'auth-epic',
+      tasks: [{ title: 'Second' }]
+    });
+
+    expect(result.tasks[0].number).toBe(2);
+  });
+
+  test('updates epic updated timestamp', async () => {
+    const before = fs.readFileSync(
+      path.join(tempDir, '.claude', 'epics', 'auth-epic', 'epic.md'), 'utf8'
+    );
+    const beforeUpdated = before.match(/updated: (.+)/)[1];
+
+    // Small delay to ensure different timestamp
+    await new Promise(r => setTimeout(r, 10));
+
+    await epicDecompose.execute({
+      name: 'auth-epic',
+      tasks: [{ title: 'Task' }]
+    });
+
+    const after = fs.readFileSync(
+      path.join(tempDir, '.claude', 'epics', 'auth-epic', 'epic.md'), 'utf8'
+    );
+    const afterUpdated = after.match(/updated: (.+)/)[1];
+
+    expect(afterUpdated).not.toBe(beforeUpdated);
+  });
+
+  test('returns error for missing epic', async () => {
+    const result = await epicDecompose.execute({
+      name: 'nonexistent',
+      tasks: [{ title: 'Task' }]
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  test('returns error without tasks', async () => {
+    const result = await epicDecompose.execute({ name: 'auth-epic' });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+describe('Full Lifecycle', () => {
+  test('prd-create -> epic-create -> epic-decompose -> epic-show', async () => {
+    // Create PRD
+    const prd = await prdCreate.execute({ title: 'Auth System', priority: 'P1' });
+    expect(prd.success).toBe(true);
+
+    // Verify PRD in list
+    const prdListed = await prdList.execute();
+    expect(prdListed.count).toBe(1);
+
+    // Show PRD
+    const prdShown = await prdShow.execute({ name: 'auth-system' });
+    expect(prdShown.prd.status).toBe('draft');
+
+    // Create Epic linked to PRD
+    const epic = await epicCreate.execute({ title: 'Auth Implementation', prd: 'auth-system' });
+    expect(epic.success).toBe(true);
+
+    // Decompose into tasks
+    const decomposed = await epicDecompose.execute({
+      name: 'auth-implementation',
+      tasks: [
+        { title: 'Setup DB schema', description: 'Create user tables' },
+        { title: 'Build login API', description: 'JWT auth endpoint' },
+        { title: 'Add tests', description: 'Integration tests' }
+      ]
+    });
+    expect(decomposed.count).toBe(3);
+
+    // Show epic with tasks
+    const shown = await epicShow.execute({ name: 'auth-implementation' });
+    expect(shown.epic.taskCount).toBe(3);
+    expect(shown.epic.tasks[0].title).toBe('Setup DB schema');
+    expect(shown.epic.tasks[1].title).toBe('Build login API');
+    expect(shown.epic.tasks[2].title).toBe('Add tests');
+
+    // List epics
+    const epics = await epicList.execute();
+    expect(epics.count).toBe(1);
+    expect(epics.epics[0].taskCount).toBe(3);
+  });
+});


### PR DESCRIPTION
## 🎯 Goal
Complete local PM provider with PRD and epic CRUD — users on lite scenario get full project management without GitHub/Azure.

## 📁 New Files (7 providers + 1 test)
- \`providers/local/prd-create.js\` — create PRD markdown
- \`providers/local/prd-list.js\` — list/filter PRDs
- \`providers/local/prd-show.js\` — display PRD
- \`providers/local/epic-create.js\` — create epic dir + epic.md
- \`providers/local/epic-list.js\` — list epics with task counts
- \`providers/local/epic-show.js\` — display epic with tasks
- \`providers/local/epic-decompose.js\` — create task files
- \`test/local-mode/local-prd-epic.test.js\` — 27 tests

## ✅ Results
- 27 new tests passing
- 64/64 quick suite passing
- Full lifecycle tested: prd-create → epic-create → decompose → show

Closes #463