### PR TITLE
[fix][install] Include PM slash commands in framework install

### DIFF
--- a/autopm/.claude/commands/pm:blocked.md
+++ b/autopm/.claude/commands/pm:blocked.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/blocked.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:clean.md
+++ b/autopm/.claude/commands/pm:clean.md
@@ -1,0 +1,119 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# Clean
+
+Clean up completed work and archive old epics.
+
+## Usage
+```
+/pm:clean [--dry-run]
+```
+
+Options:
+- `--dry-run` - Show what would be cleaned without doing it
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Identify Completed Epics
+
+Find epics with:
+- `status: completed` in frontmatter
+- All tasks closed
+- Last update > 30 days ago
+
+### 2. Identify Stale Work
+
+Find:
+- Progress files for closed issues
+- Update directories for completed work
+- Orphaned task files (epic deleted)
+- Empty directories
+
+### 3. Show Cleanup Plan
+
+```
+🧹 Cleanup Plan
+
+Completed Epics to Archive:
+  {epic_name} - Completed {days} days ago
+  {epic_name} - Completed {days} days ago
+  
+Stale Progress to Remove:
+  {count} progress files for closed issues
+  
+Empty Directories:
+  {list_of_empty_dirs}
+  
+Space to Recover: ~{size}KB
+
+{If --dry-run}: This is a dry run. No changes made.
+{Otherwise}: Proceed with cleanup? (yes/no)
+```
+
+### 4. Execute Cleanup
+
+If user confirms:
+
+**Archive Epics:**
+```bash
+mkdir -p .claude/epics/.archived
+mv .claude/epics/{completed_epic} .claude/epics/.archived/
+```
+
+**Remove Stale Files:**
+- Delete progress files for closed issues > 30 days
+- Remove empty update directories
+- Clean up orphaned files
+
+**Create Archive Log:**
+Create `.claude/epics/.archived/archive-log.md`:
+```markdown
+# Archive Log
+
+## {current_date}
+- Archived: {epic_name} (completed {date})
+- Removed: {count} stale progress files
+- Cleaned: {count} empty directories
+```
+
+### 5. Output
+
+```
+✅ Cleanup Complete
+
+Archived:
+  {count} completed epics
+  
+Removed:
+  {count} stale files
+  {count} empty directories
+  
+Space recovered: {size}KB
+
+System is clean and organized.
+```
+
+## Important Notes
+
+Always offer --dry-run to preview changes.
+Never delete PRDs or incomplete work.
+Keep archive log for history.

--- a/autopm/.claude/commands/pm:context-create.md
+++ b/autopm/.claude/commands/pm:context-create.md
@@ -1,0 +1,136 @@
+---
+allowed-tools: Bash, Read, Write, Glob
+---
+
+# Context Create
+
+Initialize project context documentation for AI agent memory.
+
+## Required Documentation Access
+
+**MANDATORY:** Before creating context, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/documentation/project-context` - Project documentation standards
+- `mcp://context7/agile/project-setup` - Project initialization best practices
+- `mcp://context7/knowledge-management/technical-documentation` - Documentation organization patterns
+
+**Why This is Required:**
+- Ensures context follows industry standards
+- Provides templates aligned with best practices
+- Establishes effective knowledge management patterns
+
+## Instructions
+
+Create comprehensive project context in `.claude/context/` directory.
+
+### 1. Check if context already exists
+
+```bash
+if [ -d ".claude/context" ]; then
+  echo "⚠️  Context already exists. Use /pm:context-update to modify."
+  exit 1
+fi
+```
+
+### 2. Create context directory structure
+
+```bash
+mkdir -p .claude/context
+```
+
+### 3. Copy and customize templates
+
+**Read templates from AutoPM installation:**
+- `.claude/templates/context-templates/project-brief.md.template`
+- `.claude/templates/context-templates/tech-context.md.template`
+- `.claude/templates/context-templates/progress.md.template`
+- `.claude/templates/context-templates/project-structure.md.template`
+
+### 4. Auto-populate with project information
+
+**Analyze project and pre-fill templates:**
+
+1. **Read package.json** for tech stack:
+   - Extract dependencies and devDependencies
+   - Determine Node.js version from engines
+   - Identify testing framework (Jest, Mocha, etc.)
+   - Detect package manager from lock files
+
+2. **Read README.md** for project description:
+   - Extract project name and description
+   - Identify key features and objectives
+   - Find usage examples
+
+3. **Detect directory structure:**
+   - Scan top-level directories
+   - Identify common patterns (src/, test/, docs/, etc.)
+   - Map key configuration files
+
+4. **Initialize progress:**
+   - Set initial phase as "Setup" or "Development"
+   - Mark context creation as first completed task
+   - Set progress to appropriate starting percentage
+
+### 5. Create context README
+
+Write `.claude/context/README.md`:
+
+```markdown
+# Project Context
+
+This directory maintains comprehensive project information for AI agents.
+
+## Files
+- **project-brief.md**: Project scope and objectives
+- **tech-context.md**: Technology stack and dependencies
+- **progress.md**: Current status and next steps
+- **project-structure.md**: Directory layout and key files
+
+## Usage
+- `/pm:context-prime`: Load context for new session
+- `/pm:context-update`: Update after changes
+- `/pm:context`: View current context
+
+## Maintenance
+Keep these files updated as the project evolves. Run `/pm:context-update` after:
+- Adding new dependencies
+- Completing major tasks
+- Changing project structure
+- Updating technical stack
+```
+
+### 6. Write populated templates
+
+Create the following files in `.claude/context/`:
+- `project-brief.md` (populated from README and package.json)
+- `tech-context.md` (populated from package.json and file detection)
+- `progress.md` (initialized with setup phase)
+- `project-structure.md` (populated from directory scan)
+
+### 7. Confirm creation
+
+Display success message:
+
+```
+✅ Context created in .claude/context/
+
+📝 Files created:
+   - project-brief.md (auto-populated from README)
+   - tech-context.md (auto-populated from package.json)
+   - progress.md (initialized)
+   - project-structure.md (auto-populated from directory scan)
+   - README.md (usage guide)
+
+💡 Next steps:
+   1. Review and customize the context files
+   2. Run /pm:context-prime to load context into session
+   3. Update regularly with /pm:context-update
+```
+
+## Output Format
+
+Return a structured summary of:
+- Files created with auto-populated content preview
+- Any information that couldn't be auto-detected
+- Recommendations for manual customization

--- a/autopm/.claude/commands/pm:context-prime.md
+++ b/autopm/.claude/commands/pm:context-prime.md
@@ -1,0 +1,170 @@
+---
+allowed-tools: Read, Bash
+---
+
+# Context Prime
+
+Load project context into current AI session for better understanding and continuity.
+
+## Required Documentation Access
+
+**MANDATORY:** Before priming context, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/knowledge-management/context-loading` - Context loading patterns
+- `mcp://context7/ai/prompt-engineering` - Effective context management for AI
+
+**Why This is Required:**
+- Ensures optimal context loading for AI comprehension
+- Provides strategies for maintaining session continuity
+
+## Instructions
+
+Load comprehensive project context into the current AI session.
+
+### 1. Verify context exists
+
+```bash
+if [ ! -d ".claude/context" ]; then
+  echo "❌ Context not found. Run /pm:context-create first."
+  exit 1
+fi
+```
+
+### 2. Read all context files
+
+Read in order:
+1. `.claude/context/project-brief.md` - Project overview and objectives
+2. `.claude/context/tech-context.md` - Technical stack and dependencies
+3. `.claude/context/project-structure.md` - Directory layout and organization
+4. `.claude/context/progress.md` - Current status and next steps
+
+### 3. Process and internalize context
+
+**Parse key information:**
+
+From **project-brief.md**:
+- Project name and description
+- Primary objectives and goals
+- Target users and stakeholders
+- Key constraints and limitations
+- Success criteria
+
+From **tech-context.md**:
+- Technology stack (frontend, backend, database, infrastructure)
+- Development environment (Node.js version, package manager, testing framework)
+- Key dependencies and their purposes
+- Architecture patterns in use
+- Development practices
+
+From **project-structure.md**:
+- Directory layout and organization
+- Key files and their purposes
+- Module structure
+- Configuration files
+
+From **progress.md**:
+- Current phase and progress percentage
+- Completed tasks
+- In-progress tasks
+- Next steps
+- Any blockers
+
+### 4. Display loaded context summary
+
+Present a comprehensive summary:
+
+```
+📋 Project Context Loaded
+
+══════════════════════════════════════════════════════════════════
+
+PROJECT: [Project Name]
+PHASE: [Current Phase] | PROGRESS: [X]%
+LAST UPDATED: [Date from progress.md]
+
+══════════════════════════════════════════════════════════════════
+
+🎯 OBJECTIVES
+  - [Primary goal]
+  - [Secondary goal]
+  - [Tertiary goal]
+
+🔧 TECH STACK
+  - Frontend: [Technologies]
+  - Backend: [Technologies]
+  - Database: [Database]
+  - Testing: [Framework]
+
+📁 STRUCTURE
+  [Brief structure overview]
+
+✅ COMPLETED
+  - [Recent completed task 1]
+  - [Recent completed task 2]
+
+🚧 IN PROGRESS
+  - [Current task 1]
+  - [Current task 2]
+
+⏭️  NEXT STEPS
+  1. [Next action 1]
+  2. [Next action 2]
+
+⚠️  BLOCKERS
+  - [Blocker 1, if any]
+
+══════════════════════════════════════════════════════════════════
+
+✅ Context loaded. AI agent now has project memory.
+
+💡 TIP: Run /pm:context-update after significant changes to keep context current.
+```
+
+### 5. Internal context retention
+
+**CRITICAL:** After displaying the summary, the AI agent should:
+
+1. **Retain project identity**: Remember project name, goals, and constraints
+2. **Understand technical environment**: Keep tech stack and dependencies in mind
+3. **Maintain progress awareness**: Know what's done, what's in progress, what's next
+4. **Respect project structure**: Work within established organization patterns
+5. **Align with practices**: Follow development practices outlined in context
+
+This context should guide all subsequent interactions in the session:
+- Suggestions should align with project objectives
+- Recommendations should fit the tech stack
+- Changes should consider current progress
+- Code should match project structure
+
+### 6. Confirmation
+
+Return structured confirmation:
+
+```json
+{
+  "status": "loaded",
+  "project": "[Project Name]",
+  "phase": "[Current Phase]",
+  "progress": "[X]%",
+  "filesRead": [
+    "project-brief.md",
+    "tech-context.md",
+    "project-structure.md",
+    "progress.md"
+  ],
+  "keyTakeaways": [
+    "[Important point 1]",
+    "[Important point 2]",
+    "[Important point 3]"
+  ]
+}
+```
+
+## Output Format
+
+Return:
+- Formatted context summary (as shown above)
+- Key information highlighted
+- Current focus areas
+- Recommendations based on loaded context

