### PR TITLE
[feat][pm] Project architecture diagrams — /pm:diagram-new, update, list, show (#510)

### DIFF
--- a/autopm/.claude/commands/pm:diagram-list.md
+++ b/autopm/.claude/commands/pm:diagram-list.md
@@ -1,0 +1,12 @@
+---
+allowed-tools: Bash, Read
+---
+
+# Diagram List
+
+List available project diagrams.
+
+## Usage
+```bash
+node .claude/scripts/pm/diagram-list.js
+```

--- a/autopm/.claude/commands/pm:diagram-new.md
+++ b/autopm/.claude/commands/pm:diagram-new.md
@@ -24,12 +24,21 @@ Create a project architecture diagram by analyzing the codebase.
    - Check for API routes (Express, FastAPI, etc.)
    - Check for database models/schemas
    - Check for .env for external service connections
+     **NEVER include actual .env values (tokens, passwords, secrets) in diagram or metadata.**
+     Only infer service names/types from variable names, not values.
 
 3. Generate Mermaid diagram based on analysis:
    - Use `graph TD` for hierarchical, `graph LR` for flow
    - Group related modules in `subgraph` blocks
    - Use icons: databases [(DB)], services [Service], external{{External}}
-   - Color-code: green for active, gray for config, blue for API
+   - Color-code using Mermaid classDef:
+     ```
+     classDef active fill:#d4f8db,stroke:#2f855a
+     classDef config fill:#e2e8f0,stroke:#4a5568
+     classDef api fill:#ebf4ff,stroke:#2b6cb0
+     class FastAPI api
+     class PostgreSQL active
+     ```
 
 4. Save diagram:
    ```bash

--- a/autopm/.claude/commands/pm:diagram-new.md
+++ b/autopm/.claude/commands/pm:diagram-new.md
@@ -1,0 +1,76 @@
+---
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
+# Diagram New
+
+Create a project architecture diagram by analyzing the codebase.
+
+## Usage
+/pm:diagram-new <name> [--type architecture|modules|data-flow|dependencies]
+
+## Instructions
+
+1. Determine diagram type from --type flag or infer from project:
+   - **architecture**: High-level system components and how they connect
+   - **modules**: Import/require dependency graph between source files
+   - **data-flow**: How data moves through the system (API → service → DB)
+   - **dependencies**: package.json dependency tree
+
+2. Analyze the project:
+   - Read package.json for dependencies and project type
+   - Scan src/ or main source directory for imports/requires
+   - Check for docker-compose.yml, Dockerfile
+   - Check for API routes (Express, FastAPI, etc.)
+   - Check for database models/schemas
+   - Check for .env for external service connections
+
+3. Generate Mermaid diagram based on analysis:
+   - Use `graph TD` for hierarchical, `graph LR` for flow
+   - Group related modules in `subgraph` blocks
+   - Use icons: databases [(DB)], services [Service], external{{External}}
+   - Color-code: green for active, gray for config, blue for API
+
+4. Save diagram:
+   ```bash
+   mkdir -p .claude/pm/diagrams
+   ```
+   Write Mermaid syntax to `.claude/pm/diagrams/<name>.mmd`
+   Write metadata to `.claude/pm/diagrams/<name>.meta.json`:
+   ```json
+   {"name":"<name>","type":"<type>","created":"<ISO>","updated":"<ISO>","scope":"src/"}
+   ```
+
+5. Display the diagram in terminal (show the Mermaid source)
+
+## Example Output
+
+For a FastAPI + React project:
+```mermaid
+graph TD
+    subgraph Frontend
+        React[React App]
+        Redux[Redux Store]
+        API_Client[API Client]
+    end
+
+    subgraph Backend
+        FastAPI[FastAPI Server]
+        Auth[Auth Module]
+        Users[Users API]
+        ORM[SQLAlchemy ORM]
+    end
+
+    subgraph Data
+        PostgreSQL[(PostgreSQL)]
+        Redis[(Redis Cache)]
+    end
+
+    React --> API_Client
+    API_Client --> FastAPI
+    FastAPI --> Auth
+    FastAPI --> Users
+    Users --> ORM
+    ORM --> PostgreSQL
+    Auth --> Redis
+```

--- a/autopm/.claude/commands/pm:diagram-show.md
+++ b/autopm/.claude/commands/pm:diagram-show.md
@@ -1,0 +1,14 @@
+---
+allowed-tools: Bash, Read
+---
+
+# Diagram Show
+
+Display a project diagram.
+
+## Usage
+```bash
+node .claude/scripts/pm/diagram-list.js --show <name>
+```
+
+Shows the Mermaid source of the diagram. View rendered version in `/pm:dashboard` Diagrams tab.

--- a/autopm/.claude/commands/pm:diagram-update.md
+++ b/autopm/.claude/commands/pm:diagram-update.md
@@ -1,0 +1,24 @@
+---
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
+# Diagram Update
+
+Update an existing project diagram after code changes.
+
+## Usage
+/pm:diagram-update <name>
+
+## Instructions
+
+1. Read existing diagram from `.claude/pm/diagrams/<name>.mmd`
+2. Read metadata from `.claude/pm/diagrams/<name>.meta.json` for type and scope
+3. If either file is missing: `❌ Diagram not found: Run /pm:diagram-new <name>`
+4. Re-analyze the project (same analysis as diagram-new, scoped to metadata scope)
+5. Compare with existing diagram — identify:
+   - New modules/components added
+   - Removed modules
+   - Changed connections
+6. Update the .mmd file with changes
+7. Update metadata: set `updated` to current timestamp (`date -u +"%Y-%m-%dT%H:%M:%SZ"`)
+8. Show diff summary: "Added: X, Removed: Y, Updated: Z connections"

--- a/autopm/.claude/scripts/pm/diagram-list.js
+++ b/autopm/.claude/scripts/pm/diagram-list.js
@@ -53,7 +53,9 @@ function listDiagrams() {
   console.log('| Name | Type | Created | Updated |');
   console.log('|------|------|---------|---------|');
   for (const r of rows) {
-    console.log(`| ${r.name} | ${r.type} | ${r.created} | ${r.updated} |`);
+    const escapedName = r.name.replace(/\|/g, '\\|');
+    const escapedType = (r.type || '').replace(/\|/g, '\\|');
+    console.log(`| ${escapedName} | ${escapedType} | ${r.created} | ${r.updated} |`);
   }
   console.log(`\nTotal: ${rows.length} diagram${rows.length === 1 ? '' : 's'}`);
   console.log('View in dashboard: /pm:dashboard → Diagrams tab');
@@ -80,7 +82,13 @@ const args = process.argv.slice(2);
 const showIdx = args.indexOf('--show');
 
 if (showIdx !== -1 && args[showIdx + 1]) {
-  showDiagram(args[showIdx + 1]);
+  const name = args[showIdx + 1];
+  const safeName = path.basename(name || '');
+  if (!safeName || !/^[a-z0-9_-]+$/i.test(safeName)) {
+    console.log('Invalid diagram name. Use alphanumeric, hyphens, underscores only.');
+    process.exit(1);
+  }
+  showDiagram(safeName);
 } else {
   listDiagrams();
 }

--- a/autopm/.claude/scripts/pm/diagram-list.js
+++ b/autopm/.claude/scripts/pm/diagram-list.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * PM Diagram List/Show Script
+ *
+ * Lists diagrams from .claude/pm/diagrams/*.mmd with metadata.
+ * With --show <name>: displays diagram content.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DIAGRAMS_DIR = path.join('.claude', 'pm', 'diagrams');
+
+function findDiagrams() {
+  if (!fs.existsSync(DIAGRAMS_DIR)) {
+    return [];
+  }
+  return fs.readdirSync(DIAGRAMS_DIR)
+    .filter(f => f.endsWith('.mmd'))
+    .map(f => f.replace('.mmd', ''));
+}
+
+function loadMeta(name) {
+  const metaPath = path.join(DIAGRAMS_DIR, `${name}.meta.json`);
+  if (!fs.existsSync(metaPath)) {
+    return { name, type: 'unknown', created: '-', updated: '-' };
+  }
+  try {
+    const raw = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+    return {
+      name: raw.name || name,
+      type: raw.type || 'unknown',
+      created: (raw.created || '-').slice(0, 10),
+      updated: (raw.updated || '-').slice(0, 10)
+    };
+  } catch {
+    return { name, type: 'unknown', created: '-', updated: '-' };
+  }
+}
+
+function listDiagrams() {
+  const names = findDiagrams();
+  if (names.length === 0) {
+    console.log('No diagrams found.');
+    console.log('Create one with: /pm:diagram-new <name>');
+    return;
+  }
+
+  const rows = names.map(loadMeta);
+
+  console.log('## Project Diagrams\n');
+  console.log('| Name | Type | Created | Updated |');
+  console.log('|------|------|---------|---------|');
+  for (const r of rows) {
+    console.log(`| ${r.name} | ${r.type} | ${r.created} | ${r.updated} |`);
+  }
+  console.log(`\nTotal: ${rows.length} diagram${rows.length === 1 ? '' : 's'}`);
+  console.log('View in dashboard: /pm:dashboard → Diagrams tab');
+}
+
+function showDiagram(name) {
+  const mmdPath = path.join(DIAGRAMS_DIR, `${name}.mmd`);
+  if (!fs.existsSync(mmdPath)) {
+    console.error(`❌ Diagram "${name}" not found. Run: /pm:diagram-new ${name}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(mmdPath, 'utf8');
+  const meta = loadMeta(name);
+
+  console.log(`## Diagram: ${meta.name} (${meta.type})\n`);
+  console.log('```mermaid');
+  console.log(content.trim());
+  console.log('```');
+}
+
+// Parse args
+const args = process.argv.slice(2);
+const showIdx = args.indexOf('--show');
+
+if (showIdx !== -1 && args[showIdx + 1]) {
+  showDiagram(args[showIdx + 1]);
+} else {
+  listDiagrams();
+}


### PR DESCRIPTION
## 🎯 Goal
Claude analyzes project code and generates Mermaid diagrams saved to .claude/pm/diagrams/. Dashboard Diagrams tab renders them.

## ✅ New Commands
- \`/pm:diagram-new <name>\` — analyze project, generate Mermaid (architecture, modules, data-flow, dependencies)
- \`/pm:diagram-update <name>\` — re-analyze and update existing
- \`/pm:diagram-list\` — list with metadata
- \`/pm:diagram-show <name>\` — display Mermaid source

158/158 tests. Closes #510.