### PR TITLE
[feat][pm] Session learnings, checkpoints, enhanced validate, preamble (#485-#488)

### DIFF
--- a/autopm/.claude/commands/pm:checkpoint.md
+++ b/autopm/.claude/commands/pm:checkpoint.md
@@ -1,0 +1,23 @@
+---
+allowed-tools: Bash, Read, Write
+---
+
+# Project Checkpoint
+
+Save, list, or show project state snapshots.
+
+## Usage
+```bash
+node .claude/scripts/pm/checkpoint.js "description"
+node .claude/scripts/pm/checkpoint.js --list
+node .claude/scripts/pm/checkpoint.js --show <timestamp>
+```
+
+## Instructions
+
+Run the checkpoint script using the Bash tool with the appropriate arguments.
+
+- To create: pass description as first argument (quoted)
+- To list: use `--list`
+- To show details: use `--show` followed by a timestamp or partial match
+- Show complete output, DO NOT truncate

--- a/autopm/.claude/commands/pm:learn.md
+++ b/autopm/.claude/commands/pm:learn.md
@@ -1,0 +1,26 @@
+---
+allowed-tools: Bash, Read, Write
+---
+
+# Session Learning
+
+Record a project learning for future reference.
+
+## Usage
+```bash
+node .claude/scripts/pm/learn.js "lesson text" [--tag tagname]
+```
+
+## Instructions
+
+Run the learn script with the user's provided learning text and optional tags using the Bash tool.
+
+- Pass the learning text as the first argument (quoted)
+- Use `--tag` for each tag the user wants to add
+- Show the complete output
+
+## Examples
+```bash
+node .claude/scripts/pm/learn.js "Always run migrations before seeding" --tag database
+node .claude/scripts/pm/learn.js "Use path.join for cross-platform paths" --tag node
+```

--- a/autopm/.claude/commands/pm:recall.md
+++ b/autopm/.claude/commands/pm:recall.md
@@ -1,0 +1,20 @@
+---
+allowed-tools: Bash, Read
+---
+
+# Recall Learnings
+
+Display recorded project learnings.
+
+## Usage
+```bash
+node .claude/scripts/pm/recall.js [--tag tagname] [--limit N]
+```
+
+## Instructions
+
+Run the recall script using the Bash tool and show the complete output.
+
+- Use `--tag` to filter by tag if the user specifies one
+- Use `--limit` to restrict results (default: 20)
+- DO NOT truncate output

--- a/autopm/.claude/lib/preamble.js
+++ b/autopm/.claude/lib/preamble.js
@@ -26,7 +26,9 @@ function loadPreamble(basePath) {
     if (fs.existsSync(configPath)) {
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
       result.version = config.version || null;
-      if (config.providers) {
+      if (config.provider) {
+        result.provider = config.provider;
+      } else if (config.providers) {
         const providers = Object.keys(config.providers);
         result.provider = providers.length > 0 ? providers[0] : 'local';
       }
@@ -112,8 +114,10 @@ function formatPreamble(preamble) {
 
 function formatTimeAgo(isoTimestamp) {
   if (!isoTimestamp) return 'unknown';
-  const diff = Date.now() - new Date(isoTimestamp).getTime();
+  const diff = Math.max(0, Date.now() - new Date(isoTimestamp).getTime());
+  if (diff === 0) return 'just now';
   const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
   if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;

--- a/autopm/.claude/lib/preamble.js
+++ b/autopm/.claude/lib/preamble.js
@@ -1,0 +1,124 @@
+/**
+ * Preamble — Quick project context summary for PM commands
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Load preamble data from project state
+ * @param {string} basePath - project root (defaults to cwd)
+ * @returns {{ version: string|null, provider: string, recentLearnings: Array, activeEpic: string|null, lastCheckpoint: Object|null }}
+ */
+function loadPreamble(basePath) {
+  basePath = basePath || process.cwd();
+  const result = {
+    version: null,
+    provider: 'local',
+    recentLearnings: [],
+    activeEpic: null,
+    lastCheckpoint: null
+  };
+
+  // Read config.json
+  try {
+    const configPath = path.join(basePath, '.claude', 'config.json');
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      result.version = config.version || null;
+      if (config.providers) {
+        const providers = Object.keys(config.providers);
+        result.provider = providers.length > 0 ? providers[0] : 'local';
+      }
+    }
+  } catch { /* skip */ }
+
+  // Read last 3 learnings
+  try {
+    const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+    if (fs.existsSync(learningsPath)) {
+      const lines = fs.readFileSync(learningsPath, 'utf8').trim().split('\n').filter(Boolean);
+      result.recentLearnings = lines.slice(-3).map(l => {
+        try { return JSON.parse(l); } catch { return null; }
+      }).filter(Boolean);
+    }
+  } catch { /* skip */ }
+
+  // Find active (in-progress) epic
+  try {
+    const epicsDir = path.join(basePath, '.claude', 'epics');
+    if (fs.existsSync(epicsDir)) {
+      const epicDirs = fs.readdirSync(epicsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory());
+
+      for (const dir of epicDirs) {
+        const epicFile = path.join(epicsDir, dir.name, 'epic.md');
+        if (fs.existsSync(epicFile)) {
+          const content = fs.readFileSync(epicFile, 'utf8');
+          const statusMatch = content.match(/^status:\s*(.+)$/m);
+          const s = statusMatch ? statusMatch[1].trim().toLowerCase() : '';
+          if (s === 'in-progress' || s === 'in_progress' || s === 'active') {
+            const nameMatch = content.match(/^name:\s*(.+)$/m);
+            result.activeEpic = nameMatch ? nameMatch[1].trim() : dir.name;
+            break;
+          }
+        }
+      }
+    }
+  } catch { /* skip */ }
+
+  // Find latest checkpoint
+  try {
+    const checkpointsDir = path.join(basePath, '.claude', 'pm', 'checkpoints');
+    if (fs.existsSync(checkpointsDir)) {
+      const files = fs.readdirSync(checkpointsDir).filter(f => f.endsWith('.json')).sort();
+      if (files.length > 0) {
+        const last = JSON.parse(fs.readFileSync(path.join(checkpointsDir, files[files.length - 1]), 'utf8'));
+        result.lastCheckpoint = { timestamp: last.timestamp, description: last.description };
+      }
+    }
+  } catch { /* skip */ }
+
+  return result;
+}
+
+/**
+ * Format preamble as single-line summary
+ * @param {Object} preamble - from loadPreamble()
+ * @returns {string}
+ */
+function formatPreamble(preamble) {
+  const parts = [];
+
+  if (preamble.version) {
+    parts.push(`AutoPM v${preamble.version}`);
+  }
+
+  parts.push(`Provider: ${preamble.provider}`);
+
+  if (preamble.activeEpic) {
+    parts.push(`Active epic: ${preamble.activeEpic}`);
+  }
+
+  if (preamble.recentLearnings.length > 0) {
+    const last = preamble.recentLearnings[preamble.recentLearnings.length - 1];
+    const ago = formatTimeAgo(last.timestamp);
+    const text = last.learning.length > 40 ? last.learning.slice(0, 37) + '...' : last.learning;
+    parts.push(`Last learning: "${text}" (${ago})`);
+  }
+
+  return parts.join(' | ');
+}
+
+function formatTimeAgo(isoTimestamp) {
+  if (!isoTimestamp) return 'unknown';
+  const diff = Date.now() - new Date(isoTimestamp).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+module.exports = { loadPreamble, formatPreamble };

--- a/autopm/.claude/scripts/pm/checkpoint.js
+++ b/autopm/.claude/scripts/pm/checkpoint.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * PM Checkpoint — Save/list/show project state snapshots
+ * Usage: node checkpoint.js "description"
+ *        node checkpoint.js --list
+ *        node checkpoint.js --show <timestamp>
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const basePath = process.cwd();
+const checkpointsDir = path.join(basePath, '.claude', 'pm', 'checkpoints');
+const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help') {
+    console.log('Usage: node checkpoint.js "description"');
+    console.log('       node checkpoint.js --list');
+    console.log('       node checkpoint.js --show <timestamp>');
+    process.exit(0);
+  }
+
+  if (args[0] === '--list') {
+    return listCheckpoints();
+  }
+
+  if (args[0] === '--show' && args[1]) {
+    return showCheckpoint(args[1]);
+  }
+
+  return createCheckpoint(args[0]);
+}
+
+function getGitInfo() {
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+    const hash = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+    const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+    return { branch, hash, clean: status.length === 0 };
+  } catch {
+    return { branch: 'unknown', hash: 'unknown', clean: false };
+  }
+}
+
+function countItems() {
+  const counts = { prds: 0, epics: 0, issues: 0 };
+
+  try {
+    const prdsDir = path.join(basePath, '.claude', 'prds');
+    if (fs.existsSync(prdsDir)) {
+      counts.prds = fs.readdirSync(prdsDir).filter(f => f.endsWith('.md')).length;
+    }
+  } catch { /* skip */ }
+
+  try {
+    const epicsDir = path.join(basePath, '.claude', 'epics');
+    if (fs.existsSync(epicsDir)) {
+      const epicDirs = fs.readdirSync(epicsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory());
+      counts.epics = epicDirs.length;
+
+      for (const dir of epicDirs) {
+        const epicPath = path.join(epicsDir, dir.name);
+        counts.issues += fs.readdirSync(epicPath)
+          .filter(f => /^\d+.*\.md$/.test(f)).length;
+      }
+    }
+  } catch { /* skip */ }
+
+  return counts;
+}
+
+function getRecentLearnings(n) {
+  if (!fs.existsSync(learningsPath)) return [];
+  try {
+    const lines = fs.readFileSync(learningsPath, 'utf8').trim().split('\n').filter(Boolean);
+    return lines.slice(-n).map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+  } catch { return []; }
+}
+
+function getConfigSnapshot() {
+  const configPath = path.join(basePath, '.claude', 'config.json');
+  if (!fs.existsSync(configPath)) return null;
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    return { version: config.version, provider: config.providers ? Object.keys(config.providers).join(', ') : 'local' };
+  } catch { return null; }
+}
+
+function createCheckpoint(description) {
+  if (!fs.existsSync(checkpointsDir)) {
+    fs.mkdirSync(checkpointsDir, { recursive: true });
+  }
+
+  const timestamp = new Date().toISOString();
+  const checkpoint = {
+    timestamp,
+    description,
+    git: getGitInfo(),
+    counts: countItems(),
+    learnings: getRecentLearnings(5),
+    config_snapshot: getConfigSnapshot()
+  };
+
+  const filename = timestamp.replace(/:/g, '-') + '.json';
+  fs.writeFileSync(path.join(checkpointsDir, filename), JSON.stringify(checkpoint, null, 2), 'utf8');
+
+  console.log(`✅ Checkpoint saved: ${description}`);
+  console.log(`  - Branch: ${checkpoint.git.branch} (${checkpoint.git.hash})`);
+  console.log(`  - Items: ${checkpoint.counts.prds} PRDs, ${checkpoint.counts.epics} epics, ${checkpoint.counts.issues} issues`);
+}
+
+function listCheckpoints() {
+  if (!fs.existsSync(checkpointsDir)) {
+    console.log('## Checkpoints\n\nNo checkpoints found. Use `node checkpoint.js "description"` to create one.');
+    process.exit(0);
+  }
+
+  const files = fs.readdirSync(checkpointsDir).filter(f => f.endsWith('.json')).sort();
+
+  if (files.length === 0) {
+    console.log('## Checkpoints\n\nNo checkpoints found.');
+    process.exit(0);
+  }
+
+  console.log('## Checkpoints');
+  console.log('');
+  console.log('| # | Description | Date | Branch | Issues |');
+  console.log('|---|------------|------|--------|--------|');
+
+  files.forEach((file, idx) => {
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(checkpointsDir, file), 'utf8'));
+      const date = data.timestamp ? data.timestamp.split('T')[0] : '-';
+      const branch = data.git ? data.git.branch : '-';
+      const issues = data.counts ? `${data.counts.issues} tasks` : '-';
+      console.log(`| ${idx + 1} | ${data.description} | ${date} | ${branch} | ${issues} |`);
+    } catch { /* skip corrupt file */ }
+  });
+}
+
+function showCheckpoint(id) {
+  if (!fs.existsSync(checkpointsDir)) {
+    console.log('❌ No checkpoints directory found');
+    process.exit(1);
+  }
+
+  // Find matching file (by timestamp prefix or full filename)
+  const files = fs.readdirSync(checkpointsDir).filter(f => f.endsWith('.json'));
+  const match = files.find(f => f.includes(id.replace(/:/g, '-')));
+
+  if (!match) {
+    console.log(`❌ Checkpoint not found: ${id}`);
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(path.join(checkpointsDir, match), 'utf8'));
+
+  console.log(`## Checkpoint: ${data.description}`);
+  console.log('');
+  console.log('| Property | Value |');
+  console.log('|----------|-------|');
+  console.log(`| Timestamp | ${data.timestamp} |`);
+  console.log(`| Description | ${data.description} |`);
+  console.log(`| Branch | ${data.git ? data.git.branch : '-'} |`);
+  console.log(`| Commit | ${data.git ? data.git.hash : '-'} |`);
+  console.log(`| Clean | ${data.git ? (data.git.clean ? 'Yes' : 'No') : '-'} |`);
+  console.log(`| PRDs | ${data.counts ? data.counts.prds : 0} |`);
+  console.log(`| Epics | ${data.counts ? data.counts.epics : 0} |`);
+  console.log(`| Issues | ${data.counts ? data.counts.issues : 0} |`);
+
+  if (data.config_snapshot) {
+    console.log(`| Version | ${data.config_snapshot.version || '-'} |`);
+    console.log(`| Provider | ${data.config_snapshot.provider || '-'} |`);
+  }
+
+  if (data.learnings && data.learnings.length > 0) {
+    console.log('');
+    console.log('### Recent Learnings at Checkpoint');
+    console.log('');
+    data.learnings.forEach((l, i) => {
+      console.log(`${i + 1}. ${l.learning} [${(l.tags || []).join(', ')}]`);
+    });
+  }
+}
+
+main();

