### PR TITLE
[feat][pm] Markdown tables in pm:status, standup, epic-status (#474)

### DIFF
--- a/packages/plugin-pm/scripts/pm/blocked.js
+++ b/packages/plugin-pm/scripts/pm/blocked.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * PM Blocked Script - Node.js Implementation
- *
- * Migrated from blocked.sh to show blocked tasks with dependencies
- * Maintains full compatibility with the original bash implementation
+ * PM Blocked Script
+ * Outputs markdown pipe table for blocked tasks with dependencies
  */
 
 const fs = require('fs');
@@ -16,9 +14,7 @@ function getBlockedTasks() {
     totalBlocked: 0
   };
 
-  if (!fs.existsSync('.claude/epics')) {
-    return result;
-  }
+  if (!fs.existsSync('.claude/epics')) return result;
 
   try {
     const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
@@ -40,23 +36,15 @@ function getBlockedTasks() {
           try {
             const taskContent = fs.readFileSync(taskFilePath, 'utf8');
 
-            // Check if task is open
             const statusMatch = taskContent.match(/^status:\s*(.*)$/m);
             const status = statusMatch ? statusMatch[1].trim() : '';
 
-            if (status !== 'open' && status !== '') {
-              continue; // Skip non-open tasks
-            }
+            if (status !== 'open' && status !== '') continue;
 
-            // Check for dependencies
             const depsMatch = taskContent.match(/^depends_on:\s*(.*)$/m);
-            if (!depsMatch) {
-              continue; // Skip tasks without dependencies
-            }
+            if (!depsMatch) continue;
 
             const depsString = depsMatch[1].trim();
-
-            // Parse dependencies - handle [1, 2, 3] format
             let dependencies = [];
             if (depsString.includes('[') && depsString.includes(']')) {
               const depsContent = depsString.replace(/[\[\]]/g, '').trim();
@@ -65,34 +53,26 @@ function getBlockedTasks() {
               }
             }
 
-            if (dependencies.length === 0) {
-              continue; // Skip if no valid dependencies found
-            }
+            if (dependencies.length === 0) continue;
 
-            // Get task name
             const nameMatch = taskContent.match(/^name:\s*(.*)$/m);
             const taskName = nameMatch ? nameMatch[1].trim() : `Task #${taskNum}`;
+
+            const updatedMatch = taskContent.match(/^updated:\s*(.*)$/m);
+            const since = updatedMatch ? updatedMatch[1].trim().split('T')[0] : '\u2014';
 
             // Check status of dependencies
             const openDependencies = [];
             for (const dep of dependencies) {
               const depFile = path.join(epicPath, `${dep}.md`);
-
               if (fs.existsSync(depFile)) {
                 try {
                   const depContent = fs.readFileSync(depFile, 'utf8');
                   const depStatusMatch = depContent.match(/^status:\s*(.*)$/m);
                   const depStatus = depStatusMatch ? depStatusMatch[1].trim() : '';
-
-                  if (depStatus === 'open' || depStatus === '') {
-                    openDependencies.push(dep);
-                  }
-                } catch (error) {
-                  // If we can't read the dependency file, consider it open/blocking
-                  openDependencies.push(dep);
-                }
+                  if (depStatus === 'open' || depStatus === '') openDependencies.push(dep);
+                } catch (error) { openDependencies.push(dep); }
               } else {
-                // Non-existent dependency files are considered blocking
                 openDependencies.push(dep);
               }
             }
@@ -103,60 +83,55 @@ function getBlockedTasks() {
                 taskName,
                 epicName,
                 dependencies,
-                openDependencies
+                openDependencies,
+                since
               });
-
               result.totalBlocked++;
             }
-          } catch (error) {
-            // Skip unreadable task files
-            continue;
-          }
+          } catch (error) { continue; }
         }
-      } catch (error) {
-        // Skip unreadable epic directories
-        continue;
-      }
+      } catch (error) { continue; }
     }
-  } catch (error) {
-    // Directory doesn't exist or can't be read
-  }
+  } catch (error) { /* skip */ }
 
   return result;
 }
 
 function formatBlockedOutput(data) {
-  let output = 'Getting tasks...\n\n\n';
-  output += '🚫 Blocked Tasks\n';
-  output += '================\n\n';
+  const lines = [];
+
+  lines.push('## Blocked Items');
+  lines.push('');
 
   if (data.blockedTasks.length === 0) {
-    output += 'No blocked tasks found!\n\n';
-    output += '💡 All tasks with dependencies are either completed or in progress.\n';
+    lines.push('No blocked tasks found. All tasks with dependencies are resolved or in progress.');
+    lines.push('');
+    lines.push('Next: /pm:next');
   } else {
+    lines.push('| # | Title | Blocker | Since | Epic |');
+    lines.push('|---|-------|---------|-------|------|');
     for (const task of data.blockedTasks) {
-      output += `⏸️ Task #${task.taskNum} - ${task.taskName}\n`;
-      output += `   Epic: ${task.epicName}\n`;
-      output += `   Blocked by: [${task.dependencies.join(', ')}]\n`;
-
-      if (task.openDependencies.length > 0) {
-        const waitingFor = task.openDependencies.map(dep => `#${dep}`).join(' ');
-        output += `   Waiting for:${waitingFor}\n`;
-      }
-
-      output += '\n';
+      const blocker = `Waiting on #${task.openDependencies.join(', #')}`;
+      lines.push(`| ${task.taskNum} | ${task.taskName} | ${blocker} | ${task.since} | ${task.epicName} |`);
     }
 
-    output += `📊 Total blocked: ${data.totalBlocked} tasks\n`;
+    // Recent Activity section
+    try {
+      const { formatRecentActivity } = require('../../../../autopm/.claude/lib/event-logger');
+      lines.push('');
+      lines.push(formatRecentActivity(7));
+    } catch (e) { /* event logger not available */ }
+
+    lines.push('');
+    lines.push(`Total: ${data.totalBlocked} blocked items`);
+    lines.push('Next: resolve blockers or /pm:next for alternative tasks');
   }
 
-  return output;
+  return lines.join('\n');
 }
 
-// CommonJS export for testing
 module.exports = getBlockedTasks;
 
