### PR TITLE
[feat][mcp] AutoPM MCP Server — 13 tools, 5 resources, 3 prompts (#509)

### DIFF
--- a/autopm/.claude/mcp/autopm.md
+++ b/autopm/.claude/mcp/autopm.md
@@ -1,0 +1,44 @@
+---
+name: autopm
+command: node
+args: [".claude/scripts/mcp/autopm-server.js"]
+description: AutoPM project management — issues, epics, PRDs, learnings, checkpoints
+category: project-management
+status: inactive
+---
+
+# AutoPM MCP Server
+
+Local MCP server exposing AutoPM project management data. Reuses local providers — same data as slash commands.
+
+## Tools (13)
+- `autopm_list_issues` — list issues (filter by status)
+- `autopm_show_issue` — issue details
+- `autopm_create_issue` — create new issue
+- `autopm_start_issue` — start working (set in_progress)
+- `autopm_close_issue` — close issue
+- `autopm_list_epics` — list epics with progress
+- `autopm_show_epic` — epic with tasks
+- `autopm_list_prds` — list PRDs
+- `autopm_show_prd` — PRD details
+- `autopm_status` — project overview
+- `autopm_learn` — save learning
+- `autopm_recall` — get learnings
+- `autopm_checkpoint` — create checkpoint
+
+## Resources (5)
+- `autopm://config` — config.json
+- `autopm://agents` — agent-registry.xml
+- `autopm://events` — recent events
+- `autopm://learnings` — all learnings
+- `autopm://test-plan` — test plan
+
+## Prompts (3)
+- `autopm_issue_template` — issue XML template
+- `autopm_prd_template` — PRD XML template
+- `autopm_epic_template` — epic XML template
+
+## Enable
+```bash
+autopm mcp enable autopm
+```

--- a/autopm/.claude/scripts/mcp/autopm-server.js
+++ b/autopm/.claude/scripts/mcp/autopm-server.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * AutoPM MCP Server
+ *
+ * Exposes PM data (issues, epics, PRDs, learnings, config) via Model Context Protocol.
+ * Reuses local providers as backend — no data duplication.
+ *
+ * Usage:
+ *   node .claude/scripts/mcp/autopm-server.js
+ *
+ * In .claude/mcp-servers.json:
+ *   { "autopm": { "command": "node", "args": [".claude/scripts/mcp/autopm-server.js"] } }
+ */
+
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema
+} = require('@modelcontextprotocol/sdk/types.js');
+
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.cwd();
+const settings = { basePath };
+
+// Lazy-load providers to avoid errors when files don't exist
+function loadProvider(name) {
+  const providerPath = path.join(basePath, '.claude', 'providers', 'local', name + '.js');
+  if (fs.existsSync(providerPath)) return require(providerPath);
+  // Fallback to autopm path
+  const autopmPath = path.join(__dirname, '..', '..', 'providers', 'local', name + '.js');
+  if (fs.existsSync(autopmPath)) return require(autopmPath);
+  return null;
+}
+
+function readFile(relativePath) {
+  const fullPath = path.join(basePath, relativePath);
+  if (fs.existsSync(fullPath)) return fs.readFileSync(fullPath, 'utf8');
+  return null;
+}
+
+function readJSON(relativePath) {
+  const content = readFile(relativePath);
+  if (!content) return null;
+  try { return JSON.parse(content); } catch { return null; }
+}
+
+// ── Server Setup ──
+
+const server = new Server(
+  { name: 'autopm', version: '1.0.0' },
+  { capabilities: { tools: {}, resources: {}, prompts: {} } }
+);
+
+// ── Tools ──
+
+const TOOLS = [
+  { name: 'autopm_list_issues', description: 'List local issues with optional status filter', inputSchema: { type: 'object', properties: { status: { type: 'string', description: 'Filter: open, in_progress, closed' } } } },
+  { name: 'autopm_show_issue', description: 'Show issue details by ID', inputSchema: { type: 'object', properties: { id: { type: 'number', description: 'Issue number' } }, required: ['id'] } },
+  { name: 'autopm_create_issue', description: 'Create a new local issue', inputSchema: { type: 'object', properties: { title: { type: 'string' }, labels: { type: 'array', items: { type: 'string' } }, body: { type: 'string' } }, required: ['title'] } },
+  { name: 'autopm_start_issue', description: 'Start working on an issue (set in_progress)', inputSchema: { type: 'object', properties: { id: { type: 'number' }, no_branch: { type: 'boolean' } }, required: ['id'] } },
+  { name: 'autopm_close_issue', description: 'Close an issue', inputSchema: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'] } },
+  { name: 'autopm_list_epics', description: 'List epics with progress', inputSchema: { type: 'object', properties: { status: { type: 'string' } } } },
+  { name: 'autopm_show_epic', description: 'Show epic with tasks', inputSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] } },
+  { name: 'autopm_list_prds', description: 'List PRDs', inputSchema: { type: 'object', properties: { status: { type: 'string' } } } },
+  { name: 'autopm_show_prd', description: 'Show PRD details', inputSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] } },
+  { name: 'autopm_status', description: 'Project overview — counts, recent activity', inputSchema: { type: 'object', properties: {} } },
+  { name: 'autopm_learn', description: 'Save a project learning', inputSchema: { type: 'object', properties: { learning: { type: 'string' }, tags: { type: 'array', items: { type: 'string' } } }, required: ['learning'] } },
+  { name: 'autopm_recall', description: 'Get project learnings', inputSchema: { type: 'object', properties: { tag: { type: 'string' }, limit: { type: 'number' } } } },
+  { name: 'autopm_checkpoint', description: 'Create a project checkpoint', inputSchema: { type: 'object', properties: { description: { type: 'string' } }, required: ['description'] } }
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case 'autopm_list_issues': {
+        const provider = loadProvider('issue-list');
+        if (!provider) return text('Issue list provider not available');
+        const result = await provider.execute(args || {}, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_show_issue': {
+        const provider = loadProvider('issue-show');
+        if (!provider) return text('Issue show provider not available');
+        const result = await provider.execute(args, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_create_issue': {
+        const provider = loadProvider('issue-create');
+        if (!provider) return text('Issue create provider not available');
+        const result = await provider.execute(args, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_start_issue': {
+        const provider = loadProvider('issue-start');
+        if (!provider) return text('Issue start provider not available');
+        const result = await provider.execute(args, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_close_issue': {
+        const provider = loadProvider('issue-close');
+        if (!provider) return text('Issue close provider not available');
+        const result = await provider.execute(args, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_list_epics': {
+        const provider = loadProvider('epic-list');
+        if (!provider) return text('Epic list provider not available');
+        const result = await provider.execute(args || {}, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_show_epic': {
+        const provider = loadProvider('epic-show');
+        if (!provider) return text('Epic show provider not available');
+        const result = await provider.execute(args, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_list_prds': {
+        const provider = loadProvider('prd-list');
+        if (!provider) return text('PRD list provider not available');
+        const result = await provider.execute(args || {}, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_show_prd': {
+        const provider = loadProvider('prd-show');
+        if (!provider) return text('PRD show provider not available');
+        const result = await provider.execute(args, settings);
+        return text(JSON.stringify(result, null, 2));
+      }
+      case 'autopm_status': {
+        const issues = loadProvider('issue-list');
+        const epics = loadProvider('epic-list');
+        const prds = loadProvider('prd-list');
+        const status = {
+          issues: issues ? await issues.execute({}, settings) : { count: 0 },
+          epics: epics ? await epics.execute({}, settings) : { count: 0 },
+          prds: prds ? await prds.execute({}, settings) : { count: 0 }
+        };
+        // Add recent events
+        try {
+          const loggerPath = path.join(basePath, '.claude', 'lib', 'event-logger');
+          const { readEvents } = require(loggerPath);
+          status.recentEvents = readEvents(10, null, basePath);
+        } catch { status.recentEvents = []; }
+        return text(JSON.stringify(status, null, 2));
+      }
+      case 'autopm_learn': {
+        try {
+          const loggerPath = path.join(basePath, '.claude', 'lib', 'event-logger');
+          const { logEvent } = require(loggerPath);
+          const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+          const dir = path.dirname(learningsPath);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          const entry = { timestamp: new Date().toISOString(), type: 'learning', learning: args.learning, tags: args.tags || [] };
+          fs.appendFileSync(learningsPath, JSON.stringify(entry) + '\n');
+          return text(JSON.stringify({ success: true, learning: args.learning }));
+        } catch (e) { return text(JSON.stringify({ error: e.message })); }
+      }
+      case 'autopm_recall': {
+        const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+        if (!fs.existsSync(learningsPath)) return text(JSON.stringify({ learnings: [] }));
+        let entries = fs.readFileSync(learningsPath, 'utf8').trim().split('\n')
+          .map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+        if (args && args.tag) entries = entries.filter(e => (e.tags || []).includes(args.tag));
+        const limit = (args && args.limit) || 20;
+        return text(JSON.stringify({ learnings: entries.slice(-limit) }));
+      }
+      case 'autopm_checkpoint': {
+        try {
+          const { execSync } = require('child_process');
+          const cpDir = path.join(basePath, '.claude', 'pm', 'checkpoints');
+          if (!fs.existsSync(cpDir)) fs.mkdirSync(cpDir, { recursive: true });
+          const now = new Date().toISOString();
+          let gitInfo = {};
+          try {
+            gitInfo.branch = execSync('git branch --show-current', { encoding: 'utf8', cwd: basePath }).trim();
+            gitInfo.hash = execSync('git rev-parse --short HEAD', { encoding: 'utf8', cwd: basePath }).trim();
+            gitInfo.clean = !execSync('git status --porcelain', { encoding: 'utf8', cwd: basePath }).trim();
+          } catch { /* not a git repo */ }
+          const checkpoint = { timestamp: now, description: args.description, git: gitInfo };
+          fs.writeFileSync(path.join(cpDir, now.replace(/[:.]/g, '-') + '.json'), JSON.stringify(checkpoint, null, 2));
+          return text(JSON.stringify({ success: true, checkpoint }));
+        } catch (e) { return text(JSON.stringify({ error: e.message })); }
+      }
+      default:
+        return text(`Unknown tool: ${name}`);
+    }
+  } catch (e) {
+    return text(JSON.stringify({ error: e.message }));
+  }
+});
+
+// ── Resources ──
+
+const RESOURCES = [
+  { uri: 'autopm://config', name: 'Project Config', description: 'Current .claude/config.json', mimeType: 'application/json' },
+  { uri: 'autopm://agents', name: 'Agent Registry', description: 'Loaded agents from agent-registry.xml', mimeType: 'text/xml' },
+  { uri: 'autopm://events', name: 'Recent Events', description: 'Last 50 events from events.jsonl', mimeType: 'application/json' },
+  { uri: 'autopm://learnings', name: 'Project Learnings', description: 'All learnings from learnings.jsonl', mimeType: 'application/json' },
+  { uri: 'autopm://test-plan', name: 'Test Plan', description: 'Current test plan', mimeType: 'text/markdown' }
+];
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: RESOURCES }));
+
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const { uri } = request.params;
+
+  switch (uri) {
+    case 'autopm://config':
+      return resource(uri, readFile('.claude/config.json') || '{}', 'application/json');
+    case 'autopm://agents':
+      return resource(uri, readFile('.claude/agents/agent-registry.xml') || '<agent-registry/>', 'text/xml');
+    case 'autopm://events': {
+      try {
+        const loggerPath = path.join(basePath, '.claude', 'lib', 'event-logger');
+        const { readEvents } = require(loggerPath);
+        return resource(uri, JSON.stringify(readEvents(50, null, basePath), null, 2), 'application/json');
+      } catch { return resource(uri, '[]', 'application/json'); }
+    }
+    case 'autopm://learnings': {
+      const content = readFile('.claude/pm/learnings.jsonl');
+      if (!content) return resource(uri, '[]', 'application/json');
+      const entries = content.trim().split('\n').map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+      return resource(uri, JSON.stringify(entries, null, 2), 'application/json');
+    }
+    case 'autopm://test-plan':
+      return resource(uri, readFile('.claude/pm/test-plan.md') || 'No test plan. Run /pm:test-plan to generate.', 'text/markdown');
+    default:
+      throw new Error(`Unknown resource: ${uri}`);
+  }
+});
+
+// ── Prompts ──
+
+const PROMPTS = [
+  { name: 'autopm_issue_template', description: 'Template for creating a new issue' },
+  { name: 'autopm_prd_template', description: 'Template for creating a new PRD' },
+  { name: 'autopm_epic_template', description: 'Template for creating a new epic' }
+];
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: PROMPTS }));
+
+server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  const { name } = request.params;
+
+  try {
+    const templateReaderPath = path.join(basePath, '.claude', 'lib', 'template-reader');
+    const { readTemplate, generateMarkdown, resolveTemplatePath } = require(templateReaderPath);
+
+    const templateMap = {
+      autopm_issue_template: 'issue.xml',
+      autopm_prd_template: 'prd.xml',
+      autopm_epic_template: 'epic.xml'
+    };
+
+    const templateFile = templateMap[name];
+    if (!templateFile) throw new Error(`Unknown prompt: ${name}`);
+
+    const templatePath = resolveTemplatePath(templateFile, basePath);
+    const template = readTemplate(templatePath);
+    const markdown = generateMarkdown(template, {});
+
+    return {
+      messages: [{
+        role: 'user',
+        content: { type: 'text', text: `Use this template to create a new ${templateFile.replace('.xml', '')}:\n\n${markdown}` }
+      }]
+    };
+  } catch (e) {
+    return {
+      messages: [{
+        role: 'user',
+        content: { type: 'text', text: `Template not available: ${e.message}. Run autopm install first.` }
+      }]
+    };
+  }
+});
+
+// ── Helpers ──
+
+function text(content) {
+  return { content: [{ type: 'text', text: content }] };
+}
+
+function resource(uri, content, mimeType) {
+  return { contents: [{ uri, text: content, mimeType }] };
+}
+
+// ── Start ──
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('AutoPM MCP Server running on stdio');
+}
+
+main().catch(console.error);