--- a/autopm/.claude/commands/pm:context-update.md
+++ b/autopm/.claude/commands/pm:context-update.md
@@ -1,0 +1,292 @@
+---
+allowed-tools: Read, Write, Edit, Bash, Glob
+---
+
+# Context Update
+
+Update project context after significant changes to maintain AI agent memory accuracy.
+
+## Required Documentation Access
+
+**MANDATORY:** Before updating context, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/knowledge-management/documentation-maintenance` - Documentation update strategies
+- `mcp://context7/agile/progress-tracking` - Progress tracking best practices
+- `mcp://context7/project-management/status-reporting` - Status update patterns
+
+**Why This is Required:**
+- Ensures context updates follow documentation best practices
+- Maintains consistency with agile progress tracking
+- Provides effective status reporting patterns
+
+## Instructions
+
+Intelligently update project context files based on detected changes.
+
+### 1. Verify context exists
+
+```bash
+if [ ! -d ".claude/context" ]; then
+  echo "❌ Context not found. Run /pm:context-create first."
+  exit 1
+fi
+```
+
+### 2. Detect changes since last update
+
+**Check multiple sources for changes:**
+
+1. **package.json changes:**
+   - Compare current dependencies with tech-context.md
+   - Detect new dependencies added
+   - Identify version updates
+   - Note removed dependencies
+
+2. **Directory structure changes:**
+   - Scan current directory structure
+   - Compare with project-structure.md
+   - Detect new directories
+   - Note removed directories
+
+3. **Git history (if available):**
+   - Check recent commits since last context update
+   - Extract meaningful changes from commit messages
+   - Identify completed features/tasks
+
+4. **README.md changes:**
+   - Compare current README with project-brief.md
+   - Detect updated project description
+   - Note new features or objectives
+
+### 3. Update relevant files
+
+**Update tech-context.md if tech stack changed:**
+
+If new dependencies detected:
+```markdown
+## Dependencies
+[Existing dependencies]
+
+**Recently Added:**
+- [new-package-name]: [Purpose/description]
+  Added: [Date]
+```
+
+If versions changed:
+```markdown
+## Development Environment
+- Node.js: [new version] (updated from [old version])
+```
+
+**Update progress.md for project progress:**
+
+Always update:
+1. **Last Updated timestamp** to current date
+2. Move completed items from "In Progress" to "Completed"
+3. Update progress percentage based on completed tasks
+4. Add new tasks to "In Progress" or "Next Steps"
+5. Update or remove blockers
+
+Example update:
+```markdown
+## Current Status
+- Phase: [Current phase]
+- Progress: [Updated]%
+- Last Updated: [Current date]
+
+## Completed
+- [x] [Previously in-progress task now completed]
+- [x] [Another completed task]
+
+## In Progress
+- [ ] [New current task]
+- [ ] [Another current task]
+
+## Next Steps
+1. [Updated next action]
+2. [New next action]
+
+## Blockers
+- [Updated or new blocker, or note "None" if resolved]
+
+## Recent Updates
+- [Date]: [Description of recent change]
+- [Date]: [Description of recent change]
+```
+
+**Update project-structure.md if structure changed:**
+
+If new directories detected:
+```markdown
+## Directory Layout
+```
+project/
+├── src/           # Source code
+├── test/          # Tests
+├── .claude/       # AutoPM configuration
+├── [new-dir]/     # [Purpose of new directory]
+└── docs/          # Documentation
+```
+```
+
+If new key files added:
+```markdown
+## Key Files
+- **[new-file]**: [Purpose and description]
+```
+
+**Update project-brief.md if scope changed:**
+
+Only if README.md or objectives significantly changed:
+- Update project description
+- Add new objectives
+- Update success criteria
+- Note scope expansions or reductions
+
+### 4. Generate change summary
+
+Track what was updated:
+```json
+{
+  "updatedFiles": [],
+  "changes": {
+    "techContext": {
+      "addedDependencies": [],
+      "updatedVersions": [],
+      "removedDependencies": []
+    },
+    "progress": {
+      "completedTasks": [],
+      "newTasks": [],
+      "progressIncrease": "X%",
+      "resolvedBlockers": []
+    },
+    "structure": {
+      "newDirectories": [],
+      "newFiles": []
+    },
+    "brief": {
+      "updated": false,
+      "changes": []
+    }
+  }
+}
+```
+
+### 5. Smart update logic
+
+**Only update files with actual changes:**
+
+```javascript
+// Pseudocode for update logic
+if (techStackChanged) {
+  updateTechContext();
+  updatedFiles.push("tech-context.md");
+}
+
+if (progressChanged || tasksCompleted) {
+  updateProgress();
+  updatedFiles.push("progress.md");
+}
+
+if (structureChanged) {
+  updateProjectStructure();
+  updatedFiles.push("project-structure.md");
+}
+
+if (scopeChanged) {
+  updateProjectBrief();
+  updatedFiles.push("project-brief.md");
+}
+
+// Always update progress.md with "Last Updated" timestamp
+if (!updatedFiles.includes("progress.md")) {
+  updateProgressTimestamp();
+  updatedFiles.push("progress.md");
+}
+```
+
+### 6. Confirm updates
+
+Display comprehensive update summary:
+
+```
+✅ Context updated
+
+══════════════════════════════════════════════════════════════════
+
+📝 UPDATED FILES
+  - tech-context.md
+  - progress.md
+  - project-structure.md
+
+══════════════════════════════════════════════════════════════════
+
+🔧 TECH CONTEXT CHANGES
+  Added Dependencies:
+  - [new-package]: [Purpose]
+
+  Updated Versions:
+  - Node.js: [old] → [new]
+
+══════════════════════════════════════════════════════════════════
+
+📊 PROGRESS UPDATES
+  Completed Tasks:
+  ✅ [Task 1]
+  ✅ [Task 2]
+
+  Progress: [Old]% → [New]%
+  Phase: [Phase name]
+
+  Next Steps:
+  1. [Next action]
+  2. [Next action]
+
+══════════════════════════════════════════════════════════════════
+
+📁 STRUCTURE CHANGES
+  New Directories:
+  + [new-dir]/  # [Purpose]
+
+  New Key Files:
+  + [new-file]  # [Purpose]
+
+══════════════════════════════════════════════════════════════════
+
+💡 RECOMMENDATIONS
+  - Run /pm:context-prime to reload updated context
+  - Consider updating project-brief.md if objectives changed
+  - [Other relevant recommendations]
+
+══════════════════════════════════════════════════════════════════
+```
+
+### 7. Handle no-change scenario
+
+If no changes detected:
+
+```
+ℹ️  No significant changes detected since last update
+
+Context is up-to-date:
+- Tech stack: No changes
+- Progress: No new completions
+- Structure: No changes
+- Last updated: [Date from progress.md]
+
+💡 Context will be updated when changes are detected:
+  - New dependencies in package.json
+  - New directories or files
+  - Changes to README.md
+  - Git commits (if available)
+```
+
+## Output Format
+
+Return:
+- List of updated files
+- Detailed change summary for each file
+- Recommendations based on changes
+- Prompt to reload context if significant updates made

