### PR TITLE
[chore] Release 3.20.3 — fix --force passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.20.3] - 2026-04-01
+
+### Fixed
+- `autopm install --force` now actually works — flag was consumed by yargs CLI and never passed to installer
+- bin/autopm.js now calls install.js directly with --force and --scenario flags
+
 ## [3.20.2] - 2026-04-01
 
 ### Fixed
@@ -5161,6 +5167,12 @@ autopm --help            # Show usage guide
 - `prettier` - Code formatting
 
 ## [Unreleased]
+
+## [3.20.3] - 2026-04-01
+
+### Fixed
+- `autopm install --force` now actually works — flag was consumed by yargs CLI and never passed to installer
+- bin/autopm.js now calls install.js directly with --force and --scenario flags
 
 ### Planned Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5166,14 +5166,6 @@ autopm --help            # Show usage guide
 - `markdownlint-cli` - Markdown linting
 - `prettier` - Code formatting
 
-## [Unreleased]
-
-## [3.20.3] - 2026-04-01
-
-### Fixed
-- `autopm install --force` now actually works — flag was consumed by yargs CLI and never passed to installer
-- bin/autopm.js now calls install.js directly with --force and --scenario flags
-
 ### Planned Features
 
 - 🔄 Auto-update mechanism for framework components

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.20.2",
+  "version": "3.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.20.2",
+      "version": "3.20.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.20.2",
+  "version": "3.20.3",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
Critical fix: --force flag now passed from CLI to installer. After merge: git tag v3.20.3 && git push --tags