--- a/autopm/.claude/scripts/mcp/autopm-server.js
+++ b/autopm/.claude/scripts/mcp/autopm-server.js
@@ -156,13 +156,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
       case 'autopm_learn': {
         try {
-          const loggerPath = path.join(basePath, '.claude', 'lib', 'event-logger');
-          const { logEvent } = require(loggerPath);
           const learningsPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
           const dir = path.dirname(learningsPath);
           if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
           const entry = { timestamp: new Date().toISOString(), type: 'learning', learning: args.learning, tags: args.tags || [] };
           fs.appendFileSync(learningsPath, JSON.stringify(entry) + '\n');
+          try {
+            const loggerPath = path.join(basePath, '.claude', 'lib', 'event-logger');
+            const { logEvent } = require(loggerPath);
+            logEvent('learning.saved', { learning: args.learning, tags: args.tags || [] }, basePath);
+          } catch { /* best effort */ }
           return text(JSON.stringify({ success: true, learning: args.learning }));
         } catch (e) { return text(JSON.stringify({ error: e.message })); }
       }
@@ -173,7 +176,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           .map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
         if (args && args.tag) entries = entries.filter(e => (e.tags || []).includes(args.tag));
         const limit = (args && args.limit) || 20;
-        return text(JSON.stringify({ learnings: entries.slice(-limit) }));
+        return text(JSON.stringify({ learnings: entries.slice(-limit).reverse() }));
       }
       case 'autopm_checkpoint': {
         try {
@@ -187,7 +190,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             gitInfo.hash = execSync('git rev-parse --short HEAD', { encoding: 'utf8', cwd: basePath }).trim();
             gitInfo.clean = !execSync('git status --porcelain', { encoding: 'utf8', cwd: basePath }).trim();
           } catch { /* not a git repo */ }
-          const checkpoint = { timestamp: now, description: args.description, git: gitInfo };
+          // Count PM artifacts to match CLI checkpoint format
+          const counts = {};
+          for (const [key, dir] of [['issues', 'issues'], ['epics', 'epics'], ['prds', 'prds']]) {
+            const d = path.join(basePath, '.claude', dir);
+            try { counts[key] = fs.readdirSync(d).filter(f => f.endsWith('.md')).length; } catch { counts[key] = 0; }
+          }
+          // Load recent learnings
+          let learnings = [];
+          try {
+            const lPath = path.join(basePath, '.claude', 'pm', 'learnings.jsonl');
+            if (fs.existsSync(lPath)) {
+              learnings = fs.readFileSync(lPath, 'utf8').trim().split('\n')
+                .map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean).slice(-5);
+            }
+          } catch { /* ignore */ }
+          const checkpoint = { timestamp: now, description: args.description, git: gitInfo, counts, learnings, config_snapshot: null };
           fs.writeFileSync(path.join(cpDir, now.replace(/[:.]/g, '-') + '.json'), JSON.stringify(checkpoint, null, 2));
           return text(JSON.stringify({ success: true, checkpoint }));
         } catch (e) { return text(JSON.stringify({ error: e.message })); }