--- a/autopm/.claude/commands/pm:context.md
+++ b/autopm/.claude/commands/pm:context.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/context.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:epic-decompose.md
+++ b/autopm/.claude/commands/pm:epic-decompose.md
@@ -1,0 +1,540 @@
+---
+allowed-tools: Bash, Read, Write, LS, Task
+---
+
+# Epic Decompose
+
+Break epic into concrete, actionable tasks.
+
+**⚠️ IMPORTANT**: This is a Claude Code command file, not a standalone script.
+- Execute via Claude Code as: `/pm:epic-decompose <feature_name>`
+- Do NOT run as: `node .claude/scripts/pm/epic-decompose.js`
+- This command has no standalone script equivalent
+
+## Usage
+
+**Single Epic:**
+```bash
+/pm:epic-decompose <feature_name> [--local]
+```
+
+**Multi-Epic (decomposes ALL epics at once):**
+```bash
+/pm:epic-decompose <feature_name> [--local]
+# Example: /pm:epic-decompose ecommerce-platform --local
+# This will automatically decompose ALL epics:
+#   - 01-infrastructure
+#   - 02-auth-backend
+#   - 03-product-api
+#   - etc.
+```
+
+**Single Epic from Multi-Epic structure:**
+```bash
+/pm:epic-decompose <feature_name>/<epic_folder> [--local]
+# Example: /pm:epic-decompose ecommerce-platform/01-infrastructure --local
+```
+
+## Flags
+
+`--local`, `-l`
+: Use local mode (offline workflow)
+: Creates task files in `.claude/epics/` directory structure
+: No GitHub/Azure synchronization
+: Task files remain local-only until manually synced
+: Ideal for offline work or projects without remote tracking
+
+Example:
+```
+/pm:epic-decompose user-authentication --local
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before decomposing epics, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-decomposition` - Epic breakdown best practices
+- `mcp://context7/agile/task-sizing` - Task estimation and sizing
+- `mcp://context7/agile/user-stories` - User story formats (INVEST criteria)
+- `mcp://context7/project-management/task-breakdown` - Work breakdown structure
+
+**Why This is Required:**
+- Ensures tasks follow industry-standard decomposition patterns
+- Applies current best practices for task sizing and dependencies
+- Validates task structure against proven methodologies
+- Prevents common anti-patterns in task breakdown
+
+## Required Rules
+
+**IMPORTANT:** Before executing this command, read and follow:
+- `.claude/rules/datetime.md` - For getting real current date/time
+
+## Agent Selection Strategy
+
+Based on the PRD content and technical requirements, automatically determine which specialized agents should be assigned to tasks.
+
+### Step 1: Analyze PRD for Technology Stack
+
+Read `.claude/prds/$ARGUMENTS.md` and identify:
+- **Programming languages** mentioned (Python, JavaScript/TypeScript, Go, Bash, etc.)
+- **Frameworks** required (React, FastAPI, Next.js, Express, etc.)
+- **Databases** needed (PostgreSQL, MongoDB, Redis, etc.)
+- **Cloud platforms** (AWS, Azure, GCP)
+- **Infrastructure** tools (Docker, Kubernetes, Terraform)
+- **Testing** requirements (unit, integration, E2E)
+- **CI/CD** platforms (GitHub Actions, Azure DevOps, GitLab CI)
+
+### Step 2: Map Technologies to Specialized Agents
+
+**Programming Languages**:
+- Python → `.claude/agents/languages/python-backend-engineer.md`
+- JavaScript/TypeScript/Node.js → `.claude/agents/languages/nodejs-backend-engineer.md`
+- React → `.claude/agents/frontend/react-frontend-engineer.md`
+- Bash/Shell scripting → `.claude/agents/languages/bash-scripting-expert.md`
+
+**Databases**:
+- PostgreSQL → `.claude/agents/databases/postgresql-expert.md`
+- MongoDB → `.claude/agents/databases/mongodb-expert.md`
+- Redis → `.claude/agents/databases/redis-expert.md`
+- Cosmos DB → `.claude/agents/databases/cosmosdb-expert.md`
+
+**Cloud Platforms**:
+- AWS → `.claude/agents/cloud/aws-cloud-architect.md`
+- Azure → `.claude/agents/cloud/azure-cloud-architect.md`
+- GCP → `.claude/agents/cloud/gcp-cloud-architect.md`
+
+**Infrastructure & Containers**:
+- Docker → `.claude/agents/containers/docker-containerization-expert.md`
+- Kubernetes → `.claude/agents/orchestration/kubernetes-orchestrator.md`
+- Terraform → `.claude/agents/infrastructure/terraform-infrastructure-expert.md`
+
+**Testing**:
+- Unit/Integration tests → `.claude/agents/core/test-runner.md`
+- Frontend E2E testing → `.claude/agents/testing/frontend-testing-engineer.md`
+- E2E automation → `.claude/agents/testing/e2e-test-engineer.md`
+
+**DevOps & CI/CD**:
+- GitHub operations → `.claude/agents/devops/github-operations-specialist.md`
+- Azure DevOps → `.claude/agents/devops/azure-devops-specialist.md`
+- Observability → `.claude/agents/devops/observability-engineer.md`
+
+### Step 3: Document Agent Assignments in Epic Frontmatter
+
+Add `required_agents` array to epic.md frontmatter:
+
+```yaml
+---
+name: user-authentication
+prd: user-authentication
+status: backlog
+created: 2025-12-17T10:00:00Z
+updated: 2025-12-17T10:00:00Z
+required_agents:
+  - path: .claude/agents/languages/python-backend-engineer.md
+    role: API implementation
+    tasks: [001, 002, 003]
+  - path: .claude/agents/databases/postgresql-expert.md
+    role: Database schema and migrations
+    tasks: [004, 005]
+  - path: .claude/agents/testing/frontend-testing-engineer.md
+    role: Test suite development
+    tasks: [006, 007]
+  - path: .claude/agents/devops/github-operations-specialist.md
+    role: CI/CD pipeline setup
+    tasks: [008]
+---
+```
+
+### Step 4: Assign Agents to Individual Tasks
+
+Each task file should include `assigned_agent` in frontmatter:
+
+```yaml
+---
+name: Implement JWT authentication endpoints
+status: open
+created: 2025-12-17T10:00:00Z
+updated: 2025-12-17T10:00:00Z
+assigned_agent: .claude/agents/languages/python-backend-engineer.md
+agent_context:
+  framework: fastapi
+  auth_method: jwt
+  libraries: [pyjwt, passlib]
+github: [Will be updated when synced to GitHub]
+depends_on: [004]  # Depends on user schema
+parallel: true
+conflicts_with: []
+---
+```
+
+**Benefits of Agent Assignment**:
+- ✅ Automatic selection of specialized agents based on technology
+- ✅ Clear agent responsibilities per task
+- ✅ Easier task assignment when starting work
+- ✅ Better parallel execution planning with appropriate agents
+- ✅ Consistent expertise application across similar tasks
+
+## Preflight Checklist
+
+Before proceeding, complete these validation steps.
+Do not bother the user with preflight checks progress ("I'm not going to ..."). Just do them and move on.
+
+1. **Verify epic exists:**
+   - Check if `.claude/epics/$ARGUMENTS` directory exists
+   - Check for either:
+     a) Single epic: `.claude/epics/$ARGUMENTS/epic.md` exists
+     b) Multiple epics: Subdirectories like `.claude/epics/$ARGUMENTS/01-infrastructure/epic.md`
+   - If neither found, tell user: "❌ Epic not found: $ARGUMENTS. First create it with: /pm:prd-parse $ARGUMENTS or /pm:epic-split $ARGUMENTS"
+   - Stop execution if no epics found
+
+2. **Detect epic structure:**
+   - If `.claude/epics/$ARGUMENTS/epic.md` exists → Single epic mode
+   - If subdirectories with epic.md files exist → Multi-epic mode
+   - Store the mode for later processing
+
+3. **Check for existing tasks:**
+   - For single epic: Check `.claude/epics/$ARGUMENTS/` for numbered task files
+   - For multi-epic: Check each subdirectory for numbered task files
+   - If tasks exist, list them and ask: "⚠️ Found {count} existing tasks. Delete and recreate all tasks? (yes/no)"
+   - Only proceed with explicit 'yes' confirmation
+   - If user says no, suggest: "View existing tasks with: /pm:epic-show $ARGUMENTS"
+
+4. **Validate epic frontmatter:**
+   - For single epic: Verify `.claude/epics/$ARGUMENTS/epic.md` has valid frontmatter
+   - For multi-epic: Verify each subdirectory's epic.md has valid frontmatter
+   - If invalid, tell user which epic file has invalid frontmatter
+
+5. **Check epic status:**
+   - For each epic, check if status is already "completed"
+   - If any epic is completed, warn user: "⚠️ Epic(s) marked as completed. Are you sure you want to decompose again?"
+
+## ⚠️ TDD REMINDER
+
+**CRITICAL: All tasks MUST follow Test-Driven Development (TDD).**
+
+When creating tasks, ensure each task includes:
+- TDD Requirements section (RED-GREEN-REFACTOR cycle)
+- "Tests written FIRST" as first item in Definition of Done
+- References to `.claude/rules/tdd.enforcement.md`
+
+Every generated task file will remind developers to write tests first.
+
+---
+
+## Instructions
+
+You are decomposing epic(s) into specific, actionable tasks for: **$ARGUMENTS**
+
+### 1. Determine Processing Mode
+
+**Single Epic Mode:**
+- Process `.claude/epics/$ARGUMENTS/epic.md`
+- Create tasks in `.claude/epics/$ARGUMENTS/`
+
+**Multi-Epic Mode (from epic-split):**
+- Find all subdirectories in `.claude/epics/$ARGUMENTS/`
+- Process each subdirectory's epic.md file separately
+- Create tasks in each respective subdirectory
+- Show progress for each epic being processed
+
+### 2. Read the Epic(s)
+- For single epic: Load from `.claude/epics/$ARGUMENTS/epic.md`
+- For multi-epic: Load each `.claude/epics/$ARGUMENTS/*/epic.md`
+- Understand the technical approach and requirements
+- Review the task breakdown preview
+
+### 3. Analyze PRD and Select Agents
+
+**IMPORTANT**: Before creating tasks, determine which specialized agents should be used:
+
+1. **Read the PRD** from `.claude/prds/$ARGUMENTS.md` (or linked PRD in epic frontmatter)
+
+2. **Identify Technology Stack**:
+   - Scan for programming languages (Python, JavaScript, Go, etc.)
+   - Find frameworks (React, FastAPI, Django, Express, etc.)
+   - Note databases (PostgreSQL, MongoDB, Redis, etc.)
+   - Identify cloud platforms (AWS, Azure, GCP)
+   - Check for infrastructure tools (Docker, K8s, Terraform)
+
+3. **Map to Specialized Agents** using the Agent Selection Strategy section above:
+   - **Backend tasks** → `python-backend-engineer` or `nodejs-backend-engineer`
+   - **Frontend tasks** → `react-frontend-engineer` or `javascript-frontend-engineer`
+   - **Database tasks** → `postgresql-expert`, `mongodb-expert`, or `redis-expert`
+   - **Cloud tasks** → `aws-cloud-architect`, `azure-cloud-architect`, or `gcp-cloud-architect`
+   - **Container tasks** → `docker-containerization-expert`
+   - **Orchestration** → `kubernetes-orchestrator`
+   - **IaC tasks** → `terraform-infrastructure-expert`
+   - **Testing** → `test-runner`, `frontend-testing-engineer`, `e2e-test-engineer`
+   - **CI/CD** → `github-operations-specialist` or `azure-devops-specialist`
+
+4. **Update Epic Frontmatter** with `required_agents` array (see Agent Selection Strategy section)
+
+5. **Prepare Agent Assignments** for each task to be created
+
+**Example**:
+```markdown
+Technology Stack Detected:
+- Backend: Python + FastAPI
+- Database: PostgreSQL
+- Testing: pytest
+- Deployment: Docker
+
+Agent Mapping:
+- Tasks 001-003 (API): python-backend-engineer
+- Tasks 004-005 (Database): postgresql-expert
+- Tasks 006-007 (Tests): test-runner
+- Task 008 (Docker): docker-containerization-expert
+```
+
+### 4. Analyze for Parallel Creation
+
+Determine if tasks can be created in parallel:
+- If tasks are mostly independent: Create in parallel using Task agents
+- If tasks have complex dependencies: Create sequentially
+- For best results: Group independent tasks for parallel creation
+
+### 5. Parallel Task Creation (When Possible)
+
+If tasks can be created in parallel, spawn sub-agents.
+
+**IMPORTANT**: Do NOT use generic "general-purpose" agents. Task creation should be done directly by Claude Code, not delegated to sub-agents, as it requires careful analysis of PRD, agent selection, and proper frontmatter generation.
+
+**Task Creation Process**:
+1. For each task, determine the appropriate `assigned_agent` based on PRD analysis
+2. Create task file with complete frontmatter including agent assignment
+3. Generate proper task content with all required sections
+4. Ensure sequential numbering (001.md, 002.md, etc.)
+
+**Example Task Creation**:
+```markdown
+Creating task 001 (API endpoint):
+- assigned_agent: .claude/agents/languages/python-backend-engineer.md
+- agent_context: {framework: "fastapi", auth: "jwt"}
+- File: .claude/epics/$ARGUMENTS/001.md
+✓ Created
+
+Creating task 002 (Database schema):
+- assigned_agent: .claude/agents/databases/postgresql-expert.md
+- agent_context: {orm: "sqlalchemy", migrations: "alembic"}
+- File: .claude/epics/$ARGUMENTS/002.md
+✓ Created
+```
+
+### 4. Task File Format with Frontmatter
+For each task, create a file with this exact structure:
+
+```markdown
+---
+name: [Task Title]
+status: open
+created: [Current ISO date/time]
+updated: [Current ISO date/time]
+assigned_agent: .claude/agents/{category}/{agent-name}.md  # Specialized agent for this task
+agent_context:  # Optional: Agent-specific configuration
+  framework: [framework_name]
+  language: [language_name]
+  approach: [implementation_approach]
+github: [Will be updated when synced to GitHub]
+depends_on: []  # List of task numbers this depends on, e.g., [001, 002]
+parallel: true  # Can this run in parallel with other tasks?
+conflicts_with: []  # Tasks that modify same files, e.g., [003, 004]
+---
+
+# Task: [Task Title]
+
+## Description
+Clear, concise description of what needs to be done
+
+## ⚠️ TDD Requirements
+**This project uses Test-Driven Development. You MUST:**
+1. 🔴 RED: Write failing test first
+2. 🟢 GREEN: Write minimal code to make test pass
+3. 🔵 REFACTOR: Clean up code while keeping tests green
+
+See `.claude/rules/tdd.enforcement.md` for complete requirements.
+
+## Acceptance Criteria
+- [ ] Specific criterion 1
+- [ ] Specific criterion 2
+- [ ] Specific criterion 3
+
+## Technical Details
+- Implementation approach
+- Key considerations
+- Code locations/files affected
+
+## Dependencies
+- [ ] Task/Issue dependencies
+- [ ] External dependencies
+
+## Effort Estimate
+- Size: XS/S/M/L/XL
+- Hours: estimated hours
+- Parallel: true/false (can run in parallel with other tasks)
+
+## Definition of Done
+- [ ] Tests written FIRST (RED phase)
+- [ ] Code implemented (GREEN phase)
+- [ ] Code refactored (REFACTOR phase)
+- [ ] All tests passing
+- [ ] Documentation updated
+- [ ] Code reviewed
+- [ ] Deployed to staging
+```
+
+### 3. Task Naming Convention
+
+**For Single Epic:**
+Save tasks as: `.claude/epics/$ARGUMENTS/{task_number}.md`
+
+**For Multi-Epic:**
+Save tasks as: `.claude/epics/$ARGUMENTS/{epic_folder}/{task_number}.md`
+Example: `.claude/epics/ecommerce/01-infrastructure/001.md`
+
+- Use sequential numbering: 001.md, 002.md, etc.
+- Keep task titles short but descriptive
+- Each epic gets its own task number sequence
+
+### 4. Frontmatter Guidelines
+- **name**: Use a descriptive task title (without "Task:" prefix)
+- **status**: Always start with "open" for new tasks
+- **created**: Get REAL current datetime by running: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+- **updated**: Use the same real datetime as created for new tasks
+- **assigned_agent**: Path to specialized agent file (e.g., `.claude/agents/languages/python-backend-engineer.md`)
+  - Select based on technology stack from PRD
+  - Use most specific agent for the task type
+  - See Agent Selection Strategy section for mapping
+- **agent_context**: Optional object with agent-specific configuration
+  - **framework**: Specific framework being used (e.g., "fastapi", "react", "express")
+  - **language**: Programming language if multiple options (e.g., "python", "typescript")
+  - **approach**: Implementation approach or pattern to use
+  - Add any task-specific parameters the agent needs
+- **github**: Leave placeholder text - will be updated during sync
+- **depends_on**: List task numbers that must complete before this can start (e.g., [001, 002])
+- **parallel**: Set to true if this can run alongside other tasks without conflicts
+- **conflicts_with**: List task numbers that modify the same files (helps coordination)
+
+### 5. Task Types to Consider
+- **Setup tasks**: Environment, dependencies, scaffolding
+- **Data tasks**: Models, schemas, migrations
+- **API tasks**: Endpoints, services, integration
+- **UI tasks**: Components, pages, styling
+- **Testing tasks**: Unit tests, integration tests
+- **Documentation tasks**: README, API docs
+- **Deployment tasks**: CI/CD, infrastructure
+
+### 6. Parallelization
+Mark tasks with `parallel: true` if they can be worked on simultaneously without conflicts.
+
+### 7. Execution Strategy
+
+Choose based on task count and complexity:
+
+**Small Epic (< 5 tasks)**: Create sequentially for simplicity
+
+**Medium Epic (5-10 tasks)**:
+- Batch into 2-3 groups
+- Spawn agents for each batch
+- Consolidate results
+
+**Large Epic (> 10 tasks)**:
+- Analyze dependencies first
+- Group independent tasks
+- Launch parallel agents (max 5 concurrent)
+- Create dependent tasks after prerequisites
+
+Example for parallel execution:
+```markdown
+Spawning 3 agents for parallel task creation:
+- Agent 1: Creating tasks 001-003 (Database layer)
+- Agent 2: Creating tasks 004-006 (API layer)
+- Agent 3: Creating tasks 007-009 (UI layer)
+```
+
+**Multi-Epic Processing Example:**
+```markdown
+Processing multiple epics from split:
+
+📂 01-infrastructure/epic.md
+   Creating 8 tasks...
+   ✅ Done
+
+📂 02-auth-backend/epic.md
+   Creating 12 tasks...
+   ✅ Done
+
+📂 03-frontend/epic.md
+   Creating 10 tasks...
+   ✅ Done
+```
+
+### 8. Task Dependency Validation
+
+When creating tasks with dependencies:
+- Ensure referenced dependencies exist (e.g., if Task 003 depends on Task 002, verify 002 was created)
+- Check for circular dependencies (Task A → Task B → Task A)
+- If dependency issues found, warn but continue: "⚠️ Task dependency warning: {details}"
+
+### 9. Update Epic with Task Summary
+After creating all tasks, update the epic file by adding this section:
+```markdown
+## Tasks Created
+- [ ] 001.md - {Task Title} (parallel: true/false)
+- [ ] 002.md - {Task Title} (parallel: true/false)
+- etc.
+
+Total tasks: {count}
+Parallel tasks: {parallel_count}
+Sequential tasks: {sequential_count}
+Estimated total effort: {sum of hours}
+```
+
+Also update the epic's frontmatter progress if needed (still 0% until tasks actually start).
+
+### 9. Quality Validation
+
+Before finalizing tasks, verify:
+- [ ] All tasks have clear acceptance criteria
+- [ ] Task sizes are reasonable (1-3 days each)
+- [ ] Dependencies are logical and achievable
+- [ ] Parallel tasks don't conflict with each other
+- [ ] Combined tasks cover all epic requirements
+
+### 10. Post-Decomposition
+
+**For Single Epic:**
+After successfully creating tasks:
+1. Confirm: "✅ Created {count} tasks for epic: $ARGUMENTS"
+2. Show summary:
+   - Total tasks created
+   - Parallel vs sequential breakdown
+   - Total estimated effort
+3. Suggest next step: "Ready to sync to GitHub? Run: /pm:epic-sync $ARGUMENTS"
+
+**For Multi-Epic:**
+After processing all epics:
+1. Show per-epic summary:
+   ```
+   ✅ Epic Decomposition Complete
+
+   📂 01-infrastructure: 8 tasks created
+   📂 02-auth-backend: 12 tasks created
+   📂 03-frontend: 10 tasks created
+
+   Total: 30 tasks across 3 epics
+   ```
+2. Show combined statistics:
+   - Total tasks across all epics
+   - Total estimated effort
+   - Breakdown by epic
+3. Suggest next step: "Ready to sync all epics? Run: /pm:epic-sync $ARGUMENTS"
+
+## Error Recovery
+
+If any step fails:
+- If task creation partially completes, list which tasks were created
+- Provide option to clean up partial tasks
+- Never leave the epic in an inconsistent state
+
+Aim for tasks that can be completed in 1-3 days each. Break down larger tasks into smaller, manageable pieces for the "$ARGUMENTS" epic.