--- a/autopm/.claude/scripts/pm/checkpoint.js
+++ b/autopm/.claude/scripts/pm/checkpoint.js
@@ -138,7 +138,7 @@ function listCheckpoints() {
       const date = data.timestamp ? data.timestamp.split('T')[0] : '-';
       const branch = data.git ? data.git.branch : '-';
       const issues = data.counts ? `${data.counts.issues} tasks` : '-';
-      console.log(`| ${idx + 1} | ${data.description} | ${date} | ${branch} | ${issues} |`);
+      console.log(`| ${idx + 1} | ${(data.description || '').replace(/\|/g, '\\|')} | ${date} | ${branch} | ${issues} |`);
     } catch { /* skip corrupt file */ }
   });
 }
@@ -158,7 +158,13 @@ function showCheckpoint(id) {
     process.exit(1);
   }
 
-  const data = JSON.parse(fs.readFileSync(path.join(checkpointsDir, match), 'utf8'));
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(path.join(checkpointsDir, match), 'utf8'));
+  } catch (err) {
+    console.log(`❌ Corrupt checkpoint file: ${match}. Delete and recreate.`);
+    process.exit(1);
+  }
 
   console.log(`## Checkpoint: ${data.description}`);
   console.log('');

--- a/autopm/.claude/scripts/pm/learn.js
+++ b/autopm/.claude/scripts/pm/learn.js
@@ -44,7 +44,7 @@ function main() {
   const entry = {
     timestamp: new Date().toISOString(),
     learning,
-    tags: tags.length > 0 ? tags : ['general'],
+    tags: tags,
     source: 'manual'
   };
 

--- a/autopm/.claude/scripts/pm/learn.js
+++ b/autopm/.claude/scripts/pm/learn.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * PM Learn — Append a learning to .claude/pm/learnings.jsonl
+ * Usage: node learn.js "lesson text" [--tag tagname]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.cwd();
+const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help') {
+    console.log('Usage: node learn.js "lesson text" [--tag tagname]');
+    process.exit(0);
+  }
+
+  // Parse arguments
+  let learning = '';
+  const tags = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--tag' && i + 1 < args.length) {
+      tags.push(args[++i]);
+    } else if (!learning) {
+      learning = args[i];
+    }
+  }
+
+  if (!learning) {
+    console.log('❌ No learning text provided');
+    process.exit(1);
+  }
+
+  // Ensure directory exists
+  const dir = path.dirname(learningsPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const entry = {
+    timestamp: new Date().toISOString(),
+    learning,
+    tags: tags.length > 0 ? tags : ['general'],
+    source: 'manual'
+  };
+
+  fs.appendFileSync(learningsPath, JSON.stringify(entry) + '\n', 'utf8');
+
+  console.log(`✅ Learning saved`);
+  console.log(`  - "${learning}"`);
+  console.log(`  - Tags: ${entry.tags.join(', ')}`);
+}
+
+main();

