### PR TITLE
chore: release 3.22.0 — AutoPM MCP Server, architecture diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump version to 3.22.0
- Includes PR #517: AutoPM MCP Server (13 tools, 5 resources, 3 prompts)
- Includes PR #516: Project architecture diagrams

## Release
Version bump only — all features already merged to main via #516 and #517.