--- a/autopm/.claude/commands/pm:epic-edit.md
+++ b/autopm/.claude/commands/pm:epic-edit.md
@@ -1,0 +1,83 @@
+---
+allowed-tools: Read, Write, LS
+---
+
+# Epic Edit
+
+Edit epic details after creation.
+
+## Usage
+```
+/pm:epic-edit <epic_name>
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Read Current Epic
+
+Read `.claude/epics/$ARGUMENTS/epic.md`:
+- Parse frontmatter
+- Read content sections
+
+### 2. Interactive Edit
+
+Ask user what to edit:
+- Name/Title
+- Description/Overview
+- Architecture decisions
+- Technical approach
+- Dependencies
+- Success criteria
+
+### 3. Update Epic File
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Update epic.md:
+- Preserve all frontmatter except `updated`
+- Apply user's edits to content
+- Update `updated` field with current datetime
+
+### 4. Option to Update GitHub
+
+If epic has GitHub URL in frontmatter:
+Ask: "Update GitHub issue? (yes/no)"
+
+If yes:
+```bash
+gh issue edit {issue_number} --body-file .claude/epics/$ARGUMENTS/epic.md
+```
+
+### 5. Output
+
+```
+✅ Updated epic: $ARGUMENTS
+  Changes made to: {sections_edited}
+  
+{If GitHub updated}: GitHub issue updated ✅
+
+View epic: /pm:epic-show $ARGUMENTS
+```
+
+## Important Notes
+
+Preserve frontmatter history (created, github URL, etc.).
+Don't change task files when editing epic.
+Follow `/rules/frontmatter-operations.md`.

--- a/autopm/.claude/commands/pm:epic-list.md
+++ b/autopm/.claude/commands/pm:epic-list.md
@@ -1,0 +1,34 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/epic-list.js` using the Bash tool and show me the complete output.
+
+- You MUST display the complete output.
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- Show ALL lines in full.
+- DO NOT print any other comments.
+

