### PR TITLE
[chore] Release 3.16.1 — fix PM commands install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## 🎯 Goal
Patch release fixing PM slash commands not appearing after install.

## Changes
- 29 PM command files (pm:*.md) included in framework install (#470)

## After merge
\`git tag v3.16.1 && git push --tags\`