--- a/autopm/.claude/scripts/pm/next.js
+++ b/autopm/.claude/scripts/pm/next.js
@@ -23,6 +23,14 @@ async function next() {
     }
   }
 
+  // Preamble
+  try {
+    const { loadPreamble, formatPreamble } = require(path.join(process.cwd(), '.claude', 'lib', 'preamble'));
+    const preamble = loadPreamble(process.cwd());
+    addMessage(formatPreamble(preamble));
+    addMessage('');
+  } catch (e) { /* preamble not available */ }
+
   try {
     const availableTasks = await findAvailableTasks();
     result.availableTasks = availableTasks;

--- a/autopm/.claude/scripts/pm/recall.js
+++ b/autopm/.claude/scripts/pm/recall.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * PM Recall — Display learnings from .claude/pm/learnings.jsonl
+ * Usage: node recall.js [--tag tagname] [--limit N]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.cwd();
+const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+
+function main() {
+  const args = process.argv.slice(2);
+
+  // Parse arguments
+  let tagFilter = null;
+  let limit = 20;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--tag' && i + 1 < args.length) {
+      tagFilter = args[++i];
+    } else if (args[i] === '--limit' && i + 1 < args.length) {
+      limit = parseInt(args[++i], 10) || 20;
+    }
+  }
+
+  if (!fs.existsSync(learningsPath)) {
+    console.log('## Project Learnings\n\nNo learnings recorded yet. Use `/pm:learn "lesson"` to add one.');
+    process.exit(0);
+  }
+
+  const lines = fs.readFileSync(learningsPath, 'utf8').trim().split('\n').filter(Boolean);
+  let entries = lines.map(line => {
+    try { return JSON.parse(line); } catch { return null; }
+  }).filter(Boolean);
+
+  if (tagFilter) {
+    entries = entries.filter(e => e.tags && e.tags.includes(tagFilter));
+  }
+
+  // Most recent first, then apply limit
+  entries = entries.reverse().slice(0, limit);
+
+  if (entries.length === 0) {
+    const filterMsg = tagFilter ? ` with tag "${tagFilter}"` : '';
+    console.log(`## Project Learnings\n\nNo learnings found${filterMsg}.`);
+    process.exit(0);
+  }
+
+  console.log('## Project Learnings');
+  console.log('');
+  console.log('| # | Learning | Tags | Date |');
+  console.log('|---|---------|------|------|');
+
+  entries.forEach((entry, idx) => {
+    const date = entry.timestamp ? entry.timestamp.split('T')[0] : '-';
+    const tags = (entry.tags || []).join(', ');
+    const text = entry.learning.replace(/\|/g, '\\|');
+    console.log(`| ${idx + 1} | ${text} | ${tags} | ${date} |`);
+  });
+
+  console.log('');
+  console.log(`${entries.length} learnings shown.`);
+}
+
+main();

--- a/autopm/.claude/scripts/pm/recall.js
+++ b/autopm/.claude/scripts/pm/recall.js
@@ -55,8 +55,8 @@ function main() {
 
   entries.forEach((entry, idx) => {
     const date = entry.timestamp ? entry.timestamp.split('T')[0] : '-';
-    const tags = (entry.tags || []).join(', ');
-    const text = entry.learning.replace(/\|/g, '\\|');
+    const tags = (entry.tags || []).length > 0 ? entry.tags.join(', ') : '\u2014';
+    const text = String(entry.learning || '').replace(/\|/g, '\\|');
     console.log(`| ${idx + 1} | ${text} | ${tags} | ${date} |`);
   });
 

--- a/autopm/.claude/scripts/pm/standup.js
+++ b/autopm/.claude/scripts/pm/standup.js
@@ -25,6 +25,14 @@ async function standup() {
     }
   }
 
+  // Preamble
+  try {
+    const { loadPreamble, formatPreamble } = require(path.join(process.cwd(), '.claude', 'lib', 'preamble'));
+    const preamble = loadPreamble(process.cwd());
+    addMessage(formatPreamble(preamble));
+    addMessage('');
+  } catch (e) { /* preamble not available */ }
+
   const oneDayAgo = Date.now() - (24 * 60 * 60 * 1000);
 
   // Scan epics for task data

--- a/autopm/.claude/scripts/pm/status.js
+++ b/autopm/.claude/scripts/pm/status.js
@@ -21,6 +21,14 @@ async function status() {
     }
   }
 