--- a/autopm/.claude/commands/pm:epic-oneshot.md
+++ b/autopm/.claude/commands/pm:epic-oneshot.md
@@ -1,0 +1,164 @@
+---
+allowed-tools: Read, LS
+---
+
+# Epic Oneshot
+
+Decompose epic into tasks and sync to GitHub in one operation.
+
+## Usage
+```
+/pm:epic-oneshot <feature_name>
+```
+
+## ⚠️ TDD REMINDER
+
+**CRITICAL: All tasks generated will include TDD requirements.**
+
+This command will create tasks that REQUIRE Test-Driven Development:
+- Each task includes TDD Requirements section
+- Definition of Done starts with "Tests written FIRST"
+- All agents must follow RED-GREEN-REFACTOR cycle
+
+See `.claude/rules/tdd.enforcement.md` for complete requirements.
+
+---
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Validate Prerequisites
+
+```bash
+# Check if PRD exists
+if [ ! -f ".claude/prds/$ARGUMENTS.md" ]; then
+  echo "❌ PRD not found: $ARGUMENTS.md"
+  echo "💡 Create it first with: /pm:prd-new $ARGUMENTS"
+  exit 1
+fi
+
+echo "✅ PRD found"
+
+# Check if epic already exists
+if [ -f ".claude/epics/$ARGUMENTS/epic.md" ]; then
+  echo "⚠️ Epic already exists: $ARGUMENTS"
+  echo "💡 View it with: /pm:epic-show $ARGUMENTS"
+  echo "💡 Or use a different name"
+  exit 1
+fi
+
+echo "✅ Ready to create epic"
+```
+
+### 2. Execute Epic Oneshot Script
+
+Run the all-in-one script that handles:
+- PRD parsing
+- Task decomposition
+- GitHub/Azure sync
+
+```bash
+node .claude/scripts/pm/epic-oneshot.cjs $ARGUMENTS
+```
+
+### 3. Verify Success
+
+```bash
+# Check epic was created
+if [ -f ".claude/epics/$ARGUMENTS/epic.md" ]; then
+  echo ""
+  echo "✅ Epic Oneshot Complete!"
+  echo ""
+  echo "📋 Next steps:"
+  echo "  • View epic: /pm:epic-show $ARGUMENTS"
+  echo "  • Start work: /pm:epic-start $ARGUMENTS"
+  echo "  • Get next task: /pm:next"
+  echo ""
+else
+  echo "❌ Epic creation failed. Check output above for errors."
+  exit 1
+fi
+```
+
+## What It Does
+
+This command executes a complete workflow in one operation:
+
+**Step 1: Parse PRD**
+- Reads `.claude/prds/$ARGUMENTS.md`
+- Extracts features, requirements, technical details
+- Creates epic structure
+
+**Step 2: Decompose Tasks**
+- Analyzes epic content
+- Generates implementation tasks
+- Adds tasks to epic.md
+
+**Step 3: Sync to Provider**
+- Creates epic issue on GitHub/Azure
+- Creates sub-issues for each task
+- Links everything together
+
+## Output Structure
+
+After successful execution:
+
+```
+.claude/
+  epics/
+    <feature-name>/
+      epic.md              # Main epic with embedded tasks
+      metadata.json        # Epic metadata
+      tasks/               # Individual task files (if created)
+```
+
+## Example Usage
+
+```bash
+# Complete workflow in one command
+/pm:epic-oneshot gym-trading-env
+
+# What happens:
+# 1. Parses .claude/prds/gym-trading-env.md
+# 2. Creates .claude/epics/gym-trading-env/epic.md
+# 3. Generates implementation tasks
+# 4. Syncs to GitHub/Azure DevOps
+# 5. Ready to start work!
+```
+
+## Important Notes
+
+**Advantages of Oneshot:**
+- ✅ Fastest way from PRD to implementation
+- ✅ No manual intervention needed
+- ✅ Automatic task generation
+- ✅ Immediate GitHub sync
+
+**When NOT to use:**
+- ❌ Complex PRDs needing manual review between steps
+- ❌ Custom task decomposition required
+- ❌ Learning the PM workflow (use step-by-step instead)
+
+**Alternative: Step-by-Step**
+```bash
+# If you prefer manual control:
+/pm:prd-parse <feature>       # Step 1: Create epic
+/pm:epic-decompose <feature>  # Step 2: Add tasks (if available)
+/pm:epic-sync <feature>       # Step 3: Sync to provider
+```