@@ -273,14 +291,14 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
     return {
       messages: [{
         role: 'user',
-        content: { type: 'text', text: `Use this template to create a new ${templateFile.replace('.xml', '')}:\n\n${markdown}` }
+        content: [{ type: 'text', text: `Use this template to create a new ${templateFile.replace('.xml', '')}:\n\n${markdown}` }]
       }]
     };
   } catch (e) {
     return {
       messages: [{
         role: 'user',
-        content: { type: 'text', text: `Template not available: ${e.message}. Run autopm install first.` }
+        content: [{ type: 'text', text: `Template not available: ${e.message}. Run autopm install first.` }]
       }]
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "@anthropic-ai/sdk": "^0.67.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/rest": "^22.0.0",
         "azure-devops-node-api": "^15.1.1",
         "chalk": "4.1.2",
@@ -688,7 +689,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
       "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -1757,11 +1757,10 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2676,7 +2675,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -2706,7 +2704,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -3064,7 +3061,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -3195,7 +3191,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3643,7 +3638,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -3657,7 +3651,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3674,7 +3667,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3684,7 +3676,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -3694,7 +3685,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -4837,7 +4827,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4919,8 +4908,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
@@ -4953,7 +4941,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5052,8 +5039,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5087,7 +5073,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5097,7 +5082,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -5110,7 +5094,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -5183,7 +5166,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5227,7 +5209,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
       "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -5353,7 +5334,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -5479,7 +5459,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5489,7 +5468,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5764,7 +5742,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5781,7 +5758,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -5941,7 +5917,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5951,7 +5926,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -6070,8 +6044,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -7586,7 +7559,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7659,8 +7631,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -8203,7 +8174,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8213,7 +8183,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -8267,7 +8236,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8277,7 +8245,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -8763,7 +8730,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8840,7 +8806,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8862,7 +8827,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -8874,7 +8838,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9021,7 +8984,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9092,7 +9054,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
       "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -9133,7 +9094,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9341,7 +9301,6 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -9436,7 +9395,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9446,7 +9404,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -9599,7 +9556,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -9709,7 +9665,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -9746,7 +9701,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -9765,8 +9719,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10006,7 +9959,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10426,7 +10378,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -10480,7 +10431,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -10567,7 +10517,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10674,7 +10623,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10757,7 +10705,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -10989,7 +10936,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10999,7 +10945,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "optional": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   ],
   "dependencies": {
     "@anthropic-ai/sdk": "^0.67.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/rest": "^22.0.0",
     "azure-devops-node-api": "^15.1.1",
     "chalk": "4.1.2",


### PR DESCRIPTION
## 🎯 Goal
MCP server exposing AutoPM PM data. Reuses local providers — same data as slash commands, accessible from any MCP client.

## ✅ Features
- **13 tools**: issue CRUD, epic/PRD list/show, status, learn/recall, checkpoint
- **5 resources**: config, agents, events, learnings, test-plan
- **3 prompts**: issue/prd/epic XML templates
- stdio transport, @modelcontextprotocol/sdk
- Zero data duplication (delegates to local providers)

## Usage
\`autopm mcp enable autopm\` then tools available as \`mcp__autopm__*\`

158/158 tests. Closes #509.