### PR TITLE
[fix][dashboard] Default to interactive dashboard-serve.js

### DIFF
--- a/autopm/.claude/commands/pm:dashboard.md
+++ b/autopm/.claude/commands/pm:dashboard.md
@@ -8,21 +8,19 @@ Project dashboard with two modes: static HTML report or interactive config serve
 
 ## Usage
 
-### Static (read-only report)
+```bash
+node .claude/scripts/pm/dashboard-serve.js
+```
+
+Starts interactive dashboard with tabs: Overview, Config, MCP & Keys, Diagrams, Tests.
+
+### Static mode (legacy, read-only)
 
 ```bash
 node .claude/scripts/pm/dashboard.js
 ```
 
-Generates `.claude/pm/dashboard.html` with PRD/Epic/Issue counts, epic progress bars, recent activity. Opens in browser.
-
-### Interactive (config editor) — `--serve`
-
-```bash
-node .claude/scripts/pm/dashboard-serve.js
-```
-
-Pass `--serve` when invoking via the PM command to launch the interactive server instead of the static report.
+Generates static `.claude/pm/dashboard.html` without tabs or config forms.
 
 Starts a localhost-only HTTP server with bearer token auth. The server writes its PID, port, and token to `.claude/pm/dashboard.pid`. The browser is opened automatically with the token in the query string (`?token=<token>`).
 

--- a/autopm/.claude/commands/pm:dashboard.md
+++ b/autopm/.claude/commands/pm:dashboard.md
@@ -4,9 +4,9 @@ allowed-tools: Bash, Read
 
 # PM Dashboard
 
-Project dashboard with two modes: static HTML report or interactive config server.
+Project dashboard with two modes: interactive config server (default) or static HTML report.
 
-## Usage
+## Interactive mode (default)
 
 ```bash
 node .claude/scripts/pm/dashboard-serve.js
@@ -14,28 +14,27 @@ node .claude/scripts/pm/dashboard-serve.js
 
 Starts interactive dashboard with tabs: Overview, Config, MCP & Keys, Diagrams, Tests.
 
-### Static mode (legacy, read-only)
+Localhost-only HTTP server with bearer token auth. Writes PID, port, and token to `.claude/pm/dashboard.pid`. Browser opens automatically with token in query string.
+
+Provides forms for editing:
+- **Config** — execution strategy, provider, docker/k8s toggles, plugins
+- **MCP Servers** — add, edit, remove MCP server entries (merges with existing config)
+- **API Keys** — .env variable editor with masked inputs (preserves existing secrets)
+- **Diagrams** — Mermaid architecture, epic flow, plugin graph, agent tree
+- **Tests** — test plan from epic AC, last test results
+
+Security:
+- Binds to 127.0.0.1 only
+- Bearer token auth on all routes
+- Auto-shutdown after 5 minutes idle
+- XSS-escaped output, JSON validation
+- Config saves merge with existing data
+- Backs up files before writing
+
+## Static mode (legacy)
 
 ```bash
 node .claude/scripts/pm/dashboard.js
 ```
 
-Generates static `.claude/pm/dashboard.html` without tabs or config forms.
-
-Starts a localhost-only HTTP server with bearer token auth. The server writes its PID, port, and token to `.claude/pm/dashboard.pid`. The browser is opened automatically with the token in the query string (`?token=<token>`).
-
-Provides forms for editing:
-- **Config** -- execution strategy, provider, docker/k8s toggles, plugins
-- **MCP Servers** -- add, edit, remove MCP server entries (merges with existing config)
-- **API Keys** -- .env variable editor with masked inputs (merges with existing .env, preserves secrets)
-
-Security:
-- Binds to 127.0.0.1 only (no external access)
-- Bearer token auth on all API routes
-- Token query param required for HTML route (`/?token=<token>`)
-- Auto-shutdown after 5 minutes idle
-- HTML output is XSS-escaped
-- JSON parse errors return 400, not 500
-- Config saves merge with existing data (no overwrites)
-- .env saves skip placeholder `********` values to preserve existing secrets
-- Backs up config files before writing
+Generates static `.claude/pm/dashboard.html` without tabs or config forms. Opens in browser.


### PR DESCRIPTION
## 🎯 Goal
/pm:dashboard now runs dashboard-serve.js (with tabs, Mermaid, config) instead of static dashboard.js.

## 📁 Changed
- \`autopm/.claude/commands/pm:dashboard.md\` — default command points to dashboard-serve.js