--- a/autopm/.claude/commands/pm:epic-show.md
+++ b/autopm/.claude/commands/pm:epic-show.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/epic-show.js $ARGUMENTS` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:epic-split.md
+++ b/autopm/.claude/commands/pm:epic-split.md
@@ -1,0 +1,131 @@
+---
+name: epic-split
+type: epic-management
+category: pm
+---
+
+# Epic Split
+
+Automatically split a PRD into multiple logical epics based on content analysis.
+
+## Usage
+```bash
+/pm:epic-split <feature_name>
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before splitting PRDs into epics, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-splitting` - Epic decomposition strategies
+- `mcp://context7/project-management/dependency-mapping` - Dependency analysis patterns
+- `mcp://context7/agile/priority-frameworks` - Priority assessment (P0, P1, P2)
+- `mcp://context7/architecture/component-analysis` - Component identification
+- `mcp://context7/agile/parallel-planning` - Parallel work planning
+
+**Why This is Required:**
+- Ensures logical epic boundaries following proven patterns
+- Applies industry-standard dependency mapping techniques
+- Validates priority assignments against frameworks (MoSCoW, RICE)
+- Prevents inefficient epic structures and bottlenecks
+
+## Description
+This command analyzes a PRD and automatically splits it into multiple epics based on:
+- Technical components (frontend, backend, infrastructure)
+- Feature areas (auth, dashboard, API, etc.)
+- Complexity and dependencies
+- Priority levels (P0, P1, P2)
+
+## How It Works
+
+1. **PRD Analysis**: Scans the PRD for keywords and patterns
+2. **Epic Identification**: Matches content against epic templates
+3. **Dependency Mapping**: Determines logical dependencies between epics
+4. **Structure Creation**: Creates organized epic folders with metadata
+
+## Epic Types Detected
+
+- **Infrastructure Foundation** - Docker, DB, monitoring
+- **Authentication Backend** - JWT, users, RBAC
+- **Authentication UI** - Login/register forms
+- **API Core Services** - REST endpoints
+- **Frontend Foundation** - React/Vue/Angular setup
+- **Dashboard & UX** - Main application UI
+- **Data Layer** - Database models, migrations
+- **Testing & Quality** - Test suites, TDD
+- **Deployment & DevOps** - CI/CD, production
+- **Security & Compliance** - OWASP, hardening
+
+## Output Structure
+
+```
+.claude/epics/<feature_name>/
+├── meta.yaml                    # Multi-epic metadata
+├── 01-infrastructure/           # Epic 1
+│   └── epic.md
+├── 02-auth_backend/            # Epic 2
+│   └── epic.md
+├── 03-frontend_foundation/     # Epic 3
+│   └── epic.md
+└── ...
+```
+
+## Example
+
+```bash
+# Split a complex PRD into epics
+/pm:epic-split frontend-backend-db-base
+
+# Output:
+✓ Identified 6 epics
+✓ Epic 1: Infrastructure Foundation (P0, 1w)
+✓ Epic 2: Authentication Backend (P0, 2w)
+✓ Epic 3: Frontend Foundation (P0, 1w)
+✓ Epic 4: Authentication UI (P0, 2w)
+✓ Epic 5: Dashboard & UX (P1, 2w)
+✓ Epic 6: Testing & Quality (P1, 1w)
+
+Total Estimated Effort: 9 weeks
+```
+
+## Benefits
+
+- **Automatic Analysis**: No manual epic creation needed
+- **Dependency Detection**: Understands epic relationships
+- **Priority Sorting**: P0 epics come first
+- **Parallel Work**: Identifies what can be done simultaneously
+- **Time Estimates**: Provides week-level estimates
+
+## Next Steps After Split
+
+1. Review the epic breakdown
+2. Decompose each epic into tasks: `/pm:epic-decompose <feature>/<epic_number>`
+3. Sync to GitHub: `/pm:epic-sync <feature>`
+4. Start implementation on parallel epics
+
+## When to Use
+
+- PRDs with multiple components (frontend + backend + infra)
+- Complex features requiring phased delivery
+- Large teams needing parallel work streams
+- Projects requiring clear milestone tracking
+
+## Manual Override
+
+If the automatic split isn't perfect, you can:
+1. Edit the generated epic files
+2. Adjust dependencies in meta.yaml
+3. Merge or split epics further
+4. Update time estimates
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/epic-split.js $ARGUMENTS` using the Bash tool and show me the complete output.
+
+- You MUST display the complete output.
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.

--- a/autopm/.claude/commands/pm:epic-status.md
+++ b/autopm/.claude/commands/pm:epic-status.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/epic-status.js $ARGUMENTS` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:help.md
+++ b/autopm/.claude/commands/pm:help.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/help.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:in-progress.md
+++ b/autopm/.claude/commands/pm:in-progress.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/in-progress.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:init.md
+++ b/autopm/.claude/commands/pm:init.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/init.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:next.md
+++ b/autopm/.claude/commands/pm:next.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/next.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:prd-edit.md
+++ b/autopm/.claude/commands/pm:prd-edit.md
@@ -1,0 +1,82 @@
+---
+allowed-tools: Read, Write, LS
+---
+
+# PRD Edit
+
+Edit an existing Product Requirements Document.
+
+## Usage
+```
+/pm:prd-edit <feature_name>
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Read Current PRD
+
+Read `.claude/prds/$ARGUMENTS.md`:
+- Parse frontmatter
+- Read all sections
+
+### 2. Interactive Edit
+
+Ask user what sections to edit:
+- Executive Summary
+- Problem Statement  
+- User Stories
+- Requirements (Functional/Non-Functional)
+- Success Criteria
+- Constraints & Assumptions
+- Out of Scope
+- Dependencies
+
+### 3. Update PRD
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Update PRD file:
+- Preserve frontmatter except `updated` field
+- Apply user's edits to selected sections
+- Update `updated` field with current datetime
+
+### 4. Check Epic Impact
+
+If PRD has associated epic:
+- Notify user: "This PRD has epic: {epic_name}"
+- Ask: "Epic may need updating based on PRD changes. Review epic? (yes/no)"
+- If yes, show: "Review with: /pm:epic-edit {epic_name}"
+
+### 5. Output
+
+```
+✅ Updated PRD: $ARGUMENTS
+  Sections edited: {list_of_sections}
+  
+{If has epic}: ⚠️ Epic may need review: {epic_name}
+
+Next: /pm:prd-parse $ARGUMENTS to update epic
+```
+
+## Important Notes
+
+Preserve original creation date.
+Keep version history in frontmatter if needed.
+Follow `/rules/frontmatter-operations.md`.

--- a/autopm/.claude/commands/pm:prd-list.md
+++ b/autopm/.claude/commands/pm:prd-list.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/prd-list.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:prd-new.md
+++ b/autopm/.claude/commands/pm:prd-new.md
@@ -1,0 +1,453 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# PRD New
+
+Create new product requirement document - interactively or from existing content.
+
+## Usage
+```
+/pm:prd-new <feature_name> [options]
+```
+
+## Flags
+
+`--local`, `-l`
+: Use local mode (offline workflow)
+: Creates PRD files in `.claude/prds/` directory
+: No GitHub/Azure synchronization required
+: Ideal for working offline or without remote provider configured
+
+`--content`, `-c`
+: PRD content for non-interactive mode
+: Use `@filepath` to read from file (e.g., `--content @/path/to/draft.md`)
+: Use inline text for short content (e.g., `--content "# My PRD..."`)
+: Skips LLM generation completely
+: Ideal for importing existing PRDs or automated workflows
+
+`--interactive`, `-i`
+: Use interactive terminal prompts (requires interactive terminal)
+: NOT compatible with Claude Code (use default LLM generation instead)
+: Launches traditional brainstorming wizard with readline prompts
+
+`--force`, `-f`
+: Overwrite existing PRD file if it exists
+
+`--priority`, `-p`
+: Set PRD priority (P0/P1/P2/P3, default: P2)
+
+`--timeline`
+: Set PRD timeline (e.g., "Q1 2025")
+
+## Examples
+
+### LLM-assisted generation (default - works in Claude Code)
+```
+/pm:prd-new user-authentication
+```
+
+### Interactive terminal mode (requires interactive terminal)
+```
+/pm:prd-new user-authentication --interactive
+```
+
+### Local mode
+```
+/pm:prd-new user-authentication --local
+```
+
+### From existing file
+```
+/pm:prd-new payment-gateway --content @docs/drafts/payment-prd.md
+```
+
+### From clipboard/inline content
+```
+/pm:prd-new api-v2 --content "# API v2 Redesign
+
+## Problem Statement
+Current API has performance issues...
+
+## Goals
+1. Improve response times
+2. Better error handling
+"
+```
+
+### With metadata
+```
+/pm:prd-new critical-fix --content @bug-report.md --priority P0 --timeline "This Sprint"
+```
+
+### Force overwrite
+```
+/pm:prd-new existing-feature --content @updated-prd.md --force
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before creating PRDs, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/product-management/prd-templates` - PRD structure and templates
+- `mcp://context7/product-management/requirements` - Requirements gathering
+- `mcp://context7/agile/user-stories` - User story best practices
+- `mcp://context7/product-management/success-metrics` - Defining success criteria
+
+**Why This is Required:**
+- Ensures PRDs follow industry-standard formats
+- Applies proven requirements gathering techniques
+- Validates completeness of product specifications
+- Prevents missing critical sections (acceptance criteria, success metrics, etc.)
+
+## Instructions
+
+### Mode Detection
+
+Parse the arguments to detect the mode:
+- If `--interactive` flag is present → **Interactive Terminal Mode**
+- If `--content @<filepath>` is present → **Content from File Mode**
+- If `--content "<text>"` is present → **Content from Inline Text Mode**
+- Otherwise → **LLM-Assisted Generation Mode** (default)
+
+### LLM-Assisted Generation Mode (DEFAULT - works in Claude Code)
+
+#### Phase 0: Codebase Analysis (MANDATORY)
+
+**CRITICAL**: Before creating any PRD, perform comprehensive codebase analysis to prevent duplicate implementations and identify reusable components.
+
+1. **Search for Existing Functionality**
+
+   Use code-analyzer agent to search the entire codebase:
+
+   ```markdown
+   Task:
+     subagent_type: "code-analyzer"
+     description: "Search for existing '<feature_name>' functionality"
+     prompt: |
+       Search the entire codebase for anything related to: <feature_name>
+
+       Search criteria:
+       - Function names containing: <feature_name> (or related terms)
+       - File names related to: <feature_name>
+       - Class/module names similar to: <feature_name>
+       - Comments/documentation mentioning: <feature_name>
+       - Similar patterns or implementations
+       - Related API endpoints or routes
+       - Database models/schemas related to feature
+
+       Return findings in this format:
+
+       ## Existing Implementations Found
+       - File: [path] - [brief description]
+       - Function: [name] - [what it does]
+       - Component: [name] - [purpose]
+
+       ## Similar Patterns
+       - [description of similar functionality]
+
+       ## Recommendation
+       ✅ Safe to create new PRD (no conflicts found)
+       OR
+       ⚠️ Existing functionality detected - review before proceeding
+
+       ## Reusable Components
+       - [list components that can be reused]
+       - [list utilities that apply]
+   ```
+
+2. **Analyze Dependencies and Integration Points**
+
+   Use code-analyzer agent to identify dependencies:
+
+   ```markdown
+   Task:
+     subagent_type: "code-analyzer"
+     description: "Identify dependencies for '<feature_name>'"
+     prompt: |
+       Identify systems that '<feature_name>' would interact with:
+
+       - **Databases**: What tables/collections would be needed?
+       - **APIs**: Which endpoints would be affected/created?
+       - **External Services**: Third-party integrations needed?
+       - **Internal Modules**: Which existing modules would be used?
+       - **Authentication**: Auth/authorization requirements?
+       - **State Management**: Frontend state considerations?
+
+       Return integration points and potential conflicts.
+   ```
+
+3. **Present Findings to User**
+
+   Format the analysis results for user review:
+
+   ```markdown
+   🔍 **Codebase Analysis Results for: <feature_name>**
+   ═══════════════════════════════════════════════════
+
+   ### Existing Implementations
+   [If found, list each with file path and purpose]
+   [If none found: "✅ No existing implementations detected"]
+
+   ### Dependencies Identified
+   [List each dependency type and specific items]
+
+   ### Reusable Components
+   [List components that can be leveraged]
+   [If none: "No directly reusable components found"]
+
+   ### Potential Conflicts
+   [List any naming conflicts, duplicate logic, etc.]
+   [If none: "✅ No conflicts detected"]
+
+   ### Technology Stack Detected
+   - Backend: [detected frameworks]
+   - Frontend: [detected frameworks]
+   - Database: [detected systems]
+   - Testing: [detected tools]
+
+   ───────────────────────────────────────────────────
+
+   ## Recommendation
+
+   Based on this analysis:
+
+   ✅ **OPTION 1: Create New PRD**
+      No conflicts found. Safe to proceed with new feature.
+
+   ⚠️ **OPTION 2: Extend Existing Feature**
+      Similar functionality found at [path]. Consider extending instead.
+
+   🔄 **OPTION 3: Refactor Existing Code**
+      Duplication detected. Consider refactoring before adding new feature.
+
+   ───────────────────────────────────────────────────
+
+   **Next Step**: Review the analysis above and confirm your choice:
+   - To proceed: Continue with PRD creation
+   - To abort: Stop here and investigate findings
+   ```
+
+4. **User Decision Point**
+
+   After presenting findings, ask user to confirm:
+   ```markdown
+   Based on the codebase analysis above, do you want to:
+
+   1. ✅ Proceed with new PRD (no conflicts found)
+   2. 🔍 Investigate existing implementations first
+   3. ❌ Cancel PRD creation
+
+   [Wait for user response before continuing]
+   ```
+
+#### Phase 1: PRD Existence Check
+
+1. **Pre-check**: Verify PRD doesn't already exist
+   ```bash
+   if [ -f .claude/prds/<feature_name>.md ]; then
+     echo "❌ PRD already exists: <feature_name>"
+     echo "💡 Use --force to overwrite or edit: /pm:prd-edit <feature_name>"
+     exit 1
+   fi
+   ```
+
+#### Phase 2: Generate PRD Content
+
+1. **Generate PRD Content**: Create a comprehensive PRD based on:
+   - Feature name: `<feature_name>`
+   - **Codebase analysis findings** from Phase 0 (existing implementations, dependencies, conflicts)
+   - Project context (analyze existing codebase structure)
+   - Technology stack (detect from package.json, requirements.txt, etc.)
+   - Existing patterns (check similar features)
+   - **Reusable components** identified in analysis
+   - **Integration points** from dependency analysis
+
+3. **PRD Structure**: Use this template:
+   ```markdown
+   ---
+   title: <Title Case Feature Name>
+   status: draft
+   priority: <from --priority or P2>
+   created: <current ISO timestamp>
+   author: <from git config or "claude">
+   timeline: <from --timeline or "TBD">
+   ---
+
+   # PRD: <feature_name>
+
+   ## Executive Summary
+   [Brief overview of the feature - 2-3 sentences]
+
+   ## Codebase Analysis
+   ### Existing Implementations
+   [List any existing functionality found during pre-analysis]
+   [If none: "✅ No existing implementations detected"]
+
+   ### Reusable Components
+   [List components that can be leveraged from existing codebase]
+   [If none: "No directly reusable components found"]
+
+   ### Integration Points
+   [List systems this feature will interact with]
+   - Database: [tables/models needed]
+   - APIs: [endpoints affected]
+   - External Services: [third-party integrations]
+   - Internal Modules: [existing modules to use]
+
+   ### Potential Conflicts
+   [List any naming conflicts or duplicate logic concerns]
+   [If none: "✅ No conflicts detected"]
+
+   ## Problem Statement
+   ### Background
+   [Context and why this feature is needed]
+
+   ### Current State
+   [What exists today and its limitations]
+
+   ### Desired State
+   [What the solution will provide]
+
+   ## Target Users
+   [Who will use this feature]
+
+   ### User Personas
+   - **Primary Users**: [Main user segment]
+   - **Secondary Users**: [Additional beneficiaries]
+
+   ### User Stories
+   - As a [user type], I want to [action], so that [benefit]
+   - As a [user type], I want to [action], so that [benefit]
+
+   ## Key Features
+   ### Must Have (P0)
+   - [ ] [Core feature 1]
+   - [ ] [Core feature 2]
+
+   ### Should Have (P1)
+   - [ ] [Important feature 1]
+   - [ ] [Important feature 2]
+
+   ### Nice to Have (P2)
+   - [ ] [Enhancement 1]
+   - [ ] [Enhancement 2]
+
+   ## Success Metrics
+   ### Key Performance Indicators (KPIs)
+   - **Adoption Rate**: [Target percentage]
+   - **User Satisfaction**: [Target score]
+   - **Performance**: [Response time targets]
+   - **Quality**: [Error rate targets]
+
+   ## Technical Requirements
+   ### Architecture Considerations
+   [System components affected, integration points, data flow]
+
+   ### Non-Functional Requirements
+   - **Performance**: [Specific targets]
+   - **Scalability**: [Capacity requirements]
+   - **Security**: [Auth/authorization requirements]
+   - **Reliability**: [Uptime targets]
+
+   ### Dependencies
+   - [External services or APIs]
+   - [Internal systems or components]
+   - [Third-party libraries or tools]
+
+   ## Implementation Plan
+   ### Phase 1: Foundation
+   - [ ] [Initial tasks]
+
+   ### Phase 2: Core Features
+   - [ ] [Main development]
+
+   ### Phase 3: Enhancement
+   - [ ] [Additional features]
+
+   ### Phase 4: Release
+   - [ ] [Final testing and deployment]
+
+   ## Risks and Mitigation
+   ### Technical Risks
+   - **Risk 1**: [Description and mitigation]
+
+   ### Business Risks
+   - **Risk 1**: [Impact and contingency]
+
+   ## Open Questions
+   - [ ] [Question requiring clarification]
+   - [ ] [Question needing stakeholder input]
+
+   ## Appendix
+   ### References
+   - [Related documentation]
+
+   ### Changelog
+   - [timestamp]: Initial PRD created
+   ```
+
+4. **Write PRD File**:
+   ```bash
+   mkdir -p .claude/prds
+   # Use Write tool to create .claude/prds/<feature_name>.md
+   ```
+
+5. **Confirm Success**: Show next steps
+
+### Interactive Terminal Mode (`--interactive`)
+
+**⚠️ WARNING**: This mode requires an interactive terminal and **will NOT work in Claude Code**.
+
+Run `node .claude/scripts/pm/prd-new.js $ARGUMENTS` using the Bash tool and show me the complete output.
+
+This will launch an interactive brainstorming session that will:
+1. Prompt for product vision
+2. Gather information about target users
+3. Collect key features through interactive prompts
+4. Define success metrics
+5. Capture technical considerations
+6. Generate a comprehensive PRD with proper frontmatter
+
+The script handles all validation, creates the necessary directories, and saves the PRD to `.claude/prds/<feature_name>.md`.
+
+### Content from File Mode (`--content @filepath`)
+
+1. Extract the file path from `--content @<filepath>` argument
+2. Use the Read tool to read the source file content
+3. Check if target PRD already exists at `.claude/prds/<feature_name>.md`
+   - If exists and `--force` not provided → Error and stop
+   - If exists and `--force` provided → Continue (will overwrite)
+4. Prepare the PRD content:
+   - If source content starts with `---` (has frontmatter) → Use as-is
+   - If no frontmatter → Add frontmatter with:
+     ```yaml
+     ---
+     title: <feature_name>
+     status: draft
+     priority: <from --priority or P2>
+     created: <current ISO timestamp>
+     author: <from git config or "unknown">
+     timeline: <from --timeline or "TBD">
+     ---
+     ```
+5. Create directory `.claude/prds/` if it doesn't exist (use Bash: `mkdir -p .claude/prds`)
+6. Write the PRD file using the Write tool to `.claude/prds/<feature_name>.md`
+7. Confirm success and show next steps
+
+### Content from Inline Text Mode (`--content "text"`)
+
+Same as file mode, but use the inline text directly instead of reading from file.
+
+## Output
+
+After successful PRD creation, show:
+```
+✅ PRD created: .claude/prds/<feature_name>.md
+
+📋 Next steps:
+  1. Review: /pm:prd-show <feature_name>
+  2. Edit:   /pm:prd-edit <feature_name>
+  3. Parse:  /pm:prd-parse <feature_name>
+```