+  // Preamble
+  try {
+    const { loadPreamble, formatPreamble } = require(path.join(process.cwd(), '.claude', 'lib', 'preamble'));
+    const preamble = loadPreamble(process.cwd());
+    addMessage(formatPreamble(preamble));
+    addMessage('');
+  } catch (e) { /* preamble not available */ }
+
   // Count PRDs by status
   try {
     if (fs.existsSync('.claude/prds') && fs.statSync('.claude/prds').isDirectory()) {

--- a/autopm/.claude/scripts/pm/validate.js
+++ b/autopm/.claude/scripts/pm/validate.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * PM System Validation Script (Node.js version)
- * Migrated from bash script with 100% backward compatibility
+ * PM System Validation Script
+ * Enhanced with AUTO-FIXED / NEEDS INPUT format and template validation.
  */
 
 async function validate() {
@@ -11,259 +11,226 @@ async function validate() {
     errors: 0,
     warnings: 0,
     invalidFiles: 0,
+    autoFixed: [],
+    needsInput: [],
     messages: [],
     exitCode: 0
   };
 
-  // Helper function to add messages
   function addMessage(message) {
     result.messages.push(message);
-    // Only log if running as CLI
     if (require.main === module) {
       console.log(message);
     }
   }
 
-  // Header
-  addMessage('Validating PM System...');
-  addMessage('');
-  addMessage('');
-  addMessage('🔍 Validating PM System');
-  addMessage('=======================');
-  addMessage('');
+  // Helper: read frontmatter from a file (simple parser)
+  function readFrontmatter(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const match = content.match(/^---\r?\n([\s\S]*?)^---\r?\n?([\s\S]*)$/m);
+    if (!match) return { fm: {}, body: content, raw: content, hasFrontmatter: false };
+
+    const lines = match[1].split('\n');
+    const fm = {};
+    for (const line of lines) {
+      const kv = line.match(/^(\w[\w_-]*):\s*(.*)$/);
+      if (kv) fm[kv[1]] = kv[2].trim();
+    }
+    return { fm, body: match[2] || '', raw: content, hasFrontmatter: true };
+  }
+
+  // Helper: write back frontmatter fix
+  function writeFrontmatterFix(filePath, fieldName, newValue) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const fieldRegex = new RegExp(`^(${fieldName}:\\s*)(.*)$`, 'm');
+    const match = content.match(fieldRegex);
+
+    if (match) {
+      const updated = content.replace(fieldRegex, `$1${newValue}`);
+      fs.writeFileSync(filePath, updated, 'utf8');
+    } else {
+      // Insert field after opening ---
+      const updated = content.replace(/^---\r?\n/, `---\n${fieldName}: ${newValue}\n`);
+      fs.writeFileSync(filePath, updated, 'utf8');
+    }
+  }
+
+  const now = new Date().toISOString();
 
   // Check directory structure
-  addMessage('📁 Directory Structure:');
-
   try {
-    if (fs.existsSync('.claude') && fs.statSync('.claude').isDirectory()) {
-      addMessage('  ✅ .claude directory exists');
-    } else {
-      addMessage('  ❌ .claude directory missing');
+    if (!fs.existsSync('.claude') || !fs.statSync('.claude').isDirectory()) {
       result.errors++;
+      result.needsInput.push('[.claude] Directory missing — run /pm:init');
+      addMessage('');
+      addMessage(`## Pre-Landing Review: 1 issues (0 auto-fixed, 1 needs input)`);
+      addMessage('');
+      addMessage('**NEEDS INPUT:**');
+      addMessage('- [.claude] Directory missing — run /pm:init');
+      return result;
     }
   } catch (err) {
-    addMessage('  ❌ .claude directory missing');
     result.errors++;
   }
 
-  // Check optional directories
-  const optionalDirs = [
-    { path: '.claude/prds', name: 'PRDs directory' },
-    { path: '.claude/epics', name: 'Epics directory' },
-    { path: '.claude/rules', name: 'Rules directory' }
-  ];
+  // Scan PRDs and epics for frontmatter issues
+  const filesToCheck = [];
 
-  for (const dir of optionalDirs) {
+  try {
+    if (fs.existsSync('.claude/prds')) {
+      const prdFiles = fs.readdirSync('.claude/prds').filter(f => f.endsWith('.md'));
+      for (const f of prdFiles) filesToCheck.push(path.join('.claude/prds', f));
+    }
+  } catch { /* skip */ }
+
+  try {
+    if (fs.existsSync('.claude/epics')) {
+      const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
+        .filter(d => d.isDirectory()).map(d => d.name);
+
+      for (const epicDir of epicDirs) {
+        const epicPath = path.join('.claude/epics', epicDir);
+        const files = fs.readdirSync(epicPath).filter(f => f.endsWith('.md'));
+        for (const f of files) filesToCheck.push(path.join(epicPath, f));
+      }
+    }
+  } catch { /* skip */ }
+
+  // Validate each file
+  for (const filePath of filesToCheck) {
     try {
-      if (fs.existsSync(dir.path) && fs.statSync(dir.path).isDirectory()) {
-        addMessage(`  ✅ ${dir.name} exists`);
-      } else {
-        addMessage(`  ⚠️ ${dir.name} missing`);
-        result.warnings++;
+      const { fm, body, hasFrontmatter } = readFrontmatter(filePath);
+      const rel = filePath;
+
+      if (!hasFrontmatter) {
+        result.needsInput.push(`[${rel}] Missing frontmatter`);
+        result.invalidFiles++;
+        continue;
       }
-    } catch (err) {
-      addMessage(`  ⚠️ ${dir.name} missing`);
-      result.warnings++;
-    }
+
+      // AUTO-FIX: missing updated timestamp
+      if (!fm.updated || fm.updated === '') {
+        writeFrontmatterFix(filePath, 'updated', now);
+        result.autoFixed.push(`[${rel}] Missing 'updated' → set to ${now}`);
+      }
+
+      // AUTO-FIX: wrong case in status field
+      const validStatuses = ['backlog', 'in-progress', 'in_progress', 'complete', 'completed', 'done', 'open', 'closed', 'active', 'blocked'];
+      if (fm.status) {
+        const lower = fm.status.toLowerCase();
+        if (fm.status !== lower && validStatuses.includes(lower)) {
+          writeFrontmatterFix(filePath, 'status', lower);
+          result.autoFixed.push(`[${rel}] Status '${fm.status}' → normalized to '${lower}'`);
+        }
+      }
+
+      // NEEDS INPUT: check required sections via XML templates
+      try {
+        const templateReader = require(path.join(process.cwd(), '.claude', 'lib', 'template-reader'));
+
+        // Determine template type based on path
+        let templateName = null;
+        if (filePath.includes('/prds/')) templateName = 'prd.xml';
+        else if (filePath.endsWith('epic.md')) templateName = 'epic.xml';
+        else if (/\/\d+.*\.md$/.test(filePath)) templateName = 'issue.xml';
+
+        if (templateName) {
+          const templatePath = templateReader.resolveTemplatePath(templateName, process.cwd());
+          if (fs.existsSync(templatePath)) {
+            const template = templateReader.readTemplate(templatePath);
+            const content = fs.readFileSync(filePath, 'utf8');
+            const validation = templateReader.validateContent(template, content);
+
+            for (const error of validation.errors) {
+              result.needsInput.push(`[${rel}] ${error}`);
+            }
+          }
+        }
+      } catch { /* template reader not available, skip template checks */ }
+
+      // NEEDS INPUT: empty goal/objective sections
+      if (body) {
+        const goalMatch = body.match(/^##\s*(?:Goal|Objective)\s*\n([\s\S]*?)(?=\n##|\n$|$)/mi);
+        if (goalMatch && !goalMatch[1].trim()) {
+          result.needsInput.push(`[${rel}] Empty goal/objective section`);
+        }
+      }
+
+    } catch { /* skip unreadable files */ }
   }
 
-  addMessage('');
-
-  // Check for data integrity
-  addMessage('🗂️ Data Integrity:');
-
-  // Check epics have epic.md files
+  // Reference check (from original)
   try {
     if (fs.existsSync('.claude/epics')) {
       const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name);
+        .filter(d => d.isDirectory()).map(d => d.name);
 
       for (const epicDir of epicDirs) {
         const epicPath = path.join('.claude/epics', epicDir);
-        const epicFilePath = path.join(epicPath, 'epic.md');
-
-        if (!fs.existsSync(epicFilePath)) {
-          addMessage(`  ⚠️ Missing epic.md in ${epicDir}`);
-          result.warnings++;
-        }
-      }
-    }
-  } catch (err) {
-    // Silently handle directory read errors
-  }
-
-  // Check for orphaned task files
-  try {
-    const orphanedFiles = [];
-
-    function findOrphanedFiles(dir) {
-      if (!fs.existsSync(dir)) return;
-
-      const items = fs.readdirSync(dir, { withFileTypes: true });
-
-      for (const item of items) {
-        const fullPath = path.join(dir, item.name);
-
-        if (item.isDirectory()) {
-          // Skip epic directories
-          if (fullPath.includes('.claude/epics/')) {
-            continue;
-          }
-          findOrphanedFiles(fullPath);
-        } else if (item.isFile() && /^[0-9].*\.md$/.test(item.name)) {
-          // Check if this is a numbered task file outside of epics
-          if (!fullPath.includes('.claude/epics/')) {
-            orphanedFiles.push(fullPath);
-          }
-        }
-      }
-    }
-
-    findOrphanedFiles('.claude');
-
-    if (orphanedFiles.length > 0) {
-      addMessage(`  ⚠️ Found ${orphanedFiles.length} orphaned task files`);
-      result.warnings++;
-    }
-  } catch (err) {
-    // Silently handle file system errors
-  }
-
-  // Reference check
-  addMessage('');
-  addMessage('🔗 Reference Check:');
-
-  let hasValidReferences = true;
-
-  try {
-    if (fs.existsSync('.claude/epics')) {
-      const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name);
-
-      for (const epicDir of epicDirs) {
-        const epicPath = path.join('.claude/epics', epicDir);
-
         if (!fs.existsSync(epicPath)) continue;
 
+        // Check for missing epic.md
+        if (!fs.existsSync(path.join(epicPath, 'epic.md'))) {
+          result.needsInput.push(`[${epicPath}] Missing epic.md`);
+        }
+
         const files = fs.readdirSync(epicPath, { withFileTypes: true })
-          .filter(dirent => dirent.isFile() && /^[0-9].*\.md$/.test(dirent.name))
-          .map(dirent => dirent.name);
+          .filter(d => d.isFile() && /^\d+.*\.md$/.test(d.name)).map(d => d.name);
 
         for (const taskFile of files) {
-          const taskPath = path.join(epicPath, taskFile);
-
           try {
-            const content = fs.readFileSync(taskPath, 'utf8');
-
-            // Look for depends_on line
-            const dependsOnMatch = content.match(/^depends_on:\s*\[(.*?)\]/m);
-
-            if (dependsOnMatch && dependsOnMatch[1].trim()) {
-              const deps = dependsOnMatch[1]
-                .split(',')
-                .map(dep => dep.trim())
-                .filter(dep => dep.length > 0);
-
+            const content = fs.readFileSync(path.join(epicPath, taskFile), 'utf8');
+            const depsMatch = content.match(/^depends_on:\s*\[(.*?)\]/m);
+            if (depsMatch && depsMatch[1].trim()) {
+              const deps = depsMatch[1].split(',').map(d => d.trim()).filter(Boolean);
               for (const dep of deps) {
-                const depPath = path.join(epicPath, `${dep}.md`);
-
-                if (!fs.existsSync(depPath)) {
-                  const taskName = path.basename(taskFile, '.md');
-                  addMessage(`  ⚠️ Task ${taskName} references missing task: ${dep}`);
-                  result.warnings++;
-                  hasValidReferences = false;
+                if (!fs.existsSync(path.join(epicPath, `${dep}.md`))) {
+                  result.needsInput.push(`[${path.join(epicPath, taskFile)}] References missing task: ${dep}`);
                 }
               }
             }
-          } catch (err) {
-            // Skip files that can't be read
-          }
+          } catch { /* skip */ }
         }
       }
     }
-  } catch (err) {
-    // Silently handle directory errors
-  }
+  } catch { /* skip */ }
 
-  if (hasValidReferences) {
-    addMessage('  ✅ All references valid');
-  }
+  // Output results
+  const totalIssues = result.autoFixed.length + result.needsInput.length;
 
-  // Frontmatter validation
   addMessage('');
-  addMessage('📝 Frontmatter Validation:');
+  addMessage(`## Pre-Landing Review: ${totalIssues} issues (${result.autoFixed.length} auto-fixed, ${result.needsInput.length} needs input)`);
 
-  let invalidFrontmatter = 0;
-
-  try {
-    function checkFrontmatter(dir, relativePath = '') {
-      if (!fs.existsSync(dir)) return;
-
-      const items = fs.readdirSync(dir, { withFileTypes: true });
-
-      for (const item of items) {
-        const fullPath = path.join(dir, item.name);
-        const relPath = relativePath ? path.join(relativePath, item.name) : item.name;
-
-        if (item.isDirectory()) {
-          checkFrontmatter(fullPath, relPath);
-        } else if (item.isFile() && item.name.endsWith('.md')) {
-          // Only check files in epics and prds directories
-          if (fullPath.includes('.claude/epics/') || fullPath.includes('.claude/prds/')) {
-            try {
-              const content = fs.readFileSync(fullPath, 'utf8');
-
-              if (!content.startsWith('---')) {
-                addMessage(`  ⚠️ Missing frontmatter: ${item.name}`);
-                invalidFrontmatter++;
-              }
-            } catch (err) {
-              // Skip files that can't be read
-            }
-          }
-        }
-      }
+  if (result.autoFixed.length > 0) {
+    addMessage('');
+    addMessage('**AUTO-FIXED:**');
+    for (const fix of result.autoFixed) {
+      addMessage(`- ${fix}`);
     }
-
-    checkFrontmatter('.claude');
-
-    if (invalidFrontmatter === 0) {
-      addMessage('  ✅ All files have frontmatter');
-    }
-  } catch (err) {
-    // Silently handle file system errors
   }
 
-  result.invalidFiles = invalidFrontmatter;
-
-  // Summary
-  addMessage('');
-  addMessage('📊 Validation Summary:');
-  addMessage(`  Errors: ${result.errors}`);
-  addMessage(`  Warnings: ${result.warnings}`);
-  addMessage(`  Invalid files: ${result.invalidFiles}`);
-
-  if (result.errors === 0 && result.warnings === 0 && result.invalidFiles === 0) {
+  if (result.needsInput.length > 0) {
     addMessage('');
-    addMessage('✅ System is healthy!');
-  } else {
-    addMessage('');
-    addMessage('💡 Run /pm:clean to fix some issues automatically');
+    addMessage('**NEEDS INPUT:**');
+    for (const issue of result.needsInput) {
+      addMessage(`- ${issue}`);
+    }
   }
 
-  // Always exit with 0 (matching bash behavior)
+  if (totalIssues === 0) {
+    addMessage('');
+    addMessage('✅ All checks passed');
+  }
+
+  result.errors = result.needsInput.length;
+  result.warnings = result.autoFixed.length;
   result.exitCode = 0;
 
   return result;
 }
 
-// Export for use as module
 module.exports = validate;
 
-// CLI execution
 if (require.main === module) {
   validate().then(result => {
     process.exit(result.exitCode);

--- a/autopm/.claude/scripts/pm/validate.js
+++ b/autopm/.claude/scripts/pm/validate.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 /**
  * PM System Validation Script
@@ -24,35 +25,39 @@ async function validate() {
     }
   }
 
-  // Helper: read frontmatter from a file (simple parser)
+  // Helper: read frontmatter from a file using shared lib
   function readFrontmatter(filePath) {
     const content = fs.readFileSync(filePath, 'utf8');
-    const match = content.match(/^---\r?\n([\s\S]*?)^---\r?\n?([\s\S]*)$/m);
-    if (!match) return { fm: {}, body: content, raw: content, hasFrontmatter: false };
-
-    const lines = match[1].split('\n');
-    const fm = {};
-    for (const line of lines) {
-      const kv = line.match(/^(\w[\w_-]*):\s*(.*)$/);
-      if (kv) fm[kv[1]] = kv[2].trim();
-    }
-    return { fm, body: match[2] || '', raw: content, hasFrontmatter: true };
+    const { frontmatter, body } = parseFrontmatter(content);
+    const hasFrontmatter = content.trimStart().startsWith('---');
+    return { fm: frontmatter, body, raw: content, hasFrontmatter };
   }
 
-  // Helper: write back frontmatter fix
+  // Helper: write back frontmatter fix (scoped to frontmatter block only)
   function writeFrontmatterFix(filePath, fieldName, newValue) {
     const content = fs.readFileSync(filePath, 'utf8');
-    const fieldRegex = new RegExp(`^(${fieldName}:\\s*)(.*)$`, 'm');
-    const match = content.match(fieldRegex);
+    const fmMatch = content.match(/^(---\r?\n)([\s\S]*?)(^---\r?\n?)/m);
 
-    if (match) {
-      const updated = content.replace(fieldRegex, `$1${newValue}`);
+    if (!fmMatch) {
+      // No frontmatter block — insert one
+      const updated = `---\n${fieldName}: ${newValue}\n---\n${content}`;
       fs.writeFileSync(filePath, updated, 'utf8');
-    } else {
-      // Insert field after opening ---
-      const updated = content.replace(/^---\r?\n/, `---\n${fieldName}: ${newValue}\n`);
-      fs.writeFileSync(filePath, updated, 'utf8');
+      return;
     }
+
+    const before = fmMatch[1];
+    let fmBlock = fmMatch[2];
+    const after = fmMatch[3];
+    const rest = content.slice(fmMatch[0].length);
+
+    const fieldRegex = new RegExp(`^(${fieldName}:\\s*)(.*)$`, 'm');
+    if (fieldRegex.test(fmBlock)) {
+      fmBlock = fmBlock.replace(fieldRegex, `$1${newValue}`);
+    } else {
+      fmBlock += `${fieldName}: ${newValue}\n`;
+    }
+
+    fs.writeFileSync(filePath, before + fmBlock + after + rest, 'utf8');
   }
 
   const now = new Date().toISOString();
@@ -115,7 +120,7 @@ async function validate() {
       }
 
       // AUTO-FIX: wrong case in status field
-      const validStatuses = ['backlog', 'in-progress', 'in_progress', 'complete', 'completed', 'done', 'open', 'closed', 'active', 'blocked'];
+      const validStatuses = ['backlog', 'in-progress', 'in_progress', 'complete', 'completed', 'done', 'open', 'closed', 'active', 'blocked', 'draft', 'review', 'approved', 'rejected'];
       if (fm.status) {
         const lower = fm.status.toLowerCase();
         if (fm.status !== lower && validStatuses.includes(lower)) {
@@ -128,11 +133,12 @@ async function validate() {
       try {
         const templateReader = require(path.join(process.cwd(), '.claude', 'lib', 'template-reader'));
 
-        // Determine template type based on path
+        // Determine template type based on path (normalize separators for Windows)
+        const normalizedPath = filePath.split(path.sep).join('/');
         let templateName = null;
-        if (filePath.includes('/prds/')) templateName = 'prd.xml';
-        else if (filePath.endsWith('epic.md')) templateName = 'epic.xml';
-        else if (/\/\d+.*\.md$/.test(filePath)) templateName = 'issue.xml';
+        if (normalizedPath.includes('/prds/')) templateName = 'prd.xml';
+        else if (normalizedPath.endsWith('epic.md')) templateName = 'epic.xml';
+        else if (/\/\d+.*\.md$/.test(normalizedPath)) templateName = 'issue.xml';
 
         if (templateName) {
           const templatePath = templateReader.resolveTemplatePath(templateName, process.cwd());

--- a/packages/plugin-pm/scripts/pm/validate.js
+++ b/packages/plugin-pm/scripts/pm/validate.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+const { parseFrontmatter } = require('../../lib/frontmatter');
 
 /**
- * PM System Validation Script (Node.js version)
- * Migrated from bash script with 100% backward compatibility
+ * PM System Validation Script
+ * Enhanced with AUTO-FIXED / NEEDS INPUT format and template validation.
  */
 
 async function validate() {
@@ -11,259 +12,231 @@ async function validate() {
     errors: 0,
     warnings: 0,
     invalidFiles: 0,
+    autoFixed: [],
+    needsInput: [],
     messages: [],
     exitCode: 0
   };
 
-  // Helper function to add messages
   function addMessage(message) {
     result.messages.push(message);
-    // Only log if running as CLI
     if (require.main === module) {
       console.log(message);
     }
   }
 
-  // Header
-  addMessage('Validating PM System...');
-  addMessage('');
-  addMessage('');
-  addMessage('🔍 Validating PM System');
-  addMessage('=======================');
-  addMessage('');
+  // Helper: read frontmatter from a file using shared lib
+  function readFrontmatter(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const { frontmatter, body } = parseFrontmatter(content);
+    const hasFrontmatter = content.trimStart().startsWith('---');
+    return { fm: frontmatter, body, raw: content, hasFrontmatter };
+  }
+
+  // Helper: write back frontmatter fix (scoped to frontmatter block only)
+  function writeFrontmatterFix(filePath, fieldName, newValue) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const fmMatch = content.match(/^(---\r?\n)([\s\S]*?)(^---\r?\n?)/m);
+
+    if (!fmMatch) {
+      // No frontmatter block — insert one
+      const updated = `---\n${fieldName}: ${newValue}\n---\n${content}`;
+      fs.writeFileSync(filePath, updated, 'utf8');
+      return;
+    }
+
+    const before = fmMatch[1];
+    let fmBlock = fmMatch[2];
+    const after = fmMatch[3];
+    const rest = content.slice(fmMatch[0].length);
+
+    const fieldRegex = new RegExp(`^(${fieldName}:\\s*)(.*)$`, 'm');
+    if (fieldRegex.test(fmBlock)) {
+      fmBlock = fmBlock.replace(fieldRegex, `$1${newValue}`);
+    } else {
+      fmBlock += `${fieldName}: ${newValue}\n`;
+    }
+
+    fs.writeFileSync(filePath, before + fmBlock + after + rest, 'utf8');
+  }
+
+  const now = new Date().toISOString();
 
   // Check directory structure
-  addMessage('📁 Directory Structure:');
-
   try {
-    if (fs.existsSync('.claude') && fs.statSync('.claude').isDirectory()) {
-      addMessage('  ✅ .claude directory exists');
-    } else {
-      addMessage('  ❌ .claude directory missing');
+    if (!fs.existsSync('.claude') || !fs.statSync('.claude').isDirectory()) {
       result.errors++;
+      result.needsInput.push('[.claude] Directory missing — run /pm:init');
+      addMessage('');
+      addMessage(`## Pre-Landing Review: 1 issues (0 auto-fixed, 1 needs input)`);
+      addMessage('');
+      addMessage('**NEEDS INPUT:**');
+      addMessage('- [.claude] Directory missing — run /pm:init');
+      return result;
     }
   } catch (err) {
-    addMessage('  ❌ .claude directory missing');
     result.errors++;
   }
 
-  // Check optional directories
-  const optionalDirs = [
-    { path: '.claude/prds', name: 'PRDs directory' },
-    { path: '.claude/epics', name: 'Epics directory' },
-    { path: '.claude/rules', name: 'Rules directory' }
-  ];
+  // Scan PRDs and epics for frontmatter issues
+  const filesToCheck = [];
 
-  for (const dir of optionalDirs) {
+  try {
+    if (fs.existsSync('.claude/prds')) {
+      const prdFiles = fs.readdirSync('.claude/prds').filter(f => f.endsWith('.md'));
+      for (const f of prdFiles) filesToCheck.push(path.join('.claude/prds', f));
+    }
+  } catch { /* skip */ }
+
+  try {
+    if (fs.existsSync('.claude/epics')) {
+      const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
+        .filter(d => d.isDirectory()).map(d => d.name);
+
+      for (const epicDir of epicDirs) {
+        const epicPath = path.join('.claude/epics', epicDir);
+        const files = fs.readdirSync(epicPath).filter(f => f.endsWith('.md'));
+        for (const f of files) filesToCheck.push(path.join(epicPath, f));
+      }
+    }
+  } catch { /* skip */ }
+
+  // Validate each file
+  for (const filePath of filesToCheck) {
     try {
-      if (fs.existsSync(dir.path) && fs.statSync(dir.path).isDirectory()) {
-        addMessage(`  ✅ ${dir.name} exists`);
-      } else {
-        addMessage(`  ⚠️ ${dir.name} missing`);
-        result.warnings++;
+      const { fm, body, hasFrontmatter } = readFrontmatter(filePath);
+      const rel = filePath;
+
+      if (!hasFrontmatter) {
+        result.needsInput.push(`[${rel}] Missing frontmatter`);
+        result.invalidFiles++;
+        continue;
       }
-    } catch (err) {
-      addMessage(`  ⚠️ ${dir.name} missing`);
-      result.warnings++;
-    }
+
+      // AUTO-FIX: missing updated timestamp
+      if (!fm.updated || fm.updated === '') {
+        writeFrontmatterFix(filePath, 'updated', now);
+        result.autoFixed.push(`[${rel}] Missing 'updated' → set to ${now}`);
+      }
+
+      // AUTO-FIX: wrong case in status field
+      const validStatuses = ['backlog', 'in-progress', 'in_progress', 'complete', 'completed', 'done', 'open', 'closed', 'active', 'blocked', 'draft', 'review', 'approved', 'rejected'];
+      if (fm.status) {
+        const lower = fm.status.toLowerCase();
+        if (fm.status !== lower && validStatuses.includes(lower)) {
+          writeFrontmatterFix(filePath, 'status', lower);
+          result.autoFixed.push(`[${rel}] Status '${fm.status}' → normalized to '${lower}'`);
+        }
+      }
+
+      // NEEDS INPUT: check required sections via XML templates
+      try {
+        const templateReader = require(path.join(process.cwd(), '.claude', 'lib', 'template-reader'));
+
+        // Determine template type based on path (normalize separators for Windows)
+        const normalizedPath = filePath.split(path.sep).join('/');
+        let templateName = null;
+        if (normalizedPath.includes('/prds/')) templateName = 'prd.xml';
+        else if (normalizedPath.endsWith('epic.md')) templateName = 'epic.xml';
+        else if (/\/\d+.*\.md$/.test(normalizedPath)) templateName = 'issue.xml';
+
+        if (templateName) {
+          const templatePath = templateReader.resolveTemplatePath(templateName, process.cwd());
+          if (fs.existsSync(templatePath)) {
+            const template = templateReader.readTemplate(templatePath);
+            const content = fs.readFileSync(filePath, 'utf8');
+            const validation = templateReader.validateContent(template, content);
+
+            for (const error of validation.errors) {
+              result.needsInput.push(`[${rel}] ${error}`);
+            }
+          }
+        }
+      } catch { /* template reader not available, skip template checks */ }
+
+      // NEEDS INPUT: empty goal/objective sections
+      if (body) {
+        const goalMatch = body.match(/^##\s*(?:Goal|Objective)\s*\n([\s\S]*?)(?=\n##|\n$|$)/mi);
+        if (goalMatch && !goalMatch[1].trim()) {
+          result.needsInput.push(`[${rel}] Empty goal/objective section`);
+        }
+      }
+
+    } catch { /* skip unreadable files */ }
   }
 
-  addMessage('');
-
-  // Check for data integrity
-  addMessage('🗂️ Data Integrity:');
-
-  // Check epics have epic.md files
+  // Reference check (from original)
   try {
     if (fs.existsSync('.claude/epics')) {
       const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name);
+        .filter(d => d.isDirectory()).map(d => d.name);
 
       for (const epicDir of epicDirs) {
         const epicPath = path.join('.claude/epics', epicDir);
-        const epicFilePath = path.join(epicPath, 'epic.md');
-
-        if (!fs.existsSync(epicFilePath)) {
-          addMessage(`  ⚠️ Missing epic.md in ${epicDir}`);
-          result.warnings++;
-        }
-      }
-    }
-  } catch (err) {
-    // Silently handle directory read errors
-  }
-
-  // Check for orphaned task files
-  try {
-    const orphanedFiles = [];
-
-    function findOrphanedFiles(dir) {
-      if (!fs.existsSync(dir)) return;
-
-      const items = fs.readdirSync(dir, { withFileTypes: true });
-
-      for (const item of items) {
-        const fullPath = path.join(dir, item.name);
-
-        if (item.isDirectory()) {
-          // Skip epic directories
-          if (fullPath.includes('.claude/epics/')) {
-            continue;
-          }
-          findOrphanedFiles(fullPath);
-        } else if (item.isFile() && /^[0-9].*\.md$/.test(item.name)) {
-          // Check if this is a numbered task file outside of epics
-          if (!fullPath.includes('.claude/epics/')) {
-            orphanedFiles.push(fullPath);
-          }
-        }
-      }
-    }
-
-    findOrphanedFiles('.claude');
-
-    if (orphanedFiles.length > 0) {
-      addMessage(`  ⚠️ Found ${orphanedFiles.length} orphaned task files`);
-      result.warnings++;
-    }
-  } catch (err) {
-    // Silently handle file system errors
-  }
-
-  // Reference check
-  addMessage('');
-  addMessage('🔗 Reference Check:');
-
-  let hasValidReferences = true;
-
-  try {
-    if (fs.existsSync('.claude/epics')) {
-      const epicDirs = fs.readdirSync('.claude/epics', { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name);
-
-      for (const epicDir of epicDirs) {
-        const epicPath = path.join('.claude/epics', epicDir);
-
         if (!fs.existsSync(epicPath)) continue;
 
+        // Check for missing epic.md
+        if (!fs.existsSync(path.join(epicPath, 'epic.md'))) {
+          result.needsInput.push(`[${epicPath}] Missing epic.md`);
+        }
+
         const files = fs.readdirSync(epicPath, { withFileTypes: true })
-          .filter(dirent => dirent.isFile() && /^[0-9].*\.md$/.test(dirent.name))
-          .map(dirent => dirent.name);
+          .filter(d => d.isFile() && /^\d+.*\.md$/.test(d.name)).map(d => d.name);
 
         for (const taskFile of files) {
-          const taskPath = path.join(epicPath, taskFile);
-
           try {
-            const content = fs.readFileSync(taskPath, 'utf8');
-
-            // Look for depends_on line
-            const dependsOnMatch = content.match(/^depends_on:\s*\[(.*?)\]/m);
-
-            if (dependsOnMatch && dependsOnMatch[1].trim()) {
-              const deps = dependsOnMatch[1]
-                .split(',')
-                .map(dep => dep.trim())
-                .filter(dep => dep.length > 0);
-
+            const content = fs.readFileSync(path.join(epicPath, taskFile), 'utf8');
+            const depsMatch = content.match(/^depends_on:\s*\[(.*?)\]/m);
+            if (depsMatch && depsMatch[1].trim()) {
+              const deps = depsMatch[1].split(',').map(d => d.trim()).filter(Boolean);
               for (const dep of deps) {
-                const depPath = path.join(epicPath, `${dep}.md`);
-
-                if (!fs.existsSync(depPath)) {
-                  const taskName = path.basename(taskFile, '.md');
-                  addMessage(`  ⚠️ Task ${taskName} references missing task: ${dep}`);
-                  result.warnings++;
-                  hasValidReferences = false;
+                if (!fs.existsSync(path.join(epicPath, `${dep}.md`))) {
+                  result.needsInput.push(`[${path.join(epicPath, taskFile)}] References missing task: ${dep}`);
                 }
               }
             }
-          } catch (err) {
-            // Skip files that can't be read
-          }
+          } catch { /* skip */ }
         }
       }
     }
-  } catch (err) {
-    // Silently handle directory errors
-  }
+  } catch { /* skip */ }
 
-  if (hasValidReferences) {
-    addMessage('  ✅ All references valid');
-  }
+  // Output results
+  const totalIssues = result.autoFixed.length + result.needsInput.length;
 
-  // Frontmatter validation
   addMessage('');
-  addMessage('📝 Frontmatter Validation:');
+  addMessage(`## Pre-Landing Review: ${totalIssues} issues (${result.autoFixed.length} auto-fixed, ${result.needsInput.length} needs input)`);
 
-  let invalidFrontmatter = 0;
-
-  try {
-    function checkFrontmatter(dir, relativePath = '') {
-      if (!fs.existsSync(dir)) return;
-
-      const items = fs.readdirSync(dir, { withFileTypes: true });
-
-      for (const item of items) {
-        const fullPath = path.join(dir, item.name);
-        const relPath = relativePath ? path.join(relativePath, item.name) : item.name;
-
-        if (item.isDirectory()) {
-          checkFrontmatter(fullPath, relPath);
-        } else if (item.isFile() && item.name.endsWith('.md')) {
-          // Only check files in epics and prds directories
-          if (fullPath.includes('.claude/epics/') || fullPath.includes('.claude/prds/')) {
-            try {
-              const content = fs.readFileSync(fullPath, 'utf8');
-
-              if (!content.startsWith('---')) {
-                addMessage(`  ⚠️ Missing frontmatter: ${item.name}`);
-                invalidFrontmatter++;
-              }
-            } catch (err) {
-              // Skip files that can't be read
-            }
-          }
-        }
-      }
+  if (result.autoFixed.length > 0) {
+    addMessage('');
+    addMessage('**AUTO-FIXED:**');
+    for (const fix of result.autoFixed) {
+      addMessage(`- ${fix}`);
     }
-
-    checkFrontmatter('.claude');
-
-    if (invalidFrontmatter === 0) {
-      addMessage('  ✅ All files have frontmatter');
-    }
-  } catch (err) {
-    // Silently handle file system errors
   }
 
-  result.invalidFiles = invalidFrontmatter;
-
-  // Summary
-  addMessage('');
-  addMessage('📊 Validation Summary:');
-  addMessage(`  Errors: ${result.errors}`);
-  addMessage(`  Warnings: ${result.warnings}`);
-  addMessage(`  Invalid files: ${result.invalidFiles}`);
-
-  if (result.errors === 0 && result.warnings === 0 && result.invalidFiles === 0) {
+  if (result.needsInput.length > 0) {
     addMessage('');
-    addMessage('✅ System is healthy!');
-  } else {
-    addMessage('');
-    addMessage('💡 Run /pm:clean to fix some issues automatically');
+    addMessage('**NEEDS INPUT:**');
+    for (const issue of result.needsInput) {
+      addMessage(`- ${issue}`);
+    }
   }
 
-  // Always exit with 0 (matching bash behavior)
+  if (totalIssues === 0) {
+    addMessage('');
+    addMessage('✅ All checks passed');
+  }
+
+  result.errors = result.needsInput.length;
+  result.warnings = result.autoFixed.length;
   result.exitCode = 0;
 
   return result;
 }
 
-// Export for use as module
 module.exports = validate;
 
-// CLI execution
 if (require.main === module) {
   validate().then(result => {
     process.exit(result.exitCode);


### PR DESCRIPTION
## 🎯 Goal
4 gstack-inspired features completing #472 sub-issues.

## ✅ New Commands
- \`/pm:learn "lesson" [--tag tag]\` — save project learning
- \`/pm:recall [--tag tag]\` — display learnings table  
- \`/pm:checkpoint "desc"\` — save project state snapshot
- \`/pm:checkpoint --list\` — list checkpoints

## ✅ Improvements
- \`/pm:validate\` — AUTO-FIXED / NEEDS INPUT format
- \`/pm:status\`, \`/pm:standup\`, \`/pm:next\` — preamble line (version, provider, epic, learning)

## 📁 Files
- 3 new scripts (learn, recall, checkpoint) + 3 commands
- 1 new lib (preamble.js)
- 3 modified scripts (status, standup, next — preamble)
- 1 modified script (validate — new format)

158/158 tests. Closes #485, #486, #487, #488.