### PR TITLE
[chore] Release 3.20.0 — dashboard v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.20.0] - 2026-03-31
+
+### Added
+- **Dashboard v2** — tab-based layout: Overview, Config, MCP & Keys, Diagrams, Tests
+- **Mermaid diagrams** — architecture, epic flow, plugin graph, agent selection tree (CDN, dark theme)
+- **Test plan** — `/pm:test-plan` generates test cases from epic acceptance criteria
+- **Tests tab** — dashboard shows test plan + last test results + coverage
+
 ## [3.19.0] - 2026-03-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## 🎯 Goal
Release v3.20.0.

## Changes since 3.19.0
- Dashboard v2: tab navigation (5 tabs)
- Mermaid diagrams (architecture, epic flow, plugins, agents)
- /pm:test-plan + Tests dashboard tab
- CHANGELOG + package-lock.json updated

## After merge
\`git tag v3.20.0 && git push --tags\`