--- a/autopm/.claude/commands/pm:prd-parse.md
+++ b/autopm/.claude/commands/pm:prd-parse.md
@@ -1,0 +1,42 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# PRD Parse
+
+Convert PRD to technical implementation epic.
+
+## Usage
+```
+/pm:prd-parse <feature_name>
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before converting PRDs to epics, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/product-management/prd-to-epic` - PRD to epic conversion patterns
+- `mcp://context7/agile/epic-structure` - Epic structure and organization
+- `mcp://context7/architecture/technical-design` - Technical architecture decisions
+- `mcp://context7/project-management/task-breakdown` - Task breakdown strategies
+- `mcp://context7/agile/estimation` - Effort estimation and timeline planning
+
+**Why This is Required:**
+- Ensures proper PRD-to-epic translation following industry standards
+- Applies proven architecture decision frameworks
+- Validates task breakdown completeness and accuracy
+- Prevents missing critical technical considerations
+
+## Instructions
+
+Run `node .claude/scripts/pm/prd-parse.js $ARGUMENTS` using the Bash tool and show me the complete output.
+
+This will convert the Product Requirements Document into a detailed technical implementation epic including:
+1. Technical analysis and architecture decisions
+2. Implementation strategy and phases
+3. Task breakdown preview (limited to 10 or fewer tasks)
+4. Dependencies and success criteria
+5. Effort estimates and timeline
+
+The script handles all validation, reads the PRD file, and creates the epic structure at `.claude/epics/$ARGUMENTS/epic.md`.

