### PR TITLE
[chore] Release 3.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.21.0] - 2026-04-01
+
+### Changed
+- **MCP & Keys tab UX** — persistent server cards with descriptions, presets (Context7, Playwright), env vars per server, save preview with confirm
+- **API Keys** — masked by default, eye icon toggle to reveal, plain text from server
+- **Diagrams tab** — dynamic loading from `.claude/pm/diagrams/*.mmd`, removed hardcoded AutoPM diagrams
+- **Config tab** — moved Installed Plugins diagram here (was in Diagrams)
+- **Overview tab** — moved Agent Selection tree here (quick reference)
+
 ## [3.20.3] - 2026-04-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.20.3",
+  "version": "3.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.20.3",
+      "version": "3.21.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.20.3",
+  "version": "3.21.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
MCP UX, dynamic diagrams, dashboard reorganization. After merge: git tag v3.21.0 && git push --tags