-// CLI execution
 if (require.main === module) {
   const data = getBlockedTasks();
   console.log(formatBlockedOutput(data));

--- a/packages/plugin-pm/scripts/pm/epic-status.js
+++ b/packages/plugin-pm/scripts/pm/epic-status.js
@@ -1,18 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * PM Epic Status Script - Node.js Implementation
- *
- * Migrated from epic-status.sh to provide epic status with progress visualization
- * Maintains full compatibility with the original bash implementation
- *
- * Features:
- * - Shows epic status with progress bar visualization
- * - Calculates task breakdown (total, open, closed, blocked)
- * - Identifies blocked tasks based on dependencies
- * - Provides visual progress indication
- * - Handles various dependency formats
- * - Includes GitHub link if available
+ * PM Epic Status Script
+ * Outputs markdown pipe tables for epic status with task breakdown
  */
 
 const fs = require('fs');
@@ -25,30 +15,26 @@ function parseMetadata(content) {
     progress: '',
     github: '',
     created: '',
+    updated: '',
     parallel: '',
     depends_on: ''
   };
 
-  // Handle YAML frontmatter (between --- lines)
   const yamlMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
   if (yamlMatch) {
-    const yamlContent = yamlMatch[1];
-    const lines = yamlContent.split('\n');
-
+    const lines = yamlMatch[1].split('\n');
     for (const line of lines) {
       const trimmedLine = line.trim();
       if (trimmedLine.includes(':')) {
         const [key, ...valueParts] = trimmedLine.split(':');
         const value = valueParts.join(':').trim();
         const cleanKey = key.trim().toLowerCase();
-
         if (Object.prototype.hasOwnProperty.call(metadata, cleanKey)) {
           metadata[cleanKey] = value;
         }
       }
     }
   } else {
-    // Handle simple key-value format (key: value lines at start of file)
     const lines = content.split('\n');
     for (const line of lines) {
       const trimmedLine = line.trim();
@@ -56,12 +42,10 @@ function parseMetadata(content) {
         const [key, ...valueParts] = trimmedLine.split(':');
         const value = valueParts.join(':').trim();
         const cleanKey = key.trim().toLowerCase();
-
         if (Object.prototype.hasOwnProperty.call(metadata, cleanKey)) {
           metadata[cleanKey] = value;
         }
       } else if (trimmedLine.startsWith('#') || trimmedLine === '') {
-        // Stop parsing when we hit content
         break;
       }
     }
@@ -71,10 +55,7 @@ function parseMetadata(content) {
 }
 
 function getAvailableEpics() {
-  if (!fs.existsSync('.claude/epics')) {
-    return [];
-  }
-
+  if (!fs.existsSync('.claude/epics')) return [];
   try {
     return fs.readdirSync('.claude/epics', { withFileTypes: true })
       .filter(dirent => dirent.isDirectory())
@@ -85,91 +66,36 @@ function getAvailableEpics() {
 }
 
 function isTaskClosed(status) {
-  const lowerStatus = (status || '').toLowerCase();
-  return ['closed', 'completed'].includes(lowerStatus);
-}
-
-function hasValidDependencies(depsString) {
-  if (!depsString || depsString.trim() === '') {
-    return false;
-  }
-
-  // Handle malformed dependency strings
-  if (depsString === 'depends_on:') {
-    return false;
-  }
-
-  // Clean up the dependency string
-  let cleanDeps = depsString.trim();
-
-  // Remove array brackets if present
-  cleanDeps = cleanDeps.replace(/^\[|\]$/g, '');
-
-  // Check if there's actual content after cleaning
-  cleanDeps = cleanDeps.trim();
-
-  return cleanDeps.length > 0;
-}
-
-function generateProgressBar(percent) {
-  const totalChars = 20;
-  const filled = Math.round((percent * totalChars) / 100);
-  const empty = totalChars - filled;
-
-  let bar = '[';
-  bar += '█'.repeat(filled);
-  bar += '░'.repeat(empty);
-  bar += ']';
-
-  return {
-    bar,
-    percent,
-    filled,
-    empty
-  };
+  return ['closed', 'completed', 'done'].includes((status || '').toLowerCase());
 }
 
 function epicStatus(epicName) {
   if (!epicName || epicName.trim() === '') {
-    throw new Error('❌ Please specify an epic name\nUsage: /pm:epic-status <epic-name>');
+    throw new Error('Please specify an epic name\nUsage: /pm:epic-status <epic-name>');
   }
 
   const epicDir = `.claude/epics/${epicName}`;
   const epicFilePath = `${epicDir}/epic.md`;
 
-  // Check if epic exists
   if (!fs.existsSync(epicFilePath)) {
     const availableEpics = getAvailableEpics();
-    let errorMessage = `❌ Epic not found: ${epicName}\n\nAvailable epics:`;
-
+    let errorMessage = `Epic not found: ${epicName}\n\nAvailable epics:`;
     if (availableEpics.length > 0) {
-      for (const epic of availableEpics) {
-        errorMessage += `\n  • ${epic}`;
-      }
+      for (const epic of availableEpics) errorMessage += `\n  - ${epic}`;
     } else {
       errorMessage += '\n  (none)';
     }
-
     throw new Error(errorMessage);
   }
 
-  // Parse epic metadata
   let epicMetadata;
   try {
     const epicContent = fs.readFileSync(epicFilePath, 'utf8');
     epicMetadata = parseMetadata(epicContent);
   } catch (error) {
-    // Use defaults if file can't be read
-    epicMetadata = {
-      name: epicName,
-      status: 'planning',
-      progress: '0%',
-      github: '',
-      created: 'unknown'
-    };
+    epicMetadata = { name: epicName, status: 'planning', progress: '0%', github: '', created: 'unknown' };
   }
 
-  // Apply defaults
   const epic = {
     name: epicMetadata.name || epicName,
     status: epicMetadata.status || 'planning',
@@ -178,105 +104,87 @@ function epicStatus(epicName) {
   };
 
   // Analyze tasks
+  const tasks = [];
   let totalTasks = 0;
-  let openTasks = 0;
   let closedTasks = 0;
-  let blockedTasks = 0;
 
   try {
     const files = fs.readdirSync(epicDir);
-    const taskFiles = files.filter(file => /^\d+\.md$/.test(file));
+    const taskFiles = files.filter(file => /^\d+\.md$/.test(file)).sort((a, b) => parseInt(a) - parseInt(b));
 
     for (const file of taskFiles) {
       const taskFilePath = path.join(epicDir, file);
+      const taskNum = path.basename(file, '.md');
 
       let taskMetadata;
       try {
         const taskContent = fs.readFileSync(taskFilePath, 'utf8');
         taskMetadata = parseMetadata(taskContent);
       } catch (error) {
-        // Use defaults if file can't be read
-        taskMetadata = {
-          status: 'open',
-          depends_on: ''
-        };
+        taskMetadata = { name: '', status: 'open', depends_on: '', updated: '' };
       }
 
       const status = taskMetadata.status || 'open';
-      const depsString = taskMetadata.depends_on || '';
+      const taskName = taskMetadata.name || `Task #${taskNum}`;
+      const updated = taskMetadata.updated ? taskMetadata.updated.split('T')[0] : '\u2014';
 
       totalTasks++;
+      if (isTaskClosed(status)) closedTasks++;
 
-      if (isTaskClosed(status)) {
-        closedTasks++;
-      } else if (hasValidDependencies(depsString)) {
-        // Task is open but has dependencies - consider it blocked
-        blockedTasks++;
-      } else {
-        // Task is open and has no dependencies
-        openTasks++;
-      }
+      tasks.push({ num: taskNum, name: taskName, status, updated });
     }
-  } catch (error) {
-    // Directory can't be read, continue with zero tasks
-  }
+  } catch (error) { /* skip */ }
 
-  // Calculate progress
-  let progressData;
-  if (totalTasks > 0) {
-    const percent = Math.round((closedTasks * 100) / totalTasks);
-    progressData = generateProgressBar(percent);
-    progressData.message = `Progress: ${progressData.bar} ${percent}%`;
-  } else {
-    progressData = {
-      bar: '',
-      percent: 0,
-      filled: 0,
-      empty: 0,
-      message: 'Progress: No tasks created'
-    };
-  }
+  const progressPercent = totalTasks > 0 ? Math.round((closedTasks * 100) / totalTasks) : 0;
 
   return {
     epic,
-    taskBreakdown: {
-      totalTasks,
-      openTasks,
-      closedTasks,
-      blockedTasks
-    },
-    progressBar: progressData
+    tasks,
+    taskBreakdown: { totalTasks, closedTasks },
+    progressPercent
   };
 }
 
 function formatEpicStatus(epicName, data) {
-  let output = 'Getting status...\n\n\n';
+  const lines = [];
 
-  output += `📚 Epic Status: ${epicName}\n`;
-  output += '================================\n\n';
+  lines.push(`## Epic: ${data.epic.name}`);
+  lines.push('');
+  lines.push(`**Status:** ${data.epic.status} | **Progress:** ${data.progressPercent}% | **Tasks:** ${data.taskBreakdown.closedTasks}/${data.taskBreakdown.totalTasks} done`);
+  lines.push('');
 
-  // Progress bar
-  output += `${data.progressBar.message}\n\n`;
-
-  // Task breakdown
-  output += '📊 Breakdown:\n';
-  output += `  Total tasks: ${data.taskBreakdown.totalTasks}\n`;
-  output += `  ✅ Completed: ${data.taskBreakdown.closedTasks}\n`;
-  output += `  🔄 Available: ${data.taskBreakdown.openTasks}\n`;
-  output += `  ⏸️ Blocked: ${data.taskBreakdown.blockedTasks}\n`;
-
-  // GitHub link if available
-  if (data.epic.github) {
-    output += `\n🔗 GitHub: ${data.epic.github}\n`;
+  if (data.tasks.length > 0) {
+    lines.push('| # | Task | Status | Updated |');
+    lines.push('|---|------|--------|---------|');
+    for (const t of data.tasks) {
+      lines.push(`| ${t.num} | ${t.name} | ${t.status} | ${t.updated} |`);
+    }
+  } else {
+    lines.push('No tasks created yet.');
   }
 
-  return output;
+  // Find next open task for suggestion
+  const nextOpen = data.tasks.find(t => t.status === 'open');
+
+  // Recent Activity section
+  try {
+    const { formatRecentActivity } = require('../../../../autopm/.claude/lib/event-logger');
+    lines.push('');
+    lines.push(formatRecentActivity(7));
+  } catch (e) { /* event logger not available */ }
+
+  lines.push('');
+  if (nextOpen) {
+    lines.push(`Next: /pm:issue-start ${nextOpen.num}`);
+  } else {
+    lines.push('Next: /pm:next');
+  }
+
+  return lines.join('\n');
 }
 
-// CommonJS export for testing
 module.exports = epicStatus;
 
-// CLI execution
 if (require.main === module) {
   const epicName = process.argv[2];
 

--- a/packages/plugin-pm/scripts/pm/in-progress.js
+++ b/packages/plugin-pm/scripts/pm/in-progress.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * PM In-Progress Script - Node.js Implementation
- *
- * Migrated from in-progress.sh to show active work items
- * Maintains full compatibility with the original bash implementation
+ * PM In-Progress Script
+ * Outputs markdown pipe table for active work items
  */
 
 const fs = require('fs');
@@ -17,9 +15,7 @@ function getInProgressWork() {
     totalActive: 0
   };
 
-  if (!fs.existsSync('.claude/epics')) {
-    return result;
-  }
+  if (!fs.existsSync('.claude/epics')) return result;
 
   try {
     const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
@@ -39,138 +35,102 @@ function getInProgressWork() {
 
           for (const issueNum of updateDirs) {
             const progressFile = path.join(updatesPath, issueNum, 'progress.md');
+            if (!fs.existsSync(progressFile)) continue;
 
-            if (fs.existsSync(progressFile)) {
-              try {
-                const progressContent = fs.readFileSync(progressFile, 'utf8');
+            try {
+              const progressContent = fs.readFileSync(progressFile, 'utf8');
+              const completionMatch = progressContent.match(/^completion:\s*(.*)$/m);
+              const completion = completionMatch ? completionMatch[1].trim() : '0%';
+              const lastSyncMatch = progressContent.match(/^last_sync:\s*(.*)$/m);
+              const lastSync = lastSyncMatch ? lastSyncMatch[1].trim() : null;
 
-                // Extract completion percentage
-                const completionMatch = progressContent.match(/^completion:\s*(.*)$/m);
-                const completion = completionMatch ? completionMatch[1].trim() : '0%';
-
-                // Extract last sync
-                const lastSyncMatch = progressContent.match(/^last_sync:\s*(.*)$/m);
-                const lastSync = lastSyncMatch ? lastSyncMatch[1].trim() : null;
-
-                // Get task name from task file
-                const taskFile = path.join(epicPath, `${issueNum}.md`);
-                let taskName = 'Unknown task';
-
-                if (fs.existsSync(taskFile)) {
-                  try {
-                    const taskContent = fs.readFileSync(taskFile, 'utf8');
-                    const nameMatch = taskContent.match(/^name:\s*(.*)$/m);
-                    if (nameMatch) {
-                      taskName = nameMatch[1].trim();
-                    }
-                  } catch (error) {
-                    // Keep default task name
-                  }
-                }
-
-                result.activeIssues.push({
-                  issueNum,
-                  epicName,
-                  taskName,
-                  completion,
-                  lastSync
-                });
-
-                result.totalActive++;
-              } catch (error) {
-                // Skip unreadable progress files
-                continue;
+              const taskFile = path.join(epicPath, `${issueNum}.md`);
+              let taskName = 'Unknown task';
+              if (fs.existsSync(taskFile)) {
+                try {
+                  const taskContent = fs.readFileSync(taskFile, 'utf8');
+                  const nameMatch = taskContent.match(/^name:\s*(.*)$/m);
+                  if (nameMatch) taskName = nameMatch[1].trim();
+                } catch (error) { /* keep default */ }
               }
-            }
+
+              result.activeIssues.push({ issueNum, epicName, taskName, completion, lastSync });
+              result.totalActive++;
+            } catch (error) { continue; }
           }
-        } catch (error) {
-          // Skip unreadable updates directories
-          continue;
-        }
+        } catch (error) { continue; }
       }
     }
 
     // Check for active epics
     for (const epicName of epicDirs) {
       const epicFile = path.join('.claude/epics', epicName, 'epic.md');
+      if (!fs.existsSync(epicFile)) continue;
 
-      if (fs.existsSync(epicFile)) {
-        try {
-          const epicContent = fs.readFileSync(epicFile, 'utf8');
+      try {
+        const epicContent = fs.readFileSync(epicFile, 'utf8');
+        const statusMatch = epicContent.match(/^status:\s*(.*)$/m);
+        const status = statusMatch ? statusMatch[1].trim() : '';
 
-          const statusMatch = epicContent.match(/^status:\s*(.*)$/m);
-          const status = statusMatch ? statusMatch[1].trim() : '';
+        if (status === 'in-progress' || status === 'active') {
+          const nameMatch = epicContent.match(/^name:\s*(.*)$/m);
+          const name = nameMatch ? nameMatch[1].trim() : epicName;
+          const progressMatch = epicContent.match(/^progress:\s*(.*)$/m);
+          const progress = progressMatch ? progressMatch[1].trim() : '0%';
+          const updatedMatch = epicContent.match(/^updated:\s*(.*)$/m);
+          const updated = updatedMatch ? updatedMatch[1].trim().split('T')[0] : '\u2014';
 
-          if (status === 'in-progress' || status === 'active') {
-            const nameMatch = epicContent.match(/^name:\s*(.*)$/m);
-            const name = nameMatch ? nameMatch[1].trim() : epicName;
-
-            const progressMatch = epicContent.match(/^progress:\s*(.*)$/m);
-            const progress = progressMatch ? progressMatch[1].trim() : '0%';
-
-            result.activeEpics.push({
-              name,
-              status,
-              progress
-            });
-          }
-        } catch (error) {
-          // Skip unreadable epic files
-          continue;
+          result.activeEpics.push({ name, status, progress, epicName, updated });
         }
-      }
+      } catch (error) { continue; }
     }
-  } catch (error) {
-    // Directory doesn't exist or can't be read
-  }
+  } catch (error) { /* skip */ }
 
   return result;
 }
 
 function formatInProgressOutput(data) {
-  let output = 'Getting status...\n\n\n';
-  output += '🔄 In Progress Work\n';
-  output += '===================\n\n';
+  const lines = [];
 
-  // Active issues
-  if (data.activeIssues.length > 0) {
-    for (const issue of data.activeIssues) {
-      output += `📝 Issue #${issue.issueNum} - ${issue.taskName}\n`;
-      output += `   Epic: ${issue.epicName}\n`;
-      output += `   Progress: ${issue.completion} complete\n`;
+  lines.push('## In Progress');
+  lines.push('');
 
-      if (issue.lastSync) {
-        output += `   Last update: ${issue.lastSync}\n`;
-      }
+  const rows = [];
 
-      output += '\n';
-    }
+  for (const issue of data.activeIssues) {
+    rows.push({ num: issue.issueNum, title: issue.taskName, type: 'task', epic: issue.epicName, started: issue.lastSync ? issue.lastSync.split('T')[0] : '\u2014' });
   }
 
-  // Active epics
-  output += '📚 Active Epics:\n';
-  if (data.activeEpics.length > 0) {
-    for (const epic of data.activeEpics) {
-      output += `   • ${epic.name} - ${epic.progress} complete\n`;
-    }
+  for (const epic of data.activeEpics) {
+    rows.push({ num: '\u2014', title: epic.name, type: 'epic', epic: '\u2014', started: epic.updated });
   }
 
-  output += '\n';
-
-  if (data.totalActive === 0) {
-    output += 'No active work items found.\n\n';
-    output += '💡 Start work with: /pm:next\n';
+  if (rows.length > 0) {
+    lines.push('| # | Title | Type | Epic | Started |');
+    lines.push('|---|-------|------|------|---------|');
+    for (const r of rows) {
+      lines.push(`| ${r.num} | ${r.title} | ${r.type} | ${r.epic} | ${r.started} |`);
+    }
+    lines.push('');
+    lines.push(`Total: ${rows.length} items in progress`);
   } else {
-    output += `📊 Total active items: ${data.totalActive}\n`;
+    lines.push('No active work items found.');
+    lines.push('');
+    lines.push('Next: /pm:next');
   }
 
-  return output;
+  // Recent Activity section
+  try {
+    const { formatRecentActivity } = require('../../../../autopm/.claude/lib/event-logger');
+    lines.push('');
+    lines.push(formatRecentActivity(7));
+  } catch (e) { /* event logger not available */ }
+
+  return lines.join('\n');
 }
 
-// CommonJS export for testing
 module.exports = getInProgressWork;
 
-// CLI execution
 if (require.main === module) {
   const data = getInProgressWork();
   console.log(formatInProgressOutput(data));

--- a/packages/plugin-pm/scripts/pm/standup.js
+++ b/packages/plugin-pm/scripts/pm/standup.js
@@ -2,347 +2,287 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * PM Standup Script (Node.js version)
- * Migrated from bash script with 100% backward compatibility
+ * PM Standup Script
+ * Outputs markdown pipe tables for daily standup report
  */
 
 async function standup() {
-  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
+  const today = new Date().toISOString().split('T')[0];
 
   const result = {
     date: today,
-    activity: { prdCount: 0, epicCount: 0, taskCount: 0, updateCount: 0 },
+    completed: [],
     inProgress: [],
-    nextTasks: [],
+    blocked: [],
     stats: { totalTasks: 0, openTasks: 0, closedTasks: 0 },
     messages: []
   };
 
-  // Helper function to add messages
   function addMessage(message) {
     result.messages.push(message);
-    // Only log if running as CLI
     if (require.main === module) {
       console.log(message);
     }
   }
 
-  // Header messages to match bash output exactly
-  addMessage(`📅 Daily Standup - ${today}`);
-  addMessage('================================');
-  addMessage('');
+  const oneDayAgo = Date.now() - (24 * 60 * 60 * 1000);
 
-  addMessage('Getting status...');
-  addMessage('');
-  addMessage('');
+  // Scan epics for task data
+  if (fs.existsSync('.claude/epics')) {
+    try {
+      const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name);
 
-  addMessage('📝 Today\'s Activity:');
-  addMessage('====================');
-  addMessage('');
+      for (const epicName of epicDirs) {
+        const epicPath = path.join('.claude/epics', epicName);
 
-  // Find files modified today
-  try {
-    const recentFiles = await findRecentFiles('.claude');
+        // Check epic status
+        const epicFile = path.join(epicPath, 'epic.md');
+        if (fs.existsSync(epicFile)) {
+          try {
+            const epicContent = fs.readFileSync(epicFile, 'utf8');
+            const statusMatch = epicContent.match(/^status:\s*(.*)$/m);
+            const epicStatus = statusMatch ? statusMatch[1].trim().toLowerCase() : '';
+            const nameMatch = epicContent.match(/^name:\s*(.*)$/m);
+            const name = nameMatch ? nameMatch[1].trim() : epicName;
+            const updatedMatch = epicContent.match(/^updated:\s*(.*)$/m);
+            const updated = updatedMatch ? updatedMatch[1].trim() : '';
 
-    // Count by type
-    for (const filePath of recentFiles) {
-      if (filePath.includes('/prds/')) {
-        result.activity.prdCount++;
-      } else if (filePath.endsWith('/epic.md')) {
-        result.activity.epicCount++;
-      } else if (/\/\d+\.md$/.test(filePath)) {
-        result.activity.taskCount++;
-      } else if (filePath.includes('/updates/')) {
-        result.activity.updateCount++;
+            if (epicStatus === 'in-progress' || epicStatus === 'in_progress' || epicStatus === 'active') {
+              result.inProgress.push({ item: name, type: 'epic', started: updated || '-', assignee: '@me' });
+            }
+          } catch (err) { /* skip */ }
+        }
+
+        // Check tasks
+        try {
+          const taskFiles = fs.readdirSync(epicPath).filter(file => /^[0-9].*\.md$/.test(file));
+
+          for (const taskFile of taskFiles) {
+            const taskPath = path.join(epicPath, taskFile);
+
+            try {
+              const content = fs.readFileSync(taskPath, 'utf8');
+              const statusMatch = content.match(/^status:\s*(.+)$/m);
+              const status = statusMatch ? statusMatch[1].trim().toLowerCase() : 'open';
+              const nameMatch = content.match(/^name:\s*(.+)$/m);
+              const taskName = nameMatch ? nameMatch[1].trim() : taskFile;
+              const updatedMatch = content.match(/^updated:\s*(.+)$/m);
+              const updated = updatedMatch ? updatedMatch[1].trim() : '';
+              const updatedDate = updated ? updated.split('T')[0] : '';
+
+              const depsMatch = content.match(/^depends_on:\s*\[(.+?)\]/m);
+              const hasDeps = depsMatch && depsMatch[1].trim().length > 0;
+
+              // Stats
+              result.stats.totalTasks++;
+              if (status === 'closed' || status === 'completed' || status === 'done') {
+                result.stats.closedTasks++;
+              } else {
+                result.stats.openTasks++;
+              }
+
+              // Recently completed (closed + modified in last 24h)
+              if (status === 'closed' || status === 'completed' || status === 'done') {
+                try {
+                  const stats = fs.statSync(taskPath);
+                  if (stats.mtime.getTime() > oneDayAgo) {
+                    result.completed.push({ item: taskName, type: 'task', completed: updatedDate || today });
+                  }
+                } catch (err) { /* skip */ }
+              }
+
+              // In progress tasks
+              if (status === 'in-progress' || status === 'in_progress' || status === 'active') {
+                result.inProgress.push({ item: taskName, type: 'task', started: updatedDate || '-', assignee: '@me' });
+              }
+
+              // Blocked tasks
+              if (hasDeps && (status === 'open' || status === 'blocked')) {
+                result.blocked.push({ item: taskName, blocker: `Depends on [${depsMatch[1].trim()}]`, since: updatedDate || '-' });
+              }
+            } catch (err) { /* skip task */ }
+          }
+        } catch (err) { /* skip epic dir */ }
       }
-    }
+    } catch (err) { /* no epics */ }
+  }
 
-    // Display activity counts
-    if (result.activity.prdCount > 0) {
-      addMessage(`  • Modified ${result.activity.prdCount} PRD(s)`);
-    }
-    if (result.activity.epicCount > 0) {
-      addMessage(`  • Updated ${result.activity.epicCount} epic(s)`);
-    }
-    if (result.activity.taskCount > 0) {
-      addMessage(`  • Worked on ${result.activity.taskCount} task(s)`);
-    }
-    if (result.activity.updateCount > 0) {
-      addMessage(`  • Posted ${result.activity.updateCount} progress update(s)`);
-    }
+  // Output markdown tables
+  addMessage('## Standup Report');
+  addMessage('');
 
-    if (recentFiles.length === 0) {
-      addMessage('  No activity recorded today');
+  // Completed section
+  addMessage('### Completed (since last standup)');
+  if (result.completed.length > 0) {
+    addMessage('| Item | Type | Completed |');
+    addMessage('|------|------|-----------|');
+    for (const c of result.completed) {
+      addMessage(`| ${c.item} | ${c.type} | ${c.completed} |`);
     }
-  } catch (err) {
-    addMessage('  No activity recorded today');
+  } else {
+    addMessage('No items completed since last standup.');
   }
 
   addMessage('');
-  addMessage('🔄 Currently In Progress:');
 
-  // Show active work items
-  try {
-    const inProgressItems = await findInProgressTasks();
-    result.inProgress = inProgressItems;
-
-    for (const item of inProgressItems) {
-      addMessage(`  • Issue #${item.issueNum} (${item.epicName}) - ${item.completion || '0%'} complete`);
+  // In Progress section
+  addMessage('### In Progress');
+  if (result.inProgress.length > 0) {
+    addMessage('| Item | Type | Started | Assignee |');
+    addMessage('|------|------|---------|----------|');
+    for (const ip of result.inProgress) {
+      addMessage(`| ${ip.item} | ${ip.type} | ${ip.started} | ${ip.assignee} |`);
     }
-  } catch (err) {
-    // Silently handle errors
+  } else {
+    addMessage('No items currently in progress.');
   }
 
   addMessage('');
-  addMessage('⏭️ Next Available Tasks:');
 
-  // Show top 3 available tasks
-  try {
-    const availableTasks = await findAvailableTasks(3);
-    result.nextTasks = availableTasks;
-
-    for (const task of availableTasks) {
-      addMessage(`  • #${task.taskNum} - ${task.name}`);
+  // Blocked section
+  addMessage('### Blocked');
+  if (result.blocked.length > 0) {
+    addMessage('| Item | Blocker | Since |');
+    addMessage('|------|---------|-------|');
+    for (const b of result.blocked) {
+      addMessage(`| ${b.item} | ${b.blocker} | ${b.since} |`);
     }
-  } catch (err) {
-    // Silently handle errors
+  } else {
+    addMessage('No blocked items.');
   }
+
+  // Recent Activity section
+  try {
+    const { formatRecentActivity } = require('../../../../autopm/.claude/lib/event-logger');
+    addMessage('');
+    addMessage(formatRecentActivity(7));
+  } catch (e) { /* event logger not available */ }
 
   addMessage('');
-  addMessage('📊 Quick Stats:');
-
-  // Calculate task statistics
-  try {
-    const stats = await calculateTaskStats();
-    result.stats = stats;
-
-    addMessage(`  Tasks:        ${stats.openTasks} open,        ${stats.closedTasks} closed,        ${stats.totalTasks} total`);
-  } catch (err) {
-    addMessage('  Tasks:        0 open,        0 closed,        0 total');
-  }
+  addMessage('Next: /pm:next');
 
   return result;
 }
 
-// Helper function to find files modified today
+// Helper functions kept for module compatibility
 async function findRecentFiles(directory) {
   const files = [];
-
-  if (!fs.existsSync(directory)) {
-    return files;
-  }
-
+  if (!fs.existsSync(directory)) return files;
   const oneDayAgo = Date.now() - (24 * 60 * 60 * 1000);
 
   function scanDirectory(dir) {
     try {
       const items = fs.readdirSync(dir, { withFileTypes: true });
-
       for (const item of items) {
         const fullPath = path.join(dir, item.name);
-
         if (item.isDirectory()) {
           scanDirectory(fullPath);
         } else if (item.isFile() && item.name.endsWith('.md')) {
           try {
             const stats = fs.statSync(fullPath);
-            if (stats.mtime.getTime() > oneDayAgo) {
-              files.push(fullPath);
-            }
-          } catch (err) {
-            // Skip files we can't stat
-          }
+            if (stats.mtime.getTime() > oneDayAgo) files.push(fullPath);
+          } catch (err) { /* skip */ }
         }
       }
-    } catch (err) {
-      // Skip directories we can't read
-    }
+    } catch (err) { /* skip */ }
   }
 
   scanDirectory(directory);
   return files;
 }
 
-// Helper function to find tasks currently in progress
 async function findInProgressTasks() {
   const inProgress = [];
-
-  if (!fs.existsSync('.claude/epics')) {
-    return inProgress;
-  }
+  if (!fs.existsSync('.claude/epics')) return inProgress;
 
   try {
     const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .map(dirent => dirent.name);
+      .filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
 
     for (const epicName of epicDirs) {
       const updatesDir = path.join('.claude/epics', epicName, 'updates');
-
-      if (fs.existsSync(updatesDir)) {
-        try {
-          const updateDirs = fs.readdirSync(updatesDir, { withFileTypes: true })
-            .filter(dirent => dirent.isDirectory())
-            .map(dirent => dirent.name);
-
-          for (const issueNum of updateDirs) {
-            const progressFile = path.join(updatesDir, issueNum, 'progress.md');
-
-            if (fs.existsSync(progressFile)) {
-              try {
-                const content = fs.readFileSync(progressFile, 'utf8');
-                const completionMatch = content.match(/^completion:\s*(.+)$/m);
-                const completion = completionMatch ? completionMatch[1].trim() : '0%';
-
-                inProgress.push({
-                  issueNum,
-                  epicName,
-                  completion
-                });
-              } catch (err) {
-                // Skip files we can't read
-              }
-            }
-          }
-        } catch (err) {
-          // Skip directories we can't read
+      if (!fs.existsSync(updatesDir)) continue;
+      try {
+        const updateDirs = fs.readdirSync(updatesDir, { withFileTypes: true })
+          .filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
+        for (const issueNum of updateDirs) {
+          const progressFile = path.join(updatesDir, issueNum, 'progress.md');
+          if (!fs.existsSync(progressFile)) continue;
+          try {
+            const content = fs.readFileSync(progressFile, 'utf8');
+            const completionMatch = content.match(/^completion:\s*(.+)$/m);
+            inProgress.push({ issueNum, epicName, completion: completionMatch ? completionMatch[1].trim() : '0%' });
+          } catch (err) { /* skip */ }
         }
-      }
+      } catch (err) { /* skip */ }
     }
-  } catch (err) {
-    // Silently handle errors
-  }
+  } catch (err) { /* skip */ }
 
   return inProgress;
 }
 
-// Helper function to find next available tasks
 async function findAvailableTasks(limit = 3) {
   const availableTasks = [];
-
-  if (!fs.existsSync('.claude/epics')) {
-    return availableTasks;
-  }
+  if (!fs.existsSync('.claude/epics')) return availableTasks;
 
   try {
     const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .map(dirent => dirent.name);
+      .filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
 
     for (const epicName of epicDirs) {
+      if (availableTasks.length >= limit) break;
       const epicPath = path.join('.claude/epics', epicName);
-
-      if (availableTasks.length >= limit) {
-        break;
-      }
-
       try {
-        const taskFiles = fs.readdirSync(epicPath)
-          .filter(file => /^[0-9].*\.md$/.test(file))
-          .sort();
-
+        const taskFiles = fs.readdirSync(epicPath).filter(file => /^[0-9].*\.md$/.test(file)).sort();
         for (const taskFile of taskFiles) {
-          if (availableTasks.length >= limit) {
-            break;
-          }
-
-          const taskPath = path.join(epicPath, taskFile);
-
+          if (availableTasks.length >= limit) break;
           try {
-            const content = fs.readFileSync(taskPath, 'utf8');
-
-            // Check if task is open
+            const content = fs.readFileSync(path.join(epicPath, taskFile), 'utf8');
             const statusMatch = content.match(/^status:\s*(.+)$/m);
             const status = statusMatch ? statusMatch[1].trim() : '';
-
-            if (status !== 'open' && status !== '') {
-              continue; // Skip non-open tasks
-            }
-
-            // Check dependencies
+            if (status !== 'open' && status !== '') continue;
             const depsMatch = content.match(/^depends_on:\s*\[(.*?)\]/m);
-            const deps = depsMatch ? depsMatch[1].trim() : '';
-
-            // If no dependencies or empty, task is available
-            if (!deps || deps === '') {
-              const nameMatch = content.match(/^name:\s*(.+)$/m);
-              const name = nameMatch ? nameMatch[1].trim() : 'Unnamed Task';
-              const taskNum = path.basename(taskFile, '.md');
-
-              availableTasks.push({
-                taskNum,
-                name,
-                epicName
-              });
-            }
-          } catch (err) {
-            // Skip files we can't read
-          }
+            if (depsMatch && depsMatch[1].trim()) continue;
+            const nameMatch = content.match(/^name:\s*(.+)$/m);
+            availableTasks.push({ taskNum: path.basename(taskFile, '.md'), name: nameMatch ? nameMatch[1].trim() : 'Unnamed Task', epicName });
+          } catch (err) { /* skip */ }
         }
-      } catch (err) {
-        // Skip directories we can't read
-      }
+      } catch (err) { /* skip */ }
     }
-  } catch (err) {
-    // Silently handle errors
-  }
+  } catch (err) { /* skip */ }
 
   return availableTasks;
 }
 
-// Helper function to calculate task statistics
 async function calculateTaskStats() {
   const stats = { totalTasks: 0, openTasks: 0, closedTasks: 0 };
-
-  if (!fs.existsSync('.claude/epics')) {
-    return stats;
-  }
+  if (!fs.existsSync('.claude/epics')) return stats;
 
   try {
     const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .map(dirent => dirent.name);
+      .filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
 
     for (const epicName of epicDirs) {
-      const epicPath = path.join('.claude/epics', epicName);
-
       try {
-        const taskFiles = fs.readdirSync(epicPath)
-          .filter(file => /^[0-9].*\.md$/.test(file));
-
+        const taskFiles = fs.readdirSync(path.join('.claude/epics', epicName)).filter(file => /^[0-9].*\.md$/.test(file));
         for (const taskFile of taskFiles) {
           stats.totalTasks++;
-
           try {
-            const taskPath = path.join(epicPath, taskFile);
-            const content = fs.readFileSync(taskPath, 'utf8');
-
-            // Check status line
+            const content = fs.readFileSync(path.join('.claude/epics', epicName, taskFile), 'utf8');
             const statusMatch = content.match(/^status:\s*(.+)$/m);
-            const status = statusMatch ? statusMatch[1].trim() : '';
-
-            if (status === 'closed') {
-              stats.closedTasks++;
-            } else {
-              stats.openTasks++;
-            }
-          } catch (err) {
-            // If we can't read the file, count as open
-            stats.openTasks++;
-          }
+            if (statusMatch && statusMatch[1].trim() === 'closed') stats.closedTasks++;
+            else stats.openTasks++;
+          } catch (err) { stats.openTasks++; }
         }
-      } catch (err) {
-        // Skip directories we can't read
-      }
+      } catch (err) { /* skip */ }
     }
-  } catch (err) {
-    // Silently handle errors
-  }
+  } catch (err) { /* skip */ }
 
   return stats;
 }
 
-// Export for use as module
 module.exports = {
   standup,
   findRecentFiles,
@@ -351,9 +291,8 @@ module.exports = {
   calculateTaskStats
 };
 
-// CLI execution
 if (require.main === module) {
-  module.exports.standup().then(result => {
+  module.exports.standup().then(() => {
     process.exit(0);
   }).catch(err => {
     console.error('Standup failed:', err.message);

--- a/packages/plugin-pm/scripts/pm/status.js
+++ b/packages/plugin-pm/scripts/pm/status.js
@@ -2,144 +2,133 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * PM Status Script (Node.js version)
- * Migrated from bash script with 100% backward compatibility
+ * PM Status Script
+ * Outputs markdown pipe tables for project status overview
  */
 
 async function status() {
   const result = {
-    prds: { total: 0, found: false },
-    epics: { total: 0, found: false },
-    tasks: { total: 0, open: 0, closed: 0, found: false },
+    prds: { total: 0, open: 0, inProgress: 0, done: 0, blocked: 0, found: false },
+    epics: { total: 0, open: 0, inProgress: 0, done: 0, blocked: 0, found: false },
+    tasks: { total: 0, open: 0, inProgress: 0, done: 0, blocked: 0, found: false },
     messages: []
   };
 
-  // Helper function to add messages
   function addMessage(message) {
     result.messages.push(message);
-    // Only log if running as CLI
     if (require.main === module) {
       console.log(message);
     }
   }
 
-  // Header messages to match bash output exactly
-  addMessage('Getting status...');
-  addMessage('');
-  addMessage('');
-  addMessage('📊 Project Status');
-  addMessage('================');
-  addMessage('');
-
-  // Check PRDs
-  addMessage('📄 PRDs:');
+  // Count PRDs by status
   try {
     if (fs.existsSync('.claude/prds') && fs.statSync('.claude/prds').isDirectory()) {
-      const prdFiles = fs.readdirSync('.claude/prds')
-        .filter(file => file.endsWith('.md'));
-
-      result.prds.total = prdFiles.length;
+      const prdFiles = fs.readdirSync('.claude/prds').filter(file => file.endsWith('.md'));
       result.prds.found = true;
-      addMessage(`  Total:        ${result.prds.total}`);
-    } else {
-      addMessage('  No PRDs found');
+
+      for (const file of prdFiles) {
+        result.prds.total++;
+        try {
+          const content = fs.readFileSync(path.join('.claude/prds', file), 'utf8');
+          const statusMatch = content.match(/^status:\s*(.+)$/m);
+          const s = statusMatch ? statusMatch[1].trim().toLowerCase() : 'backlog';
+
+          if (s === 'complete' || s === 'completed' || s === 'done') result.prds.done++;
+          else if (s === 'in-progress' || s === 'in_progress' || s === 'active') result.prds.inProgress++;
+          else if (s === 'blocked') result.prds.blocked++;
+          else result.prds.open++;
+        } catch (err) {
+          result.prds.open++;
+        }
+      }
     }
-  } catch (err) {
-    addMessage('  No PRDs found');
-  }
+  } catch (err) { /* no PRDs */ }
 
-  addMessage('');
-
-  // Check Epics
-  addMessage('📚 Epics:');
-  try {
-    if (fs.existsSync('.claude/epics') && fs.statSync('.claude/epics').isDirectory()) {
-      const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .length;
-
-      result.epics.total = epicDirs;
-      result.epics.found = true;
-      addMessage(`  Total:        ${result.epics.total}`);
-    } else {
-      addMessage('  No epics found');
-    }
-  } catch (err) {
-    addMessage('  No epics found');
-  }
-
-  addMessage('');
-
-  // Check Tasks
-  addMessage('📝 Tasks:');
+  // Count Epics by status
   try {
     if (fs.existsSync('.claude/epics') && fs.statSync('.claude/epics').isDirectory()) {
       const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
         .filter(dirent => dirent.isDirectory())
         .map(dirent => dirent.name);
 
-      let totalTasks = 0;
-      let openTasks = 0;
-      let closedTasks = 0;
+      result.epics.found = true;
 
-      for (const epicDir of epicDirs) {
-        const epicPath = path.join('.claude/epics', epicDir);
-
+      for (const epicName of epicDirs) {
+        result.epics.total++;
+        const epicFile = path.join('.claude/epics', epicName, 'epic.md');
         try {
-          const taskFiles = fs.readdirSync(epicPath)
-            .filter(file => /^[0-9].*\.md$/.test(file));
+          if (fs.existsSync(epicFile)) {
+            const content = fs.readFileSync(epicFile, 'utf8');
+            const statusMatch = content.match(/^status:\s*(.+)$/m);
+            const s = statusMatch ? statusMatch[1].trim().toLowerCase() : 'backlog';
 
-          for (const taskFile of taskFiles) {
-            totalTasks++;
-
-            try {
-              const taskPath = path.join(epicPath, taskFile);
-              const content = fs.readFileSync(taskPath, 'utf8');
-
-              // Check status line
-              const statusMatch = content.match(/^status:\s*(.+)$/m);
-              const status = statusMatch ? statusMatch[1].trim() : '';
-
-              if (status === 'closed') {
-                closedTasks++;
-              } else {
-                // Anything that's not explicitly closed is considered open
-                openTasks++;
-              }
-            } catch (err) {
-              // If we can't read the file, count as open
-              openTasks++;
-            }
+            if (s === 'completed' || s === 'complete' || s === 'done') result.epics.done++;
+            else if (s === 'in-progress' || s === 'in_progress' || s === 'active') result.epics.inProgress++;
+            else if (s === 'blocked') result.epics.blocked++;
+            else result.epics.open++;
+          } else {
+            result.epics.open++;
           }
         } catch (err) {
-          // Skip directories we can't read
+          result.epics.open++;
         }
+
+        // Count tasks within this epic
+        const epicPath = path.join('.claude/epics', epicName);
+        try {
+          const taskFiles = fs.readdirSync(epicPath).filter(file => /^[0-9].*\.md$/.test(file));
+
+          for (const taskFile of taskFiles) {
+            result.tasks.total++;
+            result.tasks.found = true;
+            try {
+              const content = fs.readFileSync(path.join(epicPath, taskFile), 'utf8');
+              const statusMatch = content.match(/^status:\s*(.+)$/m);
+              const s = statusMatch ? statusMatch[1].trim().toLowerCase() : 'open';
+
+              const depsMatch = content.match(/^depends_on:\s*\[(.+?)\]/m);
+              const hasDeps = depsMatch && depsMatch[1].trim().length > 0;
+
+              if (s === 'closed' || s === 'completed' || s === 'done') result.tasks.done++;
+              else if (s === 'in-progress' || s === 'in_progress' || s === 'active') result.tasks.inProgress++;
+              else if (s === 'blocked' || (s === 'open' && hasDeps)) result.tasks.blocked++;
+              else result.tasks.open++;
+            } catch (err) {
+              result.tasks.open++;
+            }
+          }
+        } catch (err) { /* skip */ }
       }
-
-      result.tasks.total = totalTasks;
-      result.tasks.open = openTasks;
-      result.tasks.closed = closedTasks;
-      result.tasks.found = totalTasks > 0;
-
-      addMessage(`  Open:        ${result.tasks.open}`);
-      addMessage(`  Closed:        ${result.tasks.closed}`);
-      addMessage(`  Total:        ${result.tasks.total}`);
-    } else {
-      addMessage('  No tasks found');
     }
-  } catch (err) {
-    addMessage('  No tasks found');
-  }
+  } catch (err) { /* no epics */ }
+
+  // Output markdown table
+  addMessage('## Project Status');
+  addMessage('');
+  addMessage('| Type | Total | Open | In Progress | Done | Blocked |');
+  addMessage('|------|-------|------|-------------|------|---------|');
+  addMessage(`| PRDs | ${result.prds.total} | ${result.prds.open} | ${result.prds.inProgress} | ${result.prds.done} | ${result.prds.blocked} |`);
+  addMessage(`| Epics | ${result.epics.total} | ${result.epics.open} | ${result.epics.inProgress} | ${result.epics.done} | ${result.epics.blocked} |`);
+  addMessage(`| Tasks | ${result.tasks.total} | ${result.tasks.open} | ${result.tasks.inProgress} | ${result.tasks.done} | ${result.tasks.blocked} |`);
+
+  // Recent Activity section
+  try {
+    const { formatRecentActivity } = require('../../../../autopm/.claude/lib/event-logger');
+    addMessage('');
+    addMessage(formatRecentActivity(7));
+  } catch (e) { /* event logger not available */ }
+
+  addMessage('');
+  addMessage('Next: /pm:next');
 
   return result;
 }
 
-// Export for use as module
 module.exports = status;
 
-// CLI execution
 if (require.main === module) {
-  status().then(result => {
+  status().then(() => {
     process.exit(0);
   }).catch(err => {
     console.error('Status failed:', err.message);


### PR DESCRIPTION
## 🎯 Goal
Replace plain text output with markdown pipe tables in 5 PM scripts. Claude Code renders tables natively.

## ✅ Changes
- status.js: summary table (Type | Total | Open | In Progress | Done | Blocked)
- standup.js: 3 tables (Completed, In Progress, Blocked)
- epic-status.js: progress summary + task table
- in-progress.js: unified active items table
- blocked.js: blocker reasons table
- All include Recent Activity from JSONL event log

158/158 tests passing.

Closes #474