--- a/autopm/.claude/commands/pm:prd-show.md
+++ b/autopm/.claude/commands/pm:prd-show.md
@@ -1,0 +1,74 @@
+---
+allowed-tools: Read, Bash, Glob
+---
+
+# /pm:prd-show - Display PRD Content
+
+Display the full content of a Product Requirements Document (PRD).
+
+## Usage
+
+```
+/pm:prd-show <feature_name>
+```
+
+## Arguments
+
+- `<feature_name>` - Name of the PRD to display (without .md extension)
+
+## Instructions
+
+1. **Locate the PRD file:**
+   ```bash
+   ls .claude/prds/{feature_name}.md 2>/dev/null || ls .pm/prds/{feature_name}.md 2>/dev/null
+   ```
+
+2. **If not found by exact name, search:**
+   ```bash
+   find .claude/prds .pm/prds -name "*{feature_name}*.md" 2>/dev/null | head -1
+   ```
+
+3. **Read and display the PRD:**
+   - Use the Read tool to display the full PRD content
+   - Show the complete file including frontmatter
+   - DO NOT truncate or abbreviate
+
+## Output Format
+
+```
+PRD: {feature_name}
+File: {file_path}
+─────────────────────────────────────
+
+{full PRD content}
+
+─────────────────────────────────────
+📋 Next steps:
+  • Edit:   /pm:prd-edit {feature_name}
+  • Parse:  /pm:prd-parse {feature_name}
+  • Status: /pm:prd-status
+```
+
+## Error Handling
+
+If PRD not found:
+```
+❌ PRD not found: {feature_name}
+
+Available PRDs:
+{list of .md files in .claude/prds/ or .pm/prds/}
+
+Create new: /pm:prd-new {feature_name}
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before displaying PRD, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/product-requirements` - PRD best practices
+- `mcp://context7/project-management/documentation` - documentation standards
+
+**Why This is Required:**
+- Ensures PRD format follows industry standards
+- Validates PRD completeness against best practices

--- a/autopm/.claude/commands/pm:prd-status.md
+++ b/autopm/.claude/commands/pm:prd-status.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/prd-status.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:search.md
+++ b/autopm/.claude/commands/pm:search.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/search.js $ARGUMENTS` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:standup.md
+++ b/autopm/.claude/commands/pm:standup.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/standup.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:status.md
+++ b/autopm/.claude/commands/pm:status.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/status.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:test-reference-update.md
+++ b/autopm/.claude/commands/pm:test-reference-update.md
@@ -1,0 +1,151 @@
+---
+allowed-tools: Bash, Read, Write
+---
+
+# Test Reference Update
+
+Test the task reference update logic used in epic-sync.
+
+## Usage
+```
+/pm:test-reference-update
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Create Test Files
+
+Create test task files with references:
+```bash
+mkdir -p /tmp/test-refs
+cd /tmp/test-refs
+
+# Create task 001
+cat > 001.md << 'EOF'
+---
+name: Task One
+status: open
+depends_on: []
+parallel: true
+conflicts_with: [002, 003]
+---
+# Task One
+This is task 001.
+EOF
+
+# Create task 002
+cat > 002.md << 'EOF'
+---
+name: Task Two
+status: open
+depends_on: [001]
+parallel: false
+conflicts_with: [003]
+---
+# Task Two
+This is task 002, depends on 001.
+EOF
+
+# Create task 003
+cat > 003.md << 'EOF'
+---
+name: Task Three
+status: open
+depends_on: [001, 002]
+parallel: false
+conflicts_with: []
+---
+# Task Three
+This is task 003, depends on 001 and 002.
+EOF
+```
+
+### 2. Create Mappings
+
+Simulate the issue creation mappings:
+```bash
+# Simulate task -> issue number mapping
+cat > /tmp/task-mapping.txt << 'EOF'
+001.md:42
+002.md:43
+003.md:44
+EOF
+
+# Create old -> new ID mapping
+> /tmp/id-mapping.txt
+while IFS=: read -r task_file task_number; do
+  old_num=$(basename "$task_file" .md)
+  echo "$old_num:$task_number" >> /tmp/id-mapping.txt
+done < /tmp/task-mapping.txt
+
+echo "ID Mapping:"
+cat /tmp/id-mapping.txt
+```
+
+### 3. Update References
+
+Process each file and update references:
+```bash
+while IFS=: read -r task_file task_number; do
+  echo "Processing: $task_file -> $task_number.md"
+  
+  # Read the file content
+  content=$(cat "$task_file")
+  
+  # Update references
+  while IFS=: read -r old_num new_num; do
+    content=$(echo "$content" | sed "s/\b$old_num\b/$new_num/g")
+  done < /tmp/id-mapping.txt
+  
+  # Write to new file
+  new_name="${task_number}.md"
+  echo "$content" > "$new_name"
+  
+  echo "Updated content preview:"
+  grep -E "depends_on:|conflicts_with:" "$new_name"
+  echo "---"
+done < /tmp/task-mapping.txt
+```
+
+### 4. Verify Results
+
+Check that references were updated correctly:
+```bash
+echo "=== Final Results ==="
+for file in 42.md 43.md 44.md; do
+  echo "File: $file"
+  grep -E "name:|depends_on:|conflicts_with:" "$file"
+  echo ""
+done
+```
+
+Expected output:
+- 42.md should have conflicts_with: [43, 44]
+- 43.md should have depends_on: [42] and conflicts_with: [44]
+- 44.md should have depends_on: [42, 43]
+
+### 5. Cleanup
+
+```bash
+cd -
+rm -rf /tmp/test-refs
+rm -f /tmp/task-mapping.txt /tmp/id-mapping.txt
+echo "✅ Test complete and cleaned up"
+```

--- a/autopm/.claude/commands/pm:validate.md
+++ b/autopm/.claude/commands/pm:validate.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/validate.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.

--- a/autopm/.claude/commands/pm:what-next.md
+++ b/autopm/.claude/commands/pm:what-next.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash
+---
+
+---
+
+## Instructions
+
+Run `node .claude/scripts/pm/what-next.js` using the Bash tool and show me the complete output.
+
+- DO NOT truncate.
+- DO NOT collapse.
+- DO NOT abbreviate.
+- Show ALL lines in full.
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+- DO NOT print any other comments.


### PR DESCRIPTION
## 🎯 Goal
Fix: PM slash commands (/pm:prd-new, /pm:issue-start, etc.) not appearing after \`autopm install\`.

## 📋 Root Cause
29 PM command files (pm:*.md) lived only in \`packages/plugin-pm/commands/\` and depended on plugin system to copy them. Plugin install didn't always run or copy correctly.

## ✅ Fix
Copied 29 PM command files to \`autopm/.claude/commands/\` so \`installFramework()\` includes them in every installation, regardless of plugin system.

## 📁 Affected Files
- \`autopm/.claude/commands/pm:*.md\` — 29 NEW files (copied from plugin-pm)