### PR TITLE
chore: release 3.22.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.22.1",
+      "version": "3.22.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
Version bump only. Includes PR #521: split-view diagram editor with pan/zoom.