### PR TITLE
[fix][pm] Actionable error messages in all local providers (#476)

### DIFF
--- a/.claude/providers/local/epic-create.js
+++ b/.claude/providers/local/epic-create.js
@@ -14,7 +14,7 @@ function getEpicsDir(basePath) {
 async function execute(options = {}, settings = {}) {
   const title = options.title || options.name;
   if (!title) {
-    return { success: false, error: 'Title is required' };
+    return { success: false, error: 'Title is required. Usage: /pm:epic-create "Epic Name"' };
   }
 
   const prd = options.prd || '';
@@ -23,17 +23,17 @@ async function execute(options = {}, settings = {}) {
 
   const slug = slugify(title);
   if (!slug) {
-    return { success: false, error: 'Could not generate valid slug from title' };
+    return { success: false, error: 'Could not generate valid slug from title. Use alphanumeric characters.' };
   }
   if (!/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid slug generated: "${slug}"` };
+    return { success: false, error: `Invalid slug "${slug}". Use only letters, numbers, hyphens.` };
   }
 
   const epicDir = path.join(getEpicsDir(basePath), slug);
   const filepath = path.join(epicDir, 'epic.md');
 
   if (fs.existsSync(filepath)) {
-    return { success: false, error: `Epic "${slug}" already exists` };
+    return { success: false, error: `Epic "${slug}" already exists at .claude/epics/${slug}/. Use /pm:epic-edit ${slug} to modify.` };
   }
 
   fs.mkdirSync(epicDir, { recursive: true });

--- a/.claude/providers/local/epic-decompose.js
+++ b/.claude/providers/local/epic-decompose.js
@@ -6,17 +6,17 @@ const { logEvent } = require('../../lib/event-logger');
 async function execute(options = {}, settings = {}) {
   const name = options.name;
   if (!name) {
-    return { success: false, error: 'Epic name is required' };
+    return { success: false, error: 'Epic name is required. Usage: /pm:epic-decompose <name>' };
   }
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name: "${name}"` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const tasks = options.tasks;
   if (!tasks || !Array.isArray(tasks) || tasks.length === 0) {
-    return { success: false, error: 'Tasks array is required' };
+    return { success: false, error: 'Tasks array is required. Provide tasks: [{title: "Task 1", description: "..."}]' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -25,7 +25,7 @@ async function execute(options = {}, settings = {}) {
   const epicFile = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(epicFile)) {
-    return { success: false, error: `Epic "${slug}" not found` };
+    return { success: false, error: `Epic "${slug}" not found. Run /pm:epic-list to see available epics, or /pm:epic-create to create one.` };
   }
 
   const now = new Date().toISOString();

--- a/.claude/providers/local/epic-decompose.js
+++ b/.claude/providers/local/epic-decompose.js
@@ -11,7 +11,7 @@ async function execute(options = {}, settings = {}) {
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase letters, numbers, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const tasks = options.tasks;

--- a/.claude/providers/local/epic-show.js
+++ b/.claude/providers/local/epic-show.js
@@ -5,12 +5,12 @@ const { parseFrontmatter } = require('../../lib/frontmatter');
 async function execute(options = {}, settings = {}) {
   const name = options.name;
   if (!name) {
-    return { success: false, error: 'Epic name is required' };
+    return { success: false, error: 'Epic name is required. Usage: /pm:epic-show <name>. Run /pm:epic-list to see available epics.' };
   }
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name: "${name}"` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -19,7 +19,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(filepath)) {
-    return { success: false, error: `Epic "${slug}" not found` };
+    return { success: false, error: `Epic "${slug}" not found. Run /pm:epic-list to see available epics.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/.claude/providers/local/epic-show.js
+++ b/.claude/providers/local/epic-show.js
@@ -10,7 +10,7 @@ async function execute(options = {}, settings = {}) {
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase letters, numbers, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const basePath = settings.basePath || process.cwd();

--- a/.claude/providers/local/issue-close.js
+++ b/.claude/providers/local/issue-close.js
@@ -7,7 +7,7 @@ const { logEvent } = require('../../lib/event-logger');
 async function execute(options = {}, settings = {}) {
   const id = options.id;
   if (!id) {
-    return { success: false, error: 'Issue ID is required' };
+    return { success: false, error: 'Issue ID is required. Usage: /pm:issue-close <number>' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -15,7 +15,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = findIssueFile(issuesDir, id);
 
   if (!filepath) {
-    return { success: false, error: `Issue #${id} not found` };
+    return { success: false, error: `Issue #${id} not found. Run /pm:issue-list to see available issues.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/.claude/providers/local/issue-create.js
+++ b/.claude/providers/local/issue-create.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { readTemplate, generateMarkdown, resolveTemplatePath } = require('../../lib/template-reader');
+const { logEvent } = require('../../lib/event-logger');
 
 function getIssuesDir(basePath) {
   return path.join(basePath || process.cwd(), '.claude', 'issues');
@@ -35,7 +36,7 @@ async function execute(options = {}, settings = {}) {
   const number = getNextNumber(issuesDir);
   const slug = slugify(title);
   if (!slug) {
-    return { success: false, error: 'Could not generate valid slug from title' };
+    return { success: false, error: 'Could not generate valid slug from title. Use alphanumeric characters: /pm:issue-create "Fix login bug"' };
   }
 
   const filename = `${number}-${slug}.md`;
@@ -73,7 +74,7 @@ async function execute(options = {}, settings = {}) {
       url: `file://${filepath}`
     },
     actions: [`Created local issue #${number}: ${filename}`],
-    timestamp: new Date().toISOString()
+    timestamp: (() => { logEvent('issue.created', { id: number, title, labels }, basePath); return new Date().toISOString(); })()
   };
 }
 

--- a/.claude/providers/local/issue-create.js
+++ b/.claude/providers/local/issue-create.js
@@ -62,6 +62,7 @@ async function execute(options = {}, settings = {}) {
   }
 
   fs.writeFileSync(filepath, content, 'utf8');
+  logEvent('issue.created', { id: number, title, labels }, basePath);
 
   return {
     success: true,
@@ -74,7 +75,7 @@ async function execute(options = {}, settings = {}) {
       url: `file://${filepath}`
     },
     actions: [`Created local issue #${number}: ${filename}`],
-    timestamp: (() => { logEvent('issue.created', { id: number, title, labels }, basePath); return new Date().toISOString(); })()
+    timestamp: new Date().toISOString()
   };
 }
 

--- a/.claude/providers/local/issue-show.js
+++ b/.claude/providers/local/issue-show.js
@@ -19,7 +19,7 @@ function findIssueFile(issuesDir, id) {
 async function execute(options = {}, settings = {}) {
   const id = options.id;
   if (!id) {
-    return { success: false, error: 'Issue ID is required' };
+    return { success: false, error: 'Issue ID is required. Usage: /pm:issue-show <number>' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -27,7 +27,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = findIssueFile(issuesDir, id);
 
   if (!filepath) {
-    return { success: false, error: `Issue #${id} not found` };
+    return { success: false, error: `Issue #${id} not found. Run /pm:issue-list to see available issues.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/.claude/providers/local/issue-start.js
+++ b/.claude/providers/local/issue-start.js
@@ -8,7 +8,7 @@ const { logEvent } = require('../../lib/event-logger');
 async function execute(options = {}, settings = {}) {
   const id = options.id;
   if (!id) {
-    return { success: false, error: 'Issue ID is required' };
+    return { success: false, error: 'Issue ID is required. Usage: /pm:issue-start <number>' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -16,7 +16,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = findIssueFile(issuesDir, id);
 
   if (!filepath) {
-    return { success: false, error: `Issue #${id} not found` };
+    return { success: false, error: `Issue #${id} not found. Run /pm:issue-list to see available issues.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/.claude/providers/local/prd-create.js
+++ b/.claude/providers/local/prd-create.js
@@ -14,7 +14,7 @@ function getPrdsDir(basePath) {
 async function execute(options = {}, settings = {}) {
   const title = options.title || options.name;
   if (!title) {
-    return { success: false, error: 'Title is required' };
+    return { success: false, error: 'Title is required. Usage: /pm:prd-new "Feature Name"' };
   }
 
   const priority = options.priority || 'P2';
@@ -24,10 +24,10 @@ async function execute(options = {}, settings = {}) {
 
   const slug = slugify(title);
   if (!slug) {
-    return { success: false, error: 'Could not generate valid slug from title' };
+    return { success: false, error: 'Could not generate valid slug from title. Use alphanumeric characters: /pm:prd-new "My Feature"' };
   }
   if (!/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid slug generated: "${slug}"` };
+    return { success: false, error: `Invalid slug "${slug}". Use only letters, numbers, hyphens: /pm:prd-new "My Feature"` };
   }
 
   const prdsDir = getPrdsDir(basePath);
@@ -38,7 +38,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = path.join(prdsDir, `${slug}.md`);
 
   if (fs.existsSync(filepath)) {
-    return { success: false, error: `PRD "${slug}" already exists` };
+    return { success: false, error: `PRD "${slug}" already exists at .claude/prds/${slug}.md. Use /pm:prd-edit ${slug} to modify.` };
   }
 
   const now = new Date().toISOString();

--- a/.claude/providers/local/prd-show.js
+++ b/.claude/providers/local/prd-show.js
@@ -10,7 +10,7 @@ async function execute(options = {}, settings = {}) {
 
   const slug = path.basename(name.replace(/\.md$/, ''));
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid PRD name "${name}". Use the slug (lowercase, hyphens). Run /pm:prd-list to see available PRDs.` };
+    return { success: false, error: `Invalid PRD name "${name}". Use the slug (lowercase letters, numbers, hyphens). Run /pm:prd-list to see available PRDs.` };
   }
 
   const basePath = settings.basePath || process.cwd();

--- a/.claude/providers/local/prd-show.js
+++ b/.claude/providers/local/prd-show.js
@@ -5,12 +5,12 @@ const { parseFrontmatter } = require('../../lib/frontmatter');
 async function execute(options = {}, settings = {}) {
   const name = options.name;
   if (!name) {
-    return { success: false, error: 'PRD name is required' };
+    return { success: false, error: 'PRD name is required. Usage: /pm:prd-show <name>. Run /pm:prd-list to see available PRDs.' };
   }
 
   const slug = path.basename(name.replace(/\.md$/, ''));
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid PRD name: "${name}"` };
+    return { success: false, error: `Invalid PRD name "${name}". Use the slug (lowercase, hyphens). Run /pm:prd-list to see available PRDs.` };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -18,7 +18,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = path.join(prdsDir, `${slug}.md`);
 
   if (!fs.existsSync(filepath)) {
-    return { success: false, error: `PRD "${slug}" not found` };
+    return { success: false, error: `PRD "${slug}" not found. Run /pm:prd-list to see available PRDs.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/autopm/.claude/providers/local/epic-create.js
+++ b/autopm/.claude/providers/local/epic-create.js
@@ -14,7 +14,7 @@ function getEpicsDir(basePath) {
 async function execute(options = {}, settings = {}) {
   const title = options.title || options.name;
   if (!title) {
-    return { success: false, error: 'Title is required' };
+    return { success: false, error: 'Title is required. Usage: /pm:epic-create "Epic Name"' };
   }
 
   const prd = options.prd || '';
@@ -23,17 +23,17 @@ async function execute(options = {}, settings = {}) {
 
   const slug = slugify(title);
   if (!slug) {
-    return { success: false, error: 'Could not generate valid slug from title' };
+    return { success: false, error: 'Could not generate valid slug from title. Use alphanumeric characters.' };
   }
   if (!/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid slug generated: "${slug}"` };
+    return { success: false, error: `Invalid slug "${slug}". Use only letters, numbers, hyphens.` };
   }
 
   const epicDir = path.join(getEpicsDir(basePath), slug);
   const filepath = path.join(epicDir, 'epic.md');
 
   if (fs.existsSync(filepath)) {
-    return { success: false, error: `Epic "${slug}" already exists` };
+    return { success: false, error: `Epic "${slug}" already exists at .claude/epics/${slug}/. Use /pm:epic-edit ${slug} to modify.` };
   }
 
   fs.mkdirSync(epicDir, { recursive: true });

--- a/autopm/.claude/providers/local/epic-decompose.js
+++ b/autopm/.claude/providers/local/epic-decompose.js
@@ -6,17 +6,17 @@ const { logEvent } = require('../../lib/event-logger');
 async function execute(options = {}, settings = {}) {
   const name = options.name;
   if (!name) {
-    return { success: false, error: 'Epic name is required' };
+    return { success: false, error: 'Epic name is required. Usage: /pm:epic-decompose <name>' };
   }
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name: "${name}"` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const tasks = options.tasks;
   if (!tasks || !Array.isArray(tasks) || tasks.length === 0) {
-    return { success: false, error: 'Tasks array is required' };
+    return { success: false, error: 'Tasks array is required. Provide tasks: [{title: "Task 1", description: "..."}]' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -25,7 +25,7 @@ async function execute(options = {}, settings = {}) {
   const epicFile = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(epicFile)) {
-    return { success: false, error: `Epic "${slug}" not found` };
+    return { success: false, error: `Epic "${slug}" not found. Run /pm:epic-list to see available epics, or /pm:epic-create to create one.` };
   }
 
   const now = new Date().toISOString();

--- a/autopm/.claude/providers/local/epic-decompose.js
+++ b/autopm/.claude/providers/local/epic-decompose.js
@@ -11,7 +11,7 @@ async function execute(options = {}, settings = {}) {
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase letters, numbers, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const tasks = options.tasks;

--- a/autopm/.claude/providers/local/epic-show.js
+++ b/autopm/.claude/providers/local/epic-show.js
@@ -5,12 +5,12 @@ const { parseFrontmatter } = require('../../lib/frontmatter');
 async function execute(options = {}, settings = {}) {
   const name = options.name;
   if (!name) {
-    return { success: false, error: 'Epic name is required' };
+    return { success: false, error: 'Epic name is required. Usage: /pm:epic-show <name>. Run /pm:epic-list to see available epics.' };
   }
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name: "${name}"` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -19,7 +19,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = path.join(epicDir, 'epic.md');
 
   if (!fs.existsSync(filepath)) {
-    return { success: false, error: `Epic "${slug}" not found` };
+    return { success: false, error: `Epic "${slug}" not found. Run /pm:epic-list to see available epics.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/autopm/.claude/providers/local/epic-show.js
+++ b/autopm/.claude/providers/local/epic-show.js
@@ -10,7 +10,7 @@ async function execute(options = {}, settings = {}) {
 
   const slug = path.basename(name);
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase, hyphens). Run /pm:epic-list to see available epics.` };
+    return { success: false, error: `Invalid epic name "${name}". Use the slug (lowercase letters, numbers, hyphens). Run /pm:epic-list to see available epics.` };
   }
 
   const basePath = settings.basePath || process.cwd();

--- a/autopm/.claude/providers/local/issue-close.js
+++ b/autopm/.claude/providers/local/issue-close.js
@@ -7,7 +7,7 @@ const { logEvent } = require('../../lib/event-logger');
 async function execute(options = {}, settings = {}) {
   const id = options.id;
   if (!id) {
-    return { success: false, error: 'Issue ID is required' };
+    return { success: false, error: 'Issue ID is required. Usage: /pm:issue-close <number>' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -15,7 +15,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = findIssueFile(issuesDir, id);
 
   if (!filepath) {
-    return { success: false, error: `Issue #${id} not found` };
+    return { success: false, error: `Issue #${id} not found. Run /pm:issue-list to see available issues.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/autopm/.claude/providers/local/issue-create.js
+++ b/autopm/.claude/providers/local/issue-create.js
@@ -36,7 +36,7 @@ async function execute(options = {}, settings = {}) {
   const number = getNextNumber(issuesDir);
   const slug = slugify(title);
   if (!slug) {
-    return { success: false, error: 'Could not generate valid slug from title' };
+    return { success: false, error: 'Could not generate valid slug from title. Use alphanumeric characters: /pm:issue-create "Fix login bug"' };
   }
 
   const filename = `${number}-${slug}.md`;

--- a/autopm/.claude/providers/local/issue-create.js
+++ b/autopm/.claude/providers/local/issue-create.js
@@ -62,6 +62,7 @@ async function execute(options = {}, settings = {}) {
   }
 
   fs.writeFileSync(filepath, content, 'utf8');
+  logEvent('issue.created', { id: number, title, labels }, basePath);
 
   return {
     success: true,
@@ -74,7 +75,7 @@ async function execute(options = {}, settings = {}) {
       url: `file://${filepath}`
     },
     actions: [`Created local issue #${number}: ${filename}`],
-    timestamp: (() => { logEvent('issue.created', { id: number, title, labels }, basePath); return new Date().toISOString(); })()
+    timestamp: new Date().toISOString()
   };
 }
 

--- a/autopm/.claude/providers/local/issue-show.js
+++ b/autopm/.claude/providers/local/issue-show.js
@@ -19,7 +19,7 @@ function findIssueFile(issuesDir, id) {
 async function execute(options = {}, settings = {}) {
   const id = options.id;
   if (!id) {
-    return { success: false, error: 'Issue ID is required' };
+    return { success: false, error: 'Issue ID is required. Usage: /pm:issue-show <number>' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -27,7 +27,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = findIssueFile(issuesDir, id);
 
   if (!filepath) {
-    return { success: false, error: `Issue #${id} not found` };
+    return { success: false, error: `Issue #${id} not found. Run /pm:issue-list to see available issues.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/autopm/.claude/providers/local/issue-start.js
+++ b/autopm/.claude/providers/local/issue-start.js
@@ -8,7 +8,7 @@ const { logEvent } = require('../../lib/event-logger');
 async function execute(options = {}, settings = {}) {
   const id = options.id;
   if (!id) {
-    return { success: false, error: 'Issue ID is required' };
+    return { success: false, error: 'Issue ID is required. Usage: /pm:issue-start <number>' };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -16,7 +16,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = findIssueFile(issuesDir, id);
 
   if (!filepath) {
-    return { success: false, error: `Issue #${id} not found` };
+    return { success: false, error: `Issue #${id} not found. Run /pm:issue-list to see available issues.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');

--- a/autopm/.claude/providers/local/prd-create.js
+++ b/autopm/.claude/providers/local/prd-create.js
@@ -14,7 +14,7 @@ function getPrdsDir(basePath) {
 async function execute(options = {}, settings = {}) {
   const title = options.title || options.name;
   if (!title) {
-    return { success: false, error: 'Title is required' };
+    return { success: false, error: 'Title is required. Usage: /pm:prd-new "Feature Name"' };
   }
 
   const priority = options.priority || 'P2';
@@ -24,10 +24,10 @@ async function execute(options = {}, settings = {}) {
 
   const slug = slugify(title);
   if (!slug) {
-    return { success: false, error: 'Could not generate valid slug from title' };
+    return { success: false, error: 'Could not generate valid slug from title. Use alphanumeric characters: /pm:prd-new "My Feature"' };
   }
   if (!/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid slug generated: "${slug}"` };
+    return { success: false, error: `Invalid slug "${slug}". Use only letters, numbers, hyphens: /pm:prd-new "My Feature"` };
   }
 
   const prdsDir = getPrdsDir(basePath);
@@ -38,7 +38,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = path.join(prdsDir, `${slug}.md`);
 
   if (fs.existsSync(filepath)) {
-    return { success: false, error: `PRD "${slug}" already exists` };
+    return { success: false, error: `PRD "${slug}" already exists at .claude/prds/${slug}.md. Use /pm:prd-edit ${slug} to modify.` };
   }
 
   const now = new Date().toISOString();

--- a/autopm/.claude/providers/local/prd-show.js
+++ b/autopm/.claude/providers/local/prd-show.js
@@ -10,7 +10,7 @@ async function execute(options = {}, settings = {}) {
 
   const slug = path.basename(name.replace(/\.md$/, ''));
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid PRD name "${name}". Use the slug (lowercase, hyphens). Run /pm:prd-list to see available PRDs.` };
+    return { success: false, error: `Invalid PRD name "${name}". Use the slug (lowercase letters, numbers, hyphens). Run /pm:prd-list to see available PRDs.` };
   }
 
   const basePath = settings.basePath || process.cwd();

--- a/autopm/.claude/providers/local/prd-show.js
+++ b/autopm/.claude/providers/local/prd-show.js
@@ -5,12 +5,12 @@ const { parseFrontmatter } = require('../../lib/frontmatter');
 async function execute(options = {}, settings = {}) {
   const name = options.name;
   if (!name) {
-    return { success: false, error: 'PRD name is required' };
+    return { success: false, error: 'PRD name is required. Usage: /pm:prd-show <name>. Run /pm:prd-list to see available PRDs.' };
   }
 
   const slug = path.basename(name.replace(/\.md$/, ''));
   if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
-    return { success: false, error: `Invalid PRD name: "${name}"` };
+    return { success: false, error: `Invalid PRD name "${name}". Use the slug (lowercase, hyphens). Run /pm:prd-list to see available PRDs.` };
   }
 
   const basePath = settings.basePath || process.cwd();
@@ -18,7 +18,7 @@ async function execute(options = {}, settings = {}) {
   const filepath = path.join(prdsDir, `${slug}.md`);
 
   if (!fs.existsSync(filepath)) {
-    return { success: false, error: `PRD "${slug}" not found` };
+    return { success: false, error: `PRD "${slug}" not found. Run /pm:prd-list to see available PRDs.` };
   }
 
   const content = fs.readFileSync(filepath, 'utf8');


### PR DESCRIPTION
## 🎯 Goal
Every error message now includes what to do next. Pattern from gstack.

## ✅ Changes
25 error messages updated across 9 provider files:
- "not found" errors → suggest /pm:*-list to see available items
- "already exists" errors → suggest /pm:*-edit to modify
- "required" errors → show usage syntax
- "invalid slug" errors → explain valid format

158/158 tests passing.

Closes #476