### PR TITLE
feat(plugin-obsidian): Obsidian vault integration as new install scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **plugin-obsidian**: New Obsidian vault integration plugin (#537)
+  - `obsidian:setup` — Interactive vault configuration wizard
+  - `obsidian:sync` — Unidirectional project-to-vault sync (rsync-based, cross-platform)
+  - `obsidian:doctor` — Five-check diagnostic for common integration issues
+  - Templates: MOC, Dashboard, Dataview queries, Mermaid diagrams, Excalidraw canvas
+  - Canonical frontmatter schema for Dataview + Breadcrumbs
+  - New install scenario: `autopm install --scenario=obsidian`
+  - Supports WSL2, macOS, and Linux-native environments
+
 ## [3.21.0] - 2026-04-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Choose your scenario during installation:
 | **GitHub** | 12 | Core + languages for GitHub projects |
 | **Azure** | 14 | Core + languages + Azure DevOps |
 | **Docker** | 16 | Core + DevOps + containers |
+| **Obsidian** | 12 | PM + Obsidian vault integration |
 | **Full** | 44+ | All plugins, all agents |
 | **Performance** | 44+ | Full + max parallelization |
 
@@ -134,10 +135,11 @@ All commands run inside Claude Code (not terminal):
 
 ## Features
 
-### 13 Official Plugins
+### 14 Official Plugins
 
 - **Core** — Context management, testing, configuration, MCP
 - **PM System** — PRD, epics, issues, decomposition, git workflow
+- **Obsidian** — Read-only vault sync, Dataview frontmatter, diagnostics
 - **Azure DevOps** — Work items, boards, pipelines, sprints
 - **GitHub** — Workflows, issues, PRs, automation
 - **Languages** — Python, JavaScript, Node.js, Bash

--- a/autopm/.claude/docs/xml-prompts/README.md
+++ b/autopm/.claude/docs/xml-prompts/README.md
@@ -435,7 +435,7 @@ Create templates tailored to your project:
   --stage 2
 
 # Edit template
-vim autopm/.claude/templates/xml-prompts/dev/microservice.xml
+vim .claude/templates/xml-prompts/dev/microservice.xml
 
 # Use custom template
 /prompt:xml microservice \
@@ -522,5 +522,5 @@ Solution: Provide missing flag
   - `.claude/commands/xml/prompt-xml.md`
   - `.claude/commands/xml/template.md`
 - **Utilities:**
-  - `autopm/.claude/lib/xml-prompt-builder.js`
-  - `autopm/.claude/lib/xml-validator.js`
+  - `.claude/lib/xml-prompt-builder.js`
+  - `.claude/lib/xml-validator.js`

--- a/autopm/.claude/docs/xml-prompts/creating-templates.md
+++ b/autopm/.claude/docs/xml-prompts/creating-templates.md
@@ -111,7 +111,7 @@ This will prompt you for:
 
 ```bash
 # Create file in appropriate category
-vim autopm/.claude/templates/xml-prompts/dev/my-template.xml
+vim .claude/templates/xml-prompts/dev/my-template.xml
 ```
 
 ### Step 3: Define Template Content
@@ -558,7 +558,7 @@ cat test.xml | grep -q "<thinking>" && echo "✅ Has thinking" || echo "❌ Miss
 Track template changes:
 
 ```bash
-git add autopm/.claude/templates/xml-prompts/dev/my-template.xml
+git add .claude/templates/xml-prompts/dev/my-template.xml
 git commit -m "Update microservice template with health check requirements"
 ```
 

--- a/autopm/.claude/docs/xml-prompts/templates-guide.md
+++ b/autopm/.claude/docs/xml-prompts/templates-guide.md
@@ -462,7 +462,7 @@ done
 /xml:template create microservice --category dev --stage 2
 
 # Edit to add project-specific constraints
-vim autopm/.claude/templates/xml-prompts/dev/microservice.xml
+vim .claude/templates/xml-prompts/dev/microservice.xml
 
 # Add your patterns:
 # - Service structure requirements

--- a/docs/plugins/obsidian.md
+++ b/docs/plugins/obsidian.md
@@ -1,0 +1,148 @@
+# Obsidian Vault Integration (plugin-obsidian)
+
+## Overview
+
+plugin-obsidian creates a read-only Obsidian vault mirror of your ClaudeAutoPM project. It syncs project markdown (agents, commands, rules, epics, PRDs, issues) to an Obsidian vault where Dataview, Mermaid, Excalidraw, and canonical frontmatter work out of the box.
+
+Sync is **unidirectional**: project to vault. Never edit files in the Obsidian vault directly.
+
+## Prerequisites
+
+- `rsync` (required for sync)
+- `inotify-tools` (Linux/WSL, optional -- for `--watch` mode)
+- `fswatch` (macOS, optional -- for `--watch` mode)
+- Obsidian desktop app
+
+## Installation
+
+```bash
+autopm install --scenario=obsidian
+```
+
+Or add to an existing installation by selecting scenario 7 during `autopm install`.
+
+## Setup
+
+After installation, configure your vault:
+
+```bash
+/obsidian:setup --vault-path /path/to/vault --prefix my-project
+```
+
+Arguments:
+- `--vault-path` (required): Path to your Obsidian vault folder
+- `--prefix` (optional): Subfolder name in vault (defaults to project directory name)
+- `--watch` / `--no-watch`: Enable/disable continuous sync
+
+The setup wizard will:
+1. Detect your environment (WSL2, macOS, Linux)
+2. Validate the vault path
+3. Save configuration to `.claude/config.json`
+4. Generate MOC, Dashboard, templates, and diagrams in your vault
+5. Apply canonical frontmatter to existing issues/PRDs
+6. Run the first sync
+
+## Commands
+
+### `/obsidian:sync`
+
+Sync project files to the Obsidian vault.
+
+```bash
+/obsidian:sync              # One-shot sync
+/obsidian:sync --watch      # Continuous sync on file changes
+/obsidian:sync --check      # Dry-run (show what would sync)
+/obsidian:sync --safe-mode  # Don't delete vault files
+```
+
+Flags can be combined: `/obsidian:sync --watch --safe-mode`
+
+### `/obsidian:doctor`
+
+Diagnose common integration problems:
+
+1. Missing rsync / inotify-tools / fswatch
+2. Unreachable or non-writable vault path
+3. Issues under `.claude/issues/` (invisible to Dataview)
+4. Wrong Dataview FROM prefix
+5. Broken symlink between `.claude/issues` and `issues/`
+
+### `/obsidian:setup`
+
+Interactive vault configuration (run once after install).
+
+## Sync Mapping
+
+| Project Path | Vault Path |
+|--------------|------------|
+| `.claude/agents/` | `{vault}/{prefix}/agents/` |
+| `.claude/commands/` | `{vault}/{prefix}/commands/` |
+| `.claude/rules/` | `{vault}/{prefix}/rules/` |
+| `.claude/epics/` | `{vault}/{prefix}/epics/` |
+| `.claude/prds/` | `{vault}/{prefix}/prds/` |
+| `issues/` | `{vault}/{prefix}/issues/` |
+| `*.md` (root) | `{vault}/{prefix}/` |
+
+> Obsidian ignores dotfolders (`.claude/`), so the sync script maps them to visible paths.
+
+## Recommended Obsidian Plugins
+
+Install these in Obsidian for the best experience:
+
+| Plugin | Purpose | Link |
+|--------|---------|------|
+| Dataview | Query and display data from frontmatter | [Install](https://obsidian.md/plugins?id=dataview) |
+| Templater | Template engine for new notes | [Install](https://obsidian.md/plugins?id=templater-obsidian) |
+| Excalidraw | Whiteboard / diagram drawing | [Install](https://obsidian.md/plugins?id=obsidian-excalidraw-plugin) |
+| Mermaid Tools | Enhanced Mermaid diagram rendering | [Install](https://obsidian.md/plugins?id=mermaid-tools) |
+| Breadcrumbs | Hierarchical navigation | [Install](https://obsidian.md/plugins?id=breadcrumbs) |
+| Advanced Tables | Markdown table editing | [Install](https://obsidian.md/plugins?id=table-editor-obsidian) |
+
+## Frontmatter Schema
+
+All synced files include canonical frontmatter for Dataview:
+
+```yaml
+---
+type: issue|prd|epic|agent|rule
+status: open|in-progress|closed
+created: "2026-01-15T14:30:00Z"
+updated: "2026-01-15T14:30:00Z"
+tags: [issue, auth]
+---
+```
+
+See `packages/plugin-obsidian/templates/FRONTMATTER_SCHEMA.md` for full schema.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Dataview shows no results | Wrong prefix or dotfolder issue | Run `/obsidian:doctor` |
+| Sync fails with "rsync not found" | rsync not installed | `sudo apt install rsync` (Linux) or `brew install rsync` (macOS) |
+| Watch mode doesn't detect changes | Missing inotify-tools/fswatch | `sudo apt install inotify-tools` (Linux) or `brew install fswatch` (macOS) |
+| Files appear in vault but Dataview can't see them | Files in dotfolder | Run `/obsidian:setup` to migrate `.claude/issues/` to `issues/` |
+| Symlink broken after git pull | Target deleted | Run `/obsidian:doctor` check 5 |
+| WSL vault path unreachable | Using `\\wsl.localhost\...` path | Use a Windows path (e.g., `/mnt/c/Users/.../vault`) or a local Linux path |
+
+## Configuration
+
+Settings are stored in `.claude/config.json`:
+
+```json
+{
+  "obsidian": {
+    "vault_path": "/path/to/vault",
+    "vault_prefix": "my-project",
+    "watch": false,
+    "environment": "wsl"
+  }
+}
+```
+
+## Limitations
+
+- Sync is unidirectional (project to vault). Do not edit vault files.
+- One vault per project (multiple vaults not supported).
+- Obsidian plugins must be installed manually (UI-only action).
+- Binary files (images, videos) are excluded from sync.

--- a/install/install.js
+++ b/install/install.js
@@ -556,6 +556,14 @@ ${this.colors.BOLD}Select installation scenario:${this.colors.NC}
    • Advanced users only
 `);
 
+    // Option 7: Obsidian (always available)
+    console.log(`${this.colors.CYAN}7. Obsidian${this.colors.NC} - PM + Obsidian vault integration (rsync, Dataview, templates)
+   • Core + PM + Obsidian vault sync
+   • Unidirectional project → vault mirroring
+   • Best for: Knowledge management, documentation-heavy projects
+   ${this.colors.DIM}• Plugins: core, pm, obsidian (3 plugins)${this.colors.NC}
+`);
+
     if (process.env.AUTOPM_TEST_MODE === '1') {
       this.printMsg('CYAN', 'Auto-selecting option 0 (lite) for test mode');
       return 'lite';
@@ -571,7 +579,7 @@ ${this.colors.BOLD}Select installation scenario:${this.colors.NC}
 
     return new Promise((resolve) => {
       const askQuestion = () => {
-        rl.question(`${this.colors.CYAN}Enter your choice (0-6) [${defaultChoice}]: ${this.colors.NC}`, (answer) => {
+        rl.question(`${this.colors.CYAN}Enter your choice (0-7) [${defaultChoice}]: ${this.colors.NC}`, (answer) => {
           const choice = answer.trim() || defaultChoice;
           const scenarios = {
             '0': 'lite',
@@ -580,7 +588,8 @@ ${this.colors.BOLD}Select installation scenario:${this.colors.NC}
             '3': 'docker',
             '4': 'full',
             '5': 'performance',
-            '6': 'custom'
+            '6': 'custom',
+            '7': 'obsidian'
           };
 
           const selectedScenario = scenarios[choice];
@@ -608,7 +617,7 @@ ${this.colors.BOLD}Select installation scenario:${this.colors.NC}
           }
 
           if (!selectedScenario) {
-            console.log(`${this.colors.RED}✗ Invalid choice. Please select 0-6.${this.colors.NC}`);
+            console.log(`${this.colors.RED}✗ Invalid choice. Please select 0-7.${this.colors.NC}`);
             askQuestion();
             return;
           }
@@ -703,6 +712,16 @@ ${this.colors.BOLD}Select installation scenario:${this.colors.NC}
           kubernetes: { enabled: true }
         },
         plugins: ['plugin-core', 'plugin-languages', 'plugin-frameworks', 'plugin-testing', 'plugin-devops', 'plugin-cloud', 'plugin-databases', 'plugin-data', 'plugin-pm', 'plugin-pm-github', 'plugin-ai', 'plugin-ml']
+      },
+      obsidian: {
+        version: version,
+        installed: new Date().toISOString(),
+        execution_strategy: 'sequential',
+        tools: {
+          docker: { enabled: false },
+          kubernetes: { enabled: false }
+        },
+        plugins: ['plugin-core', 'plugin-pm', 'plugin-obsidian']
       }
     };
 

--- a/install/post-install-check.js
+++ b/install/post-install-check.js
@@ -37,6 +37,7 @@ class PostInstallChecker {
     this.checkMCPConfiguration();
     this.checkGitHooks();
     this.checkNodeVersion();
+    this.checkObsidianVault();
 
     // Display results
     this.displayResults();
@@ -334,6 +335,34 @@ class PostInstallChecker {
     if (!isSupported) {
       this.results.nextSteps.push('Upgrade Node.js to v18 or higher');
     }
+  }
+
+  /**
+   * Check Obsidian vault configuration
+   */
+  checkObsidianVault() {
+    const configPath = path.join(this.projectRoot, '.claude', 'config.json');
+    let configured = false;
+    let message = 'Not configured — run: obsidian:setup';
+
+    if (fs.existsSync(configPath)) {
+      try {
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        const vaultPath = config.obsidian?.vault_path;
+        if (vaultPath) {
+          configured = true;
+          message = `Vault: ${vaultPath}`;
+        }
+      } catch (error) {
+        // config unreadable, leave as not configured
+      }
+    }
+
+    this.results.optional.push({
+      name: 'Obsidian vault',
+      status: configured,
+      message: message
+    });
   }
 
   /**

--- a/packages/plugin-obsidian/LICENSE
+++ b/packages/plugin-obsidian/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Rafal Lagowski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugin-obsidian/README.md
+++ b/packages/plugin-obsidian/README.md
@@ -1,0 +1,32 @@
+# @claudeautopm/plugin-obsidian
+
+Obsidian vault integration plugin for ClaudeAutoPM.
+
+## Features
+
+- **Vault Sync**: Unidirectional project → Obsidian vault sync via rsync
+- **Setup Wizard**: Interactive configuration for vault path, prefix, and watch mode
+- **Doctor**: Five-check diagnostic for common integration issues
+- **Templates**: MOC, Dashboard, and Dataview-aware templates with canonical frontmatter
+
+## Installation
+
+```bash
+autopm install --scenario=obsidian
+```
+
+## Commands
+
+- `obsidian:setup` — Interactive vault configuration wizard
+- `obsidian:sync` — Sync project to Obsidian vault
+- `obsidian:doctor` — Diagnose common integration problems
+
+## Requirements
+
+- `rsync` (required)
+- `inotify-tools` (Linux/WSL, optional for watch mode)
+- `fswatch` (macOS, optional for watch mode)
+
+## License
+
+MIT

--- a/packages/plugin-obsidian/README.md
+++ b/packages/plugin-obsidian/README.md
@@ -1,31 +1,128 @@
 # @claudeautopm/plugin-obsidian
 
-Obsidian vault integration plugin for ClaudeAutoPM.
+> **Obsidian Vault Integration Plugin for ClaudeAutoPM Framework**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Overview
+
+`@claudeautopm/plugin-obsidian` creates a read-only Obsidian vault mirror of your ClaudeAutoPM project. It syncs project markdown (agents, commands, rules, epics, PRDs, issues) to an Obsidian vault where Dataview, Mermaid, Excalidraw, and canonical frontmatter work out of the box.
+
+Sync is **unidirectional**: project to vault. Never edit files in the Obsidian vault directly.
+
+### Package Information
+
+- **Package Name:** `@claudeautopm/plugin-obsidian`
+- **Category:** Integration
+- **Schema Version:** 2.0
+
+---
 
 ## Features
 
-- **Vault Sync**: Unidirectional project → Obsidian vault sync via rsync
-- **Setup Wizard**: Interactive configuration for vault path, prefix, and watch mode
-- **Doctor**: Five-check diagnostic for common integration issues
-- **Templates**: MOC, Dashboard, and Dataview-aware templates with canonical frontmatter
+- **Vault Sync** -- Unidirectional project-to-vault sync via rsync (one-shot, watch, dry-run, safe-mode)
+- **Setup Wizard** -- Interactive configuration for vault path, prefix, watch mode, and environment detection (WSL2, macOS, Linux)
+- **Doctor** -- Five-check diagnostic for common integration issues (missing tools, unreachable vault, dotfolder visibility, Dataview prefix, broken symlinks)
+- **Templates** -- MOC, Dashboard, Dataview queries, Mermaid diagrams, and Excalidraw canvas
+- **Canonical Frontmatter** -- Schema for Dataview + Breadcrumbs compatibility across all synced files
+- **Cross-Platform** -- Supports WSL2, macOS, and Linux-native environments
+
+---
 
 ## Installation
 
 ```bash
+# Install via scenario
 autopm install --scenario=obsidian
+
+# Or add to existing installation (scenario 7)
+autopm install
 ```
+
+### Prerequisites
+
+- `rsync` (required)
+- `inotify-tools` (Linux/WSL, optional for `--watch` mode)
+- `fswatch` (macOS, optional for `--watch` mode)
+- Obsidian desktop app
+
+---
 
 ## Commands
 
-- `obsidian:setup` — Interactive vault configuration wizard
-- `obsidian:sync` — Sync project to Obsidian vault
-- `obsidian:doctor` — Diagnose common integration problems
+### `obsidian:setup`
 
-## Requirements
+Interactive vault configuration wizard. Run once after install.
 
-- `rsync` (required)
-- `inotify-tools` (Linux/WSL, optional for watch mode)
-- `fswatch` (macOS, optional for watch mode)
+```bash
+/obsidian:setup --vault-path /path/to/vault --prefix my-project
+```
+
+### `obsidian:sync`
+
+Sync project files to the Obsidian vault.
+
+```bash
+/obsidian:sync              # One-shot sync
+/obsidian:sync --watch      # Continuous sync on file changes
+/obsidian:sync --check      # Dry-run (show what would sync)
+/obsidian:sync --safe-mode  # Don't delete vault files
+```
+
+### `obsidian:doctor`
+
+Diagnose common integration problems:
+
+1. Missing rsync / inotify-tools / fswatch
+2. Unreachable or non-writable vault path
+3. Issues under `.claude/issues/` (invisible to Dataview)
+4. Wrong Dataview FROM prefix
+5. Broken symlink between `.claude/issues` and `issues/`
+
+---
+
+## Configuration
+
+Settings are stored in `.claude/config.json`:
+
+```json
+{
+  "obsidian": {
+    "vault_path": "/path/to/vault",
+    "vault_prefix": "my-project",
+    "watch": false,
+    "environment": "wsl"
+  }
+}
+```
+
+---
+
+## Sync Mapping
+
+| Project Path | Vault Path |
+|--------------|------------|
+| `.claude/agents/` | `{vault}/{prefix}/agents/` |
+| `.claude/commands/` | `{vault}/{prefix}/commands/` |
+| `.claude/rules/` | `{vault}/{prefix}/rules/` |
+| `.claude/epics/` | `{vault}/{prefix}/epics/` |
+| `.claude/prds/` | `{vault}/{prefix}/prds/` |
+| `issues/` | `{vault}/{prefix}/issues/` |
+| `*.md` (root) | `{vault}/{prefix}/` |
+
+---
+
+## Documentation
+
+Full user guide: [docs/plugins/obsidian.md](../../docs/plugins/obsidian.md)
+
+---
+
+## Peer Dependencies
+
+- **@claudeautopm/plugin-core** (^2.0.0) -- Core framework plugin (REQUIRED)
+
+---
 
 ## License
 

--- a/packages/plugin-obsidian/claude-md/obsidian-section.md
+++ b/packages/plugin-obsidian/claude-md/obsidian-section.md
@@ -1,0 +1,30 @@
+## Obsidian Vault Integration
+
+This project uses Obsidian as a visual layer for project documentation.
+
+### Vault Sync
+
+- **Sync is unidirectional**: Project → Vault (never edit in Obsidian)
+- Run `/obsidian:sync` for one-shot sync
+- Run `/obsidian:sync --watch` for continuous sync
+- Run `/obsidian:doctor` to diagnose issues
+
+### Frontmatter Convention
+
+All markdown files should include canonical frontmatter for Dataview:
+
+```yaml
+---
+type: issue|prd|epic|agent|rule
+status: open|in-progress|closed
+created: "YYYY-MM-DDTHH:mm:ssZ"
+updated: "YYYY-MM-DDTHH:mm:ssZ"
+tags: [relevant, tags]
+---
+```
+
+### Important Rules
+
+- **Never edit files in the Obsidian vault directly** — changes will be overwritten on next sync
+- Dotfolders (`.claude/`) are invisible to Dataview — the sync script maps them to visible paths
+- If using shared vaults, set `obsidian.vault_prefix` in `.claude/config.json`

--- a/packages/plugin-obsidian/commands/obsidian:doctor.md
+++ b/packages/plugin-obsidian/commands/obsidian:doctor.md
@@ -1,0 +1,63 @@
+---
+allowed-tools: Bash, Read
+---
+
+# Obsidian Doctor
+
+Run diagnostics on the Obsidian integration and suggest fixes for common problems.
+
+## Usage
+
+```
+/obsidian:doctor
+```
+
+## Instructions
+
+### 1. Locate Script
+
+```bash
+SCRIPT_JS="packages/plugin-obsidian/scripts/obsidian/doctor.js"
+
+if [ ! -f "$SCRIPT_JS" ]; then
+  SCRIPT_JS=".claude/scripts/doctor.js"
+fi
+
+if [ ! -f "$SCRIPT_JS" ]; then
+  echo "❌ Doctor script not found. Reinstall plugin-obsidian or run: /obsidian:setup"
+  exit 1
+fi
+```
+
+### 2. Run Diagnostics
+
+```bash
+node "$SCRIPT_JS"
+```
+
+### 3. Output
+
+On success (all checks pass or only warnings):
+
+```
+Obsidian Doctor
+════════════════════════════════════════════════════════════
+
+✅  rsync                    installed    /usr/bin/rsync
+⚠️  inotify-tools            missing      Install: sudo apt install inotify-tools
+✅  Vault path               ok           /path/to/vault
+✅  Issues location          ok           issues/
+✅  Dataview prefix          correct      my-project
+✅  Symlink                  ok           .claude/issues -> issues
+
+════════════════════════════════════════════════════════════
+Result: 5 passed, 1 warning
+```
+
+On failure (any check has an error):
+
+```
+Result: 3 passed, 1 warning, 2 errors
+```
+
+Exit code 0 means all checks passed (warnings are OK). Exit code 1 means at least one check failed.

--- a/packages/plugin-obsidian/commands/obsidian:setup.md
+++ b/packages/plugin-obsidian/commands/obsidian:setup.md
@@ -1,0 +1,69 @@
+---
+allowed-tools: Bash, Read, Write
+---
+
+# Obsidian Setup Wizard
+
+Configure an Obsidian vault for use with ClaudeAutoPM. Run this once after `autopm install --scenario=obsidian`.
+
+## Usage
+
+```
+/obsidian:setup --vault-path /path/to/vault [--prefix my-project] [--watch] [--no-watch]
+```
+
+Options:
+- `--vault-path PATH` — Absolute path to your Obsidian vault (required)
+- `--prefix NAME` — Subfolder name inside the vault (default: project directory name)
+- `--watch` — Enable continuous sync in config
+- `--no-watch` — Disable continuous sync in config (default)
+
+## Instructions
+
+### 1. Gather Arguments
+
+Ask the user for `--vault-path` if not provided. The vault must already exist as a directory.
+
+On WSL, vault paths typically look like: `/mnt/c/Users/<name>/Documents/Obsidian/Vault`
+
+### 2. Run Setup Script
+
+Execute the backend script with the user's arguments:
+
+```bash
+node packages/plugin-obsidian/scripts/obsidian/setup.js \
+  --vault-path "$VAULT_PATH" \
+  --prefix "$PREFIX" \
+  --project-root "$(pwd)"
+```
+
+Add `--watch` or `--no-watch` if the user specified either.
+
+### 3. What the Script Does
+
+The setup script performs these steps in order:
+
+1. **Detects environment** — WSL, macOS, or Linux
+2. **Validates vault path** — Checks existence and write permissions
+3. **Merges config** — Adds `obsidian` section to `.claude/config.json` (preserves all existing keys)
+4. **Generates templates** — Writes MOC, Dashboard, Obsidian templates, and diagram stubs into the vault
+5. **Applies canonical frontmatter** — Adds missing fields (`type`, `status`, `created`, `updated`, `tags`) to existing issues and PRDs without overwriting existing values
+6. **Migrates issues** — If `issues/` doesn't exist but `.claude/issues/` does, moves it and creates a symlink
+7. **Copies sync script** — Places `sync-to-obsidian.sh` into `.claude/scripts/`
+8. **Runs first sync** — Executes the sync script once to populate the vault
+
+### 4. Output
+
+On success, the script prints a summary showing the vault path, prefix, environment, generated files, and recommended next steps (plugin installation links).
+
+### 5. Troubleshooting
+
+If the script fails:
+
+- **Vault path does not exist** — Create the directory first or check the path
+- **Vault path is not writable** — Fix permissions: `chmod u+w /path/to/vault`
+- **Sync script not found** — Re-run `autopm install --scenario=obsidian`
+
+## Related Commands
+
+- `/obsidian:sync` — Run a one-off or continuous sync after setup

--- a/packages/plugin-obsidian/commands/obsidian:sync.md
+++ b/packages/plugin-obsidian/commands/obsidian:sync.md
@@ -1,0 +1,105 @@
+---
+allowed-tools: Bash, Read
+---
+
+# Obsidian Sync
+
+Sync project markdown to an Obsidian vault (unidirectional: project → vault).
+
+## Usage
+
+```
+/obsidian:sync [--watch] [--check] [--safe-mode]
+```
+
+Options:
+- `--watch` — Continuous sync on file changes (inotifywait on Linux/WSL, fswatch on macOS)
+- `--check` — Dry-run: show what would be synced without creating files
+- `--safe-mode` — Never delete vault files (omits `--delete` from rsync)
+
+Options can be combined: `--watch --safe-mode`
+
+## Instructions
+
+### 1. Verify Setup
+
+Check that Obsidian has been configured:
+
+```bash
+if [ ! -f .claude/config.json ] || ! node -e "
+  const c = JSON.parse(require('fs').readFileSync('.claude/config.json','utf8'));
+  if (!c.obsidian || !c.obsidian.vault_path) process.exit(1);
+" 2>/dev/null; then
+  echo "❌ Obsidian not configured. Run: /obsidian:setup"
+  exit 1
+fi
+```
+
+### 2. Detect Script Runner
+
+Choose shell or Node fallback based on environment:
+
+```bash
+PLUGIN_DIR="$(dirname "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")")"
+
+# Try to find scripts relative to plugin package
+SCRIPT_SH="packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.sh"
+SCRIPT_JS="packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.js"
+
+# Also check if copied to .claude/scripts during setup
+if [ ! -f "$SCRIPT_SH" ]; then
+  SCRIPT_SH=".claude/scripts/sync-to-obsidian.sh"
+fi
+if [ ! -f "$SCRIPT_JS" ]; then
+  SCRIPT_JS=".claude/scripts/sync-to-obsidian.js"
+fi
+```
+
+### 3. Run Sync
+
+Build flags from user arguments and execute:
+
+```bash
+FLAGS=""
+
+# Parse arguments from $ARGUMENTS
+case "$ARGUMENTS" in
+  *--watch*)    FLAGS="$FLAGS --watch" ;;
+esac
+case "$ARGUMENTS" in
+  *--check*)    FLAGS="$FLAGS --check" ;;
+esac
+case "$ARGUMENTS" in
+  *--safe-mode*) FLAGS="$FLAGS --safe-mode" ;;
+esac
+
+# Prefer shell script, fall back to Node
+if [ -f "$SCRIPT_SH" ] && command -v bash >/dev/null 2>&1; then
+  bash "$SCRIPT_SH" $FLAGS
+elif [ -f "$SCRIPT_JS" ] && command -v node >/dev/null 2>&1; then
+  node "$SCRIPT_JS" $FLAGS
+else
+  echo "❌ Sync script not found. Reinstall plugin-obsidian or run: /obsidian:setup"
+  exit 1
+fi
+```
+
+### 4. Output
+
+On success:
+
+```
+✅ Sync complete
+  Vault: {vault_path}
+  Prefix: {vault_prefix}
+  Files synced: {count}
+
+Next: Open vault in Obsidian to see changes
+```
+
+On watch mode:
+
+```
+👁️ Watching for changes... (Ctrl+C to stop)
+  Vault: {vault_path}
+```

--- a/packages/plugin-obsidian/package.json
+++ b/packages/plugin-obsidian/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@claudeautopm/plugin-obsidian",
+  "version": "1.0.0",
+  "description": "Obsidian vault integration plugin for ClaudeAutoPM — sync, Dataview, Mermaid, and Excalidraw support",
+  "main": "plugin.json",
+  "type": "module",
+  "files": [
+    "commands/",
+    "scripts/",
+    "templates/",
+    "claude-md/",
+    "plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "validate": "node -e \"require('./plugin.json')\" && echo 'plugin.json is valid'"
+  },
+  "keywords": [
+    "claudeautopm",
+    "plugin",
+    "obsidian",
+    "vault",
+    "sync",
+    "dataview",
+    "mermaid",
+    "excalidraw"
+  ],
+  "author": "ClaudeAutoPM Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rafeekpro/ClaudeAutoPM.git",
+    "directory": "packages/plugin-obsidian"
+  },
+  "bugs": {
+    "url": "https://github.com/rafeekpro/ClaudeAutoPM/issues"
+  },
+  "homepage": "https://github.com/rafeekpro/ClaudeAutoPM/tree/main/packages/plugin-obsidian#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "peerDependencies": {
+    "@claudeautopm/plugin-core": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/plugin-obsidian/plugin.json
+++ b/packages/plugin-obsidian/plugin.json
@@ -19,7 +19,26 @@
     "required": false,
     "tags": ["obsidian", "vault", "sync", "dataview", "integration"]
   },
-  "scripts": [],
+  "scripts": [
+    {
+      "name": "sync-to-obsidian",
+      "file": "scripts/obsidian/sync-to-obsidian.sh",
+      "description": "Cross-platform rsync-based project-to-vault sync",
+      "type": "utility",
+      "executable": true,
+      "category": "sync",
+      "tags": ["sync", "rsync", "vault"]
+    },
+    {
+      "name": "sync-to-obsidian-node",
+      "file": "scripts/obsidian/sync-to-obsidian.js",
+      "description": "Node.js fallback for sync engine",
+      "type": "utility",
+      "executable": true,
+      "category": "sync",
+      "tags": ["sync", "node", "vault"]
+    }
+  ],
   "commands": [
     {
       "subdirectory": "commands/",

--- a/packages/plugin-obsidian/plugin.json
+++ b/packages/plugin-obsidian/plugin.json
@@ -1,0 +1,54 @@
+{
+  "name": "@claudeautopm/plugin-obsidian",
+  "version": "1.0.0",
+  "schemaVersion": "2.0",
+  "displayName": "Obsidian Vault Integration",
+  "description": "Obsidian vault mirror integration with Dataview, Mermaid, Excalidraw and canonical frontmatter support",
+  "category": "integration",
+  "metadata": {
+    "category": "Integration",
+    "author": "ClaudeAutoPM Team",
+    "license": "MIT",
+    "homepage": "https://github.com/rafeekpro/ClaudeAutoPM",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/rafeekpro/ClaudeAutoPM.git",
+      "directory": "packages/plugin-obsidian"
+    },
+    "size": "~10 KB (gzipped)",
+    "required": false,
+    "tags": ["obsidian", "vault", "sync", "dataview", "integration"]
+  },
+  "scripts": [],
+  "commands": [
+    {
+      "subdirectory": "commands/",
+      "description": "Obsidian vault management commands",
+      "type": "collection",
+      "categories": {
+        "obsidian": "Obsidian vault integration commands"
+      },
+      "discovery": "auto",
+      "tags": ["obsidian", "vault", "sync"]
+    }
+  ],
+  "features": {
+    "vault_sync": {
+      "enabled": true,
+      "description": "Unidirectional project-to-vault sync"
+    },
+    "setup_wizard": {
+      "enabled": true,
+      "description": "Interactive vault configuration wizard"
+    },
+    "diagnostics": {
+      "enabled": true,
+      "description": "Doctor command for troubleshooting"
+    }
+  },
+  "rules": [],
+  "dependencies": [],
+  "peerPlugins": ["@claudeautopm/plugin-core"],
+  "keywords": ["claudeautopm", "obsidian", "vault", "sync", "dataview", "mermaid", "excalidraw"],
+  "compatibleWith": ">=3.0.0"
+}

--- a/packages/plugin-obsidian/scripts/obsidian/doctor.js
+++ b/packages/plugin-obsidian/scripts/obsidian/doctor.js
@@ -1,0 +1,455 @@
+#!/usr/bin/env node
+/**
+ * doctor.js -- Obsidian integration diagnostics.
+ *
+ * Reports and suggests fixes for five canonical Obsidian integration problems.
+ * ESM module, Node built-ins only, executable with shebang.
+ *
+ * Usage:
+ *   node doctor.js [OPTIONS]
+ *
+ * Options:
+ *   --project-root DIR   Override project root (for testing)
+ *   -h, --help           Show help
+ */
+
+import {
+  readFileSync,
+  existsSync,
+  writeFileSync,
+  lstatSync,
+  realpathSync,
+  accessSync,
+  constants as fsConstants,
+  unlinkSync,
+} from 'node:fs';
+import { join, resolve, dirname, basename } from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { platform } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SCRIPT_NAME = 'doctor.js';
+const SCRIPT_VERSION = '1.0.0';
+
+// --- Output helpers ---------------------------------------------------------
+
+const STATUS_PASS = '\u2705';
+const STATUS_WARN = '\u26A0\uFE0F';
+const STATUS_FAIL = '\u274C';
+
+function padRight(str, len) {
+  return str.length >= len ? str : str + ' '.repeat(len - str.length);
+}
+
+function formatRow(icon, label, status, detail) {
+  return `${icon}  ${padRight(label, 24)} ${padRight(status, 12)} ${detail}`;
+}
+
+// --- Usage / help -----------------------------------------------------------
+
+function usage() {
+  const text = `Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Obsidian integration diagnostics -- checks for common problems and suggests fixes.
+
+Options:
+  --project-root DIR   Override project root (for testing)
+  -h, --help           Show this help message`;
+  console.log(text);
+}
+
+// --- Argument parsing -------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = { projectRoot: '' };
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--project-root':
+        if (i + 1 >= argv.length || argv[i + 1].startsWith('--')) {
+          console.error('[error] --project-root requires a directory argument');
+          process.exit(1);
+        }
+        opts.projectRoot = argv[i + 1];
+        i += 2;
+        break;
+      case '-h':
+      case '--help':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        console.error(`[error] Unknown option: ${arg}`);
+        console.log('');
+        usage();
+        process.exit(1);
+    }
+  }
+
+  return opts;
+}
+
+// --- Project root detection -------------------------------------------------
+
+function findProjectRoot(overridePath) {
+  if (overridePath) {
+    return resolve(overridePath);
+  }
+
+  let dir = __dirname;
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, '.claude', 'config.json'))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+
+  console.error('[error] Could not find project root (no .claude/config.json found)');
+  process.exit(1);
+}
+
+// --- Config loading ---------------------------------------------------------
+
+function readConfig(root) {
+  const configFile = join(root, '.claude', 'config.json');
+
+  if (!existsSync(configFile)) {
+    return { error: `Config not found: ${configFile}` };
+  }
+
+  let cfg;
+  try {
+    cfg = JSON.parse(readFileSync(configFile, 'utf8'));
+  } catch (e) {
+    return { error: `Failed to parse ${configFile}: ${e.message}` };
+  }
+
+  const vaultPath = cfg?.obsidian?.vault_path;
+  if (!vaultPath) {
+    return { error: `obsidian.vault_path not set in ${configFile}` };
+  }
+
+  const vaultPrefix = cfg?.obsidian?.vault_prefix || basename(root);
+
+  return { vaultPath, vaultPrefix };
+}
+
+// --- OS detection -----------------------------------------------------------
+
+function detectOS() {
+  const p = platform();
+  if (p === 'darwin') return 'darwin';
+  if (p === 'linux') {
+    try {
+      const procVersion = readFileSync('/proc/version', 'utf8');
+      if (/microsoft/i.test(procVersion)) return 'wsl';
+    } catch {
+      // ignore
+    }
+    return 'linux';
+  }
+  return 'linux';
+}
+
+// --- Check functions --------------------------------------------------------
+
+function checkRsync() {
+  try {
+    const rsyncPath = execSync('which rsync', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return { status: 'pass', label: 'rsync', state: 'installed', detail: rsyncPath };
+  } catch {
+    const os = detectOS();
+    let installCmd = 'sudo apt install rsync';
+    if (os === 'darwin') installCmd = 'brew install rsync';
+    return {
+      status: 'fail',
+      label: 'rsync',
+      state: 'missing',
+      detail: `Install: ${installCmd}`,
+    };
+  }
+}
+
+function checkWatchTools() {
+  const os = detectOS();
+  const results = [];
+
+  if (os === 'linux' || os === 'wsl') {
+    try {
+      const toolPath = execSync('which inotifywait', {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+      results.push({
+        status: 'pass',
+        label: 'inotify-tools',
+        state: 'installed',
+        detail: toolPath,
+      });
+    } catch {
+      results.push({
+        status: 'warn',
+        label: 'inotify-tools',
+        state: 'missing',
+        detail: 'Install: sudo apt install inotify-tools',
+      });
+    }
+  }
+
+  if (os === 'darwin') {
+    try {
+      const toolPath = execSync('which fswatch', {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+      results.push({
+        status: 'pass',
+        label: 'fswatch',
+        state: 'installed',
+        detail: toolPath,
+      });
+    } catch {
+      results.push({
+        status: 'warn',
+        label: 'fswatch',
+        state: 'missing',
+        detail: 'Install: brew install fswatch',
+      });
+    }
+  }
+
+  return results;
+}
+
+function checkVaultPath(config) {
+  const { vaultPath } = config;
+
+  if (!existsSync(vaultPath)) {
+    return {
+      status: 'fail',
+      label: 'Vault path',
+      state: 'not found',
+      detail: vaultPath,
+    };
+  }
+
+  // Check write access by writing a temp file
+  const tmpFile = join(vaultPath, '.doctor-write-test');
+  try {
+    writeFileSync(tmpFile, 'test');
+    unlinkSync(tmpFile);
+  } catch {
+    return {
+      status: 'fail',
+      label: 'Vault path',
+      state: 'not writable',
+      detail: vaultPath,
+    };
+  }
+
+  return {
+    status: 'pass',
+    label: 'Vault path',
+    state: 'ok',
+    detail: vaultPath,
+  };
+}
+
+function checkDotfolderIssues(root) {
+  const claudeIssues = join(root, '.claude', 'issues');
+  const topIssues = join(root, 'issues');
+
+  // Check if .claude/issues is a symlink first -- that is handled by checkSymlink
+  try {
+    const stat = lstatSync(claudeIssues);
+    if (stat.isSymbolicLink()) {
+      // Symlink case is handled separately
+      return { status: 'pass', label: 'Issues location', state: 'ok', detail: 'symlink exists' };
+    }
+  } catch {
+    // .claude/issues does not exist at all
+  }
+
+  const claudeIssuesExists = existsSync(claudeIssues);
+  const topIssuesExists = existsSync(topIssues);
+
+  if (claudeIssuesExists && !topIssuesExists) {
+    return {
+      status: 'fail',
+      label: 'Issues location',
+      state: 'dotfolder',
+      detail: 'Move .claude/issues/ to issues/',
+    };
+  }
+
+  if (topIssuesExists) {
+    return {
+      status: 'pass',
+      label: 'Issues location',
+      state: 'ok',
+      detail: 'issues/',
+    };
+  }
+
+  // Neither exists -- no issues yet, that is fine
+  return {
+    status: 'pass',
+    label: 'Issues location',
+    state: 'ok',
+    detail: 'no issues directory (ok)',
+  };
+}
+
+function checkDataviewPrefix(config) {
+  const { vaultPath, vaultPrefix } = config;
+  const prefixDir = join(vaultPath, vaultPrefix);
+
+  if (!existsSync(prefixDir)) {
+    return {
+      status: 'warn',
+      label: 'Dataview prefix',
+      state: 'missing',
+      detail: `${prefixDir} does not exist. Run obsidian:sync first.`,
+    };
+  }
+
+  return {
+    status: 'pass',
+    label: 'Dataview prefix',
+    state: 'correct',
+    detail: vaultPrefix,
+  };
+}
+
+function checkSymlink(root) {
+  const claudeIssues = join(root, '.claude', 'issues');
+
+  let stat;
+  try {
+    stat = lstatSync(claudeIssues);
+  } catch {
+    // .claude/issues does not exist -- no symlink to check
+    return {
+      status: 'pass',
+      label: 'Symlink',
+      state: 'ok',
+      detail: 'no symlink (not migrated)',
+    };
+  }
+
+  if (!stat.isSymbolicLink()) {
+    // It is a real directory, not a symlink -- handled by dotfolder check
+    return {
+      status: 'pass',
+      label: 'Symlink',
+      state: 'ok',
+      detail: 'no symlink',
+    };
+  }
+
+  // It is a symlink -- verify target exists
+  try {
+    const target = realpathSync(claudeIssues);
+    if (existsSync(target)) {
+      return {
+        status: 'pass',
+        label: 'Symlink',
+        state: 'ok',
+        detail: `.claude/issues -> ${target}`,
+      };
+    }
+  } catch {
+    // realpathSync fails if target does not exist
+  }
+
+  return {
+    status: 'warn',
+    label: 'Symlink',
+    state: 'broken',
+    detail: '.claude/issues points to non-existent target',
+  };
+}
+
+// --- Main -------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  const opts = parseArgs(args);
+  const root = findProjectRoot(opts.projectRoot);
+
+  // Load config
+  const config = readConfig(root);
+  if (config.error) {
+    console.error(`[error] ${config.error}`);
+    process.exit(1);
+  }
+
+  // Collect results
+  const results = [];
+  let passed = 0;
+  let warnings = 0;
+  let errors = 0;
+
+  // 1. Check rsync
+  results.push(checkRsync());
+
+  // 2. Check watch tools (optional)
+  const watchResults = checkWatchTools();
+  results.push(...watchResults);
+
+  // 3. Check vault path
+  results.push(checkVaultPath(config));
+
+  // 4. Check dotfolder issues
+  results.push(checkDotfolderIssues(root));
+
+  // 5. Check Dataview prefix
+  results.push(checkDataviewPrefix(config));
+
+  // 6. Check symlink
+  results.push(checkSymlink(root));
+
+  // Count
+  for (const r of results) {
+    if (r.status === 'pass') passed++;
+    else if (r.status === 'warn') warnings++;
+    else errors++;
+  }
+
+  // Output
+  console.log('');
+  console.log('Obsidian Doctor');
+  console.log('\u2550'.repeat(60));
+  console.log('');
+
+  for (const r of results) {
+    let icon;
+    if (r.status === 'pass') icon = STATUS_PASS;
+    else if (r.status === 'warn') icon = STATUS_WARN;
+    else icon = STATUS_FAIL;
+
+    console.log(formatRow(icon, r.label, r.state, r.detail));
+  }
+
+  console.log('');
+  console.log('\u2550'.repeat(60));
+
+  const parts = [];
+  parts.push(`${passed} passed`);
+  if (warnings > 0) parts.push(`${warnings} warning${warnings > 1 ? 's' : ''}`);
+  if (errors > 0) parts.push(`${errors} error${errors > 1 ? 's' : ''}`);
+  console.log(`Result: ${parts.join(', ')}`);
+  console.log('');
+
+  process.exit(errors > 0 ? 1 : 0);
+}
+
+main();

--- a/packages/plugin-obsidian/scripts/obsidian/setup.js
+++ b/packages/plugin-obsidian/scripts/obsidian/setup.js
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+/**
+ * setup.js — Obsidian setup wizard backend.
+ *
+ * Non-interactive script that Claude Code executes on behalf of the user.
+ * Configures an Obsidian vault for use with ClaudeAutoPM.
+ *
+ * Usage:
+ *   node setup.js --vault-path /path/to/vault [--prefix my-project] [--watch] [--no-watch]
+ *                  [--project-root /path/to/project]
+ *
+ * Node built-ins only (fs, path, child_process, os, url).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, renameSync,
+         symlinkSync, readdirSync, accessSync, constants, lstatSync } from 'node:fs';
+import { join, basename, dirname, resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ─── Output helpers ─────────────────────────────────────────────────
+
+function log(msg)  { process.stdout.write(`[setup] ${msg}\n`); }
+function err(msg)  { process.stderr.write(`[error] ${msg}\n`); }
+function warn(msg) { process.stderr.write(`[warn]  ${msg}\n`); }
+
+// ─── Environment detection ─────────────────────────────────────────
+
+function detectEnvironment() {
+  if (platform() === 'darwin') {
+    return 'macos';
+  }
+  try {
+    const procVersion = readFileSync('/proc/version', 'utf8');
+    if (/microsoft/i.test(procVersion)) {
+      return 'wsl';
+    }
+  } catch {
+    // /proc/version not available — not Linux or WSL
+  }
+  return 'linux';
+}
+
+// ─── Argument parsing ───────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {
+    vaultPath: null,
+    prefix: null,
+    watch: false,
+    projectRoot: null,
+  };
+
+  let i = 0;
+  while (i < argv.length) {
+    switch (argv[i]) {
+      case '--vault-path':
+        args.vaultPath = argv[++i];
+        break;
+      case '--prefix':
+        args.prefix = argv[++i];
+        break;
+      case '--watch':
+        args.watch = true;
+        break;
+      case '--no-watch':
+        args.watch = false;
+        break;
+      case '--project-root':
+        args.projectRoot = argv[++i];
+        break;
+      default:
+        err(`Unknown option: ${argv[i]}`);
+        printUsage();
+        process.exit(1);
+    }
+    i++;
+  }
+
+  return args;
+}
+
+function printUsage() {
+  process.stderr.write(`Usage: node setup.js --vault-path /path/to/vault [OPTIONS]
+
+Options:
+  --vault-path PATH    Path to Obsidian vault (required)
+  --prefix NAME        Vault subfolder prefix (default: project directory name)
+  --watch              Enable watch mode in config
+  --no-watch           Disable watch mode in config (default)
+  --project-root DIR   Override project root directory
+`);
+}
+
+// ─── Project root detection ─────────────────────────────────────────
+
+function findProjectRoot(startDir) {
+  let dir = startDir || process.cwd();
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, '.claude'))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  // Fallback: use cwd
+  return process.cwd();
+}
+
+// ─── Vault path validation ──────────────────────────────────────────
+
+function validateVaultPath(vaultPath) {
+  if (!existsSync(vaultPath)) {
+    err(`Vault path does not exist: ${vaultPath}`);
+    process.exit(1);
+  }
+  try {
+    accessSync(vaultPath, constants.W_OK);
+  } catch {
+    err(`Vault path is not writable: ${vaultPath}`);
+    process.exit(1);
+  }
+}
+
+// ─── Config merging ─────────────────────────────────────────────────
+
+function mergeConfig(configPath, obsidianSection) {
+  let existing = {};
+  if (existsSync(configPath)) {
+    try {
+      existing = JSON.parse(readFileSync(configPath, 'utf8'));
+    } catch {
+      // If config is malformed, start fresh but warn
+      warn(`Could not parse ${configPath}, creating new config`);
+    }
+  }
+
+  // Deep-merge: only touch the obsidian namespace
+  existing.obsidian = { ...(existing.obsidian || {}), ...obsidianSection };
+
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n');
+  return existing;
+}
+
+// ─── Template substitution ──────────────────────────────────────────
+
+function substituteTemplate(content, vars) {
+  return content
+    .replace(/\{\{PREFIX\}\}/g, vars.prefix)
+    .replace(/\{\{PROJECT_NAME\}\}/g, vars.projectName)
+    .replace(/\{\{CREATED_DATE\}\}/g, vars.createdDate);
+}
+
+// ─── Template generation ────────────────────────────────────────────
+
+function generateTemplates(vaultDest, prefix, projectRoot) {
+  const templatesDir = join(__dirname, '..', '..', 'templates');
+  const createdDate = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const projectName = prefix;
+
+  const vars = { prefix, projectName, createdDate };
+
+  const templateMap = [
+    { src: 'MOC.md.tmpl',                    dest: join(vaultDest, 'MOC.md') },
+    { src: 'DASHBOARD.md.tmpl',              dest: join(vaultDest, 'DASHBOARD.md') },
+    { src: '_templates/issue.md',            dest: join(vaultDest, '_templates', 'issue.md') },
+    { src: '_templates/prd.md',              dest: join(vaultDest, '_templates', 'prd.md') },
+    { src: '_templates/epic.md',             dest: join(vaultDest, '_templates', 'epic.md') },
+    { src: 'diagrams/01-architecture.md',    dest: join(vaultDest, 'diagrams', '01-architecture.md') },
+    { src: 'diagrams/pizarra.excalidraw.md', dest: join(vaultDest, 'diagrams', 'pizarra.excalidraw.md') },
+  ];
+
+  const generated = [];
+
+  for (const { src, dest } of templateMap) {
+    const srcPath = join(templatesDir, src);
+    if (!existsSync(srcPath)) {
+      warn(`Template not found: ${srcPath}`);
+      continue;
+    }
+
+    mkdirSync(dirname(dest), { recursive: true });
+    const content = readFileSync(srcPath, 'utf8');
+    writeFileSync(dest, substituteTemplate(content, vars));
+    generated.push(dest);
+  }
+
+  return generated;
+}
+
+// ─── Canonical frontmatter application ──────────────────────────────
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return null;
+
+  const yamlBlock = match[1];
+  const fields = {};
+  for (const line of yamlBlock.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const val = line.slice(colonIdx + 1).trim();
+    if (key) fields[key] = val;
+  }
+
+  return {
+    raw: match[0],
+    fields,
+    body: content.slice(match[0].length),
+  };
+}
+
+function serializeFrontmatter(fields) {
+  const lines = ['---'];
+  for (const [key, val] of Object.entries(fields)) {
+    lines.push(`${key}: ${val}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function applyCanonicalFrontmatter(filePath, dirType) {
+  const content = readFileSync(filePath, 'utf8');
+  const parsed = parseFrontmatter(content);
+
+  // Skip files without frontmatter
+  if (!parsed) return false;
+
+  const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const defaults = {
+    type: dirType === 'issues' ? 'issue' : dirType === 'prds' ? 'prd' : 'issue',
+    status: 'open',
+    created: now,
+    updated: now,
+    tags: dirType === 'issues' ? '[issue]' : `[${dirType === 'prds' ? 'prd' : 'issue'}]`,
+  };
+
+  let changed = false;
+  const merged = { ...parsed.fields };
+
+  for (const [key, val] of Object.entries(defaults)) {
+    if (!(key in merged)) {
+      merged[key] = val;
+      changed = true;
+    }
+  }
+
+  if (!changed) return false;
+
+  const newContent = serializeFrontmatter(merged) + '\n' + parsed.body;
+  writeFileSync(filePath, newContent);
+  return true;
+}
+
+function applyFrontmatterToDir(dirPath, dirType) {
+  if (!existsSync(dirPath)) return 0;
+
+  let count = 0;
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    if (!entry.endsWith('.md')) continue;
+    const filePath = join(dirPath, entry);
+    try {
+      if (applyCanonicalFrontmatter(filePath, dirType)) {
+        count++;
+      }
+    } catch (e) {
+      warn(`Could not process ${filePath}: ${e.message}`);
+    }
+  }
+  return count;
+}
+
+// ─── Issues migration ───────────────────────────────────────────────
+
+function handleIssuesMigration(projectRoot) {
+  const topLevelIssues = join(projectRoot, 'issues');
+  const claudeIssues = join(projectRoot, '.claude', 'issues');
+
+  if (existsSync(topLevelIssues)) return false;
+  if (!existsSync(claudeIssues)) return false;
+
+  // Check if .claude/issues is already a symlink
+  try {
+    const stat = lstatSync(claudeIssues);
+    if (stat.isSymbolicLink()) return false;
+  } catch {
+    return false;
+  }
+
+  // Move .claude/issues/ to issues/
+  renameSync(claudeIssues, topLevelIssues);
+
+  // Create symlink .claude/issues -> issues/
+  // Use relative path for portability
+  symlinkSync(join('..', 'issues'), claudeIssues);
+
+  log('Migrated .claude/issues/ -> issues/ (symlink created)');
+  return true;
+}
+
+// ─── Sync script copy ───────────────────────────────────────────────
+
+function copySyncScript(projectRoot) {
+  const src = join(__dirname, 'sync-to-obsidian.sh');
+  const destDir = join(projectRoot, '.claude', 'scripts');
+  const dest = join(destDir, 'sync-to-obsidian.sh');
+
+  if (!existsSync(src)) {
+    warn('Sync script not found at ' + src);
+    return false;
+  }
+
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(src, dest);
+
+  try {
+    execSync(`chmod +x "${dest}"`, { stdio: 'ignore' });
+  } catch {
+    // chmod may fail on some systems; not critical
+  }
+
+  return true;
+}
+
+// ─── Run first sync ─────────────────────────────────────────────────
+
+function runFirstSync(projectRoot) {
+  const scripts = [
+    join(projectRoot, '.claude', 'scripts', 'sync-to-obsidian.sh'),
+    join(__dirname, 'sync-to-obsidian.sh'),
+  ];
+
+  for (const script of scripts) {
+    if (existsSync(script)) {
+      try {
+        execSync(`bash "${script}" --project-root "${projectRoot}"`, {
+          stdio: 'pipe',
+          timeout: 30000,
+        });
+        return true;
+      } catch (e) {
+        warn(`First sync failed: ${e.message}`);
+        return false;
+      }
+    }
+  }
+
+  warn('Sync script not found, skipping first sync');
+  return false;
+}
+
+// ─── Main ───────────────────────────────────────────────────────────
+
+function main() {
+  const userArgs = process.argv.slice(2);
+  const args = parseArgs(userArgs);
+
+  // Require --vault-path
+  if (!args.vaultPath) {
+    err('--vault-path is required');
+    printUsage();
+    process.exit(1);
+  }
+
+  // Resolve paths
+  const vaultPath = resolve(args.vaultPath);
+  const projectRoot = args.projectRoot ? resolve(args.projectRoot) : findProjectRoot(process.cwd());
+  const prefix = args.prefix || basename(projectRoot);
+  const configPath = join(projectRoot, '.claude', 'config.json');
+  const vaultDest = join(vaultPath, prefix);
+
+  // 1. Detect environment
+  const environment = detectEnvironment();
+  log(`Environment: ${environment}`);
+
+  // 2. Validate vault path
+  validateVaultPath(vaultPath);
+  log(`Vault path: ${vaultPath}`);
+
+  // 3. Merge config
+  const obsidianConfig = {
+    vault_path: vaultPath,
+    vault_prefix: prefix,
+    watch: args.watch,
+    environment,
+  };
+
+  mergeConfig(configPath, obsidianConfig);
+  log('Config updated: .claude/config.json');
+
+  // 4. Generate templates
+  const generated = generateTemplates(vaultDest, prefix, projectRoot);
+  log(`Generated ${generated.length} template files`);
+
+  // 5. Apply canonical frontmatter
+  const issuesDir = join(projectRoot, 'issues');
+  const prdsDir = join(projectRoot, 'prds');
+
+  // Handle migration first (before frontmatter application)
+  handleIssuesMigration(projectRoot);
+
+  const issuesUpdated = applyFrontmatterToDir(issuesDir, 'issues');
+  const prdsUpdated = applyFrontmatterToDir(prdsDir, 'prds');
+  if (issuesUpdated > 0 || prdsUpdated > 0) {
+    log(`Applied canonical frontmatter: ${issuesUpdated} issues, ${prdsUpdated} PRDs`);
+  }
+
+  // 6. Copy sync script
+  copySyncScript(projectRoot);
+
+  // 7. Run first sync
+  const syncOk = runFirstSync(projectRoot);
+
+  // 8. Print summary
+  const envLabel = environment === 'wsl' ? 'WSL2' : environment === 'macos' ? 'macOS' : 'Linux';
+
+  process.stdout.write(`
+\u2705 Obsidian setup complete!
+
+Vault: ${vaultPath}
+Prefix: ${prefix}
+Environment: ${envLabel}
+
+Generated files:
+  ${vaultDest}/MOC.md
+  ${vaultDest}/DASHBOARD.md
+  ${vaultDest}/_templates/ (3 templates)
+  ${vaultDest}/diagrams/ (2 diagrams)
+
+${syncOk ? 'First sync completed.' : 'First sync skipped (sync script not available).'}
+
+Next steps:
+  1. Open the vault folder in Obsidian
+  2. Install recommended plugins:
+     - Dataview: https://obsidian.md/plugins?id=dataview
+     - Templater: https://obsidian.md/plugins?id=templater-obsidian
+     - Excalidraw: https://obsidian.md/plugins?id=obsidian-excalidraw-plugin
+     - Mermaid Tools: https://obsidian.md/plugins?id=mermaid-tools
+  3. Run /obsidian:sync --watch for continuous sync
+`);
+}
+
+main();

--- a/packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.js
+++ b/packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.js
@@ -1,0 +1,584 @@
+#!/usr/bin/env node
+/**
+ * sync-to-obsidian.js — Unidirectional sync: project -> Obsidian vault
+ *
+ * Node.js fallback that mirrors sync-to-obsidian.sh for environments
+ * without bash.
+ *
+ * Usage:
+ *   node sync-to-obsidian.js [OPTIONS]
+ *
+ * Options:
+ *   --check          Dry-run mode (show what would be synced)
+ *   --watch          Continuous sync on file changes
+ *   --safe-mode      Omit --delete from rsync (never remove vault files)
+ *   --project-root DIR   Override project root (default: auto-detect)
+ *   -h, --help       Show this help message
+ *   -v, --version    Show version
+ */
+
+import {
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  accessSync,
+  constants as fsConstants,
+  watch as fsWatch,
+} from 'node:fs';
+import { join, resolve, dirname, basename } from 'node:path';
+import { spawnSync, execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { platform } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+const SCRIPT_NAME = 'sync-to-obsidian.js';
+const SCRIPT_VERSION = '1.0.0';
+
+const RSYNC_EXCLUDES = [
+  '.git/',
+  'node_modules/',
+  '*.png',
+  '*.jpg',
+  '*.gif',
+  '*.mp4',
+  '__pycache__/',
+  '.env',
+];
+
+const CLAUDE_SYNC_DIRS = ['agents', 'commands', 'rules', 'epics', 'prds'];
+
+// ─── Output helpers ─────────────────────────────────────────────────
+
+function syncLog(...args) {
+  console.log(`[sync]  ${args.join(' ')}`);
+}
+
+function watchLog(...args) {
+  console.log(`[watch] ${args.join(' ')}`);
+}
+
+function err(...args) {
+  console.error(`[error] ${args.join(' ')}`);
+}
+
+// ─── Usage / help ───────────────────────────────────────────────────
+
+function usage() {
+  const text = `Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Sync project markdown to an Obsidian vault (unidirectional: project -> vault).
+
+Options:
+  --check          Dry-run: show what would be synced (rsync --dry-run)
+  --watch          Continuous sync on file changes
+  --safe-mode      Omit --delete from rsync (never remove vault files)
+  --project-root DIR  Override project root directory
+  -h, --help       Show this help message
+  -v, --version    Show version
+
+Modes can be combined: --watch --safe-mode
+
+Configuration (.claude/config.json):
+  {
+    "obsidian": {
+      "vault_path": "/path/to/vault",
+      "vault_prefix": "my-project",
+      "watch": false
+    }
+  }`;
+  console.log(text);
+}
+
+// ─── Argument parsing ───────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const opts = {
+    check: false,
+    watch: false,
+    safe: false,
+    projectRoot: '',
+  };
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--check':
+        opts.check = true;
+        i++;
+        break;
+      case '--watch':
+        opts.watch = true;
+        i++;
+        break;
+      case '--safe-mode':
+        opts.safe = true;
+        i++;
+        break;
+      case '--project-root':
+        if (i + 1 >= argv.length || argv[i + 1].startsWith('--')) {
+          err('--project-root requires a directory argument');
+          process.exit(1);
+        }
+        opts.projectRoot = argv[i + 1];
+        i += 2;
+        break;
+      case '-h':
+      case '--help':
+        usage();
+        process.exit(0);
+        break; // unreachable but conventional
+      case '-v':
+      case '--version':
+        console.log(`${SCRIPT_NAME} ${SCRIPT_VERSION}`);
+        process.exit(0);
+        break;
+      default:
+        err(`Unknown option: ${arg}`);
+        console.log('');
+        usage();
+        process.exit(1);
+    }
+  }
+
+  return opts;
+}
+
+// ─── Project root detection ─────────────────────────────────────────
+
+function findProjectRoot(overridePath) {
+  if (overridePath) {
+    return resolve(overridePath);
+  }
+
+  // Walk up from script location looking for .claude/config.json
+  let dir = __dirname;
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, '.claude', 'config.json'))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+
+  err('Could not find project root (no .claude/config.json found)');
+  process.exit(1);
+}
+
+// ─── Config loading ─────────────────────────────────────────────────
+
+function readConfig(root, opts) {
+  const configFile = join(root, '.claude', 'config.json');
+
+  if (!existsSync(configFile)) {
+    err(`Config not found: ${configFile}`);
+    err('Run the Obsidian setup wizard or add obsidian settings to .claude/config.json');
+    process.exit(1);
+  }
+
+  let cfg;
+  try {
+    cfg = JSON.parse(readFileSync(configFile, 'utf8'));
+  } catch (e) {
+    err(`Failed to parse ${configFile}: ${e.message}`);
+    process.exit(1);
+  }
+
+  const vaultPath = cfg?.obsidian?.vault_path;
+  if (!vaultPath) {
+    err(`obsidian.vault_path not set in ${configFile}`);
+    err('Add: { "obsidian": { "vault_path": "/path/to/vault" } }');
+    process.exit(1);
+  }
+
+  const vaultPrefix = cfg?.obsidian?.vault_prefix || basename(root);
+
+  // Check watch config (can be overridden by --watch flag)
+  if (!opts.watch && cfg?.obsidian?.watch === true) {
+    opts.watch = true;
+  }
+
+  // Validate vault path exists
+  if (!existsSync(vaultPath)) {
+    err(`Vault path does not exist: ${vaultPath}`);
+    err('Create it or update obsidian.vault_path in .claude/config.json');
+    process.exit(1);
+  }
+
+  // Validate vault path is writable
+  try {
+    accessSync(vaultPath, fsConstants.W_OK);
+  } catch {
+    err(`Vault path is not writable: ${vaultPath}`);
+    process.exit(1);
+  }
+
+  return { vaultPath, vaultPrefix };
+}
+
+// ─── OS detection ───────────────────────────────────────────────────
+
+function detectOS() {
+  const p = platform();
+  if (p === 'darwin') {
+    return 'darwin';
+  }
+  if (p === 'linux') {
+    try {
+      const procVersion = readFileSync('/proc/version', 'utf8');
+      if (/microsoft/i.test(procVersion)) {
+        return 'wsl';
+      }
+    } catch {
+      // /proc/version not available, assume linux
+    }
+    return 'linux';
+  }
+  return 'linux'; // best-effort fallback
+}
+
+// ─── Dependency checks ─────────────────────────────────────────────
+
+function checkRsync() {
+  try {
+    execSync('command -v rsync', { stdio: 'ignore' });
+  } catch {
+    err('rsync is required but not found');
+    err('Install: sudo apt install rsync  (Linux)  /  brew install rsync  (macOS)');
+    process.exit(1);
+  }
+}
+
+function checkWatchTool(os) {
+  if (os === 'linux' || os === 'wsl') {
+    try {
+      execSync('command -v inotifywait', { stdio: 'ignore' });
+    } catch {
+      // Fall back to Node fs.watch — no external tool required for Node fallback
+      return 'node';
+    }
+    return 'inotifywait';
+  }
+  if (os === 'darwin') {
+    try {
+      execSync('command -v fswatch', { stdio: 'ignore' });
+    } catch {
+      return 'node';
+    }
+    return 'fswatch';
+  }
+  return 'node';
+}
+
+// ─── Rsync output filtering ────────────────────────────────────────
+
+function printRsyncOutput(stdout) {
+  if (!stdout) return;
+  const lines = stdout
+    .split('\n')
+    .filter(
+      (line) =>
+        line.trim() !== '' &&
+        !line.startsWith('sending') &&
+        !line.startsWith('sent ') &&
+        !line.startsWith('total ')
+    );
+  if (lines.length > 0) {
+    console.log(lines.join('\n'));
+  }
+}
+
+// ─── Build rsync arguments ─────────────────────────────────────────
+
+function buildRsyncArgs(opts) {
+  const args = ['-av'];
+
+  for (const excl of RSYNC_EXCLUDES) {
+    args.push(`--exclude=${excl}`);
+  }
+
+  // Include only markdown files (and directories for traversal)
+  args.push('--include=*/', '--include=*.md', '--exclude=*');
+
+  if (opts.check) {
+    args.push('--dry-run');
+  }
+
+  if (!opts.safe) {
+    args.push('--delete');
+  }
+
+  return args;
+}
+
+// ─── Sync a single source dir to vault ──────────────────────────────
+
+function syncDir(src, dest, label, opts) {
+  if (!existsSync(src)) {
+    return; // Skip non-existent optional dirs silently
+  }
+
+  syncLog(`Syncing ${label} -> ${dest}`);
+
+  // Ensure trailing slashes for rsync
+  const srcSlash = src.endsWith('/') ? src : `${src}/`;
+  const destSlash = dest.endsWith('/') ? dest : `${dest}/`;
+
+  // Only create destination in non-dry-run mode
+  if (!opts.check) {
+    mkdirSync(destSlash, { recursive: true });
+  }
+
+  const rsyncArgs = buildRsyncArgs(opts);
+  rsyncArgs.push(srcSlash, destSlash);
+
+  const result = spawnSync('rsync', rsyncArgs, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  printRsyncOutput(result.stdout);
+
+  if (result.status !== 0 && result.stderr) {
+    err(result.stderr.trim());
+  }
+}
+
+// ─── Sync root-level markdown files ────────────────────────────────
+
+function syncRootMarkdown(root, dest, opts) {
+  let mdFiles;
+  try {
+    mdFiles = readdirSync(root)
+      .filter((f) => f.endsWith('.md'))
+      .filter((f) => {
+        try {
+          return statSync(join(root, f)).isFile();
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return;
+  }
+
+  if (mdFiles.length === 0) {
+    return;
+  }
+
+  syncLog(`Syncing root *.md -> ${dest}`);
+
+  if (opts.check) {
+    for (const f of mdFiles) {
+      console.log(`  ${f} (dry-run)`);
+    }
+    return;
+  }
+
+  mkdirSync(dest, { recursive: true });
+
+  // Use rsync for root markdown files to maintain consistency
+  const rsyncArgs = ['-av'];
+  for (const excl of RSYNC_EXCLUDES) {
+    rsyncArgs.push(`--exclude=${excl}`);
+  }
+  rsyncArgs.push('--include=*.md', '--exclude=*');
+  // No --delete for root files (matches shell script cp behaviour)
+
+  const srcSlash = root.endsWith('/') ? root : `${root}/`;
+  const destSlash = dest.endsWith('/') ? dest : `${dest}/`;
+  rsyncArgs.push(srcSlash, destSlash);
+
+  const result = spawnSync('rsync', rsyncArgs, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  printRsyncOutput(result.stdout);
+}
+
+// ─── Count synced files ─────────────────────────────────────────────
+
+function countVaultFiles(dest) {
+  if (!existsSync(dest)) {
+    return 0;
+  }
+
+  let count = 0;
+  function walk(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      try {
+        const st = statSync(full);
+        if (st.isDirectory()) {
+          walk(full);
+        } else if (st.isFile() && entry.endsWith('.md')) {
+          count++;
+        }
+      } catch {
+        // skip inaccessible entries
+      }
+    }
+  }
+  walk(dest);
+  return count;
+}
+
+// ─── Main sync operation ───────────────────────────────────────────
+
+function runSync(root, vaultPath, vaultPrefix, opts) {
+  const vaultDest = join(vaultPath, vaultPrefix);
+
+  if (opts.check) {
+    syncLog('Dry-run mode: showing what would be synced');
+  }
+  if (opts.safe) {
+    syncLog('Safe mode: will not delete files in vault');
+  }
+
+  syncLog(`Starting sync: ${root} -> ${vaultDest}`);
+
+  // Sync .claude/* subdirectories to visible vault paths
+  for (const dirName of CLAUDE_SYNC_DIRS) {
+    const src = join(root, '.claude', dirName);
+    const dest = join(vaultDest, dirName);
+    syncDir(src, dest, `.claude/${dirName}/`, opts);
+  }
+
+  // Sync issues/ if it exists
+  syncDir(join(root, 'issues'), join(vaultDest, 'issues'), 'issues/', opts);
+
+  // Sync root markdown files
+  syncRootMarkdown(root, vaultDest, opts);
+
+  if (!opts.check) {
+    const fileCount = countVaultFiles(vaultDest);
+    syncLog(`Done: ${fileCount} files synced`);
+  } else {
+    syncLog('Done: dry-run complete (no files changed)');
+  }
+}
+
+// ─── Watch mode ────────────────────────────────────────────────────
+
+function startWatch(root, vaultPath, vaultPrefix, opts) {
+  const os = detectOS();
+  const watchTool = checkWatchTool(os);
+
+  watchLog('Watching for changes... (Ctrl+C to stop)');
+
+  if (watchTool === 'node') {
+    watchWithNode(root, vaultPath, vaultPrefix, opts);
+  } else if (watchTool === 'inotifywait') {
+    watchWithInotify(root, vaultPath, vaultPrefix, opts);
+  } else if (watchTool === 'fswatch') {
+    watchWithFswatch(root, vaultPath, vaultPrefix, opts);
+  }
+}
+
+function watchWithNode(root, vaultPath, vaultPrefix, opts) {
+  // Build list of directories to watch
+  const watchPaths = [];
+  for (const dirName of CLAUDE_SYNC_DIRS) {
+    const d = join(root, '.claude', dirName);
+    if (existsSync(d)) {
+      watchPaths.push(d);
+    }
+  }
+  const issuesDir = join(root, 'issues');
+  if (existsSync(issuesDir)) {
+    watchPaths.push(issuesDir);
+  }
+  watchPaths.push(root);
+
+  let debounceTimer = null;
+
+  const triggerSync = () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      watchLog('Change detected, syncing...');
+      try {
+        runSync(root, vaultPath, vaultPrefix, opts);
+      } catch (e) {
+        err(e.message);
+      }
+    }, 300);
+  };
+
+  for (const watchPath of watchPaths) {
+    try {
+      fsWatch(watchPath, { recursive: true }, (eventType, filename) => {
+        if (filename && filename.endsWith('.md')) {
+          triggerSync();
+        }
+      });
+    } catch {
+      // Recursive watch may not be supported on all platforms; try non-recursive
+      try {
+        fsWatch(watchPath, (eventType, filename) => {
+          if (filename && filename.endsWith('.md')) {
+            triggerSync();
+          }
+        });
+      } catch (e) {
+        err(`Cannot watch ${watchPath}: ${e.message}`);
+      }
+    }
+  }
+
+  // Keep process alive
+  setInterval(() => {}, 1_000_000);
+}
+
+function watchWithInotify(root, vaultPath, vaultPrefix, opts) {
+  // For the Node.js fallback, we use Node's fs.watch instead of inotifywait
+  watchWithNode(root, vaultPath, vaultPrefix, opts);
+}
+
+function watchWithFswatch(root, vaultPath, vaultPrefix, opts) {
+  // For the Node.js fallback, we use Node's fs.watch instead of fswatch
+  watchWithNode(root, vaultPath, vaultPrefix, opts);
+}
+
+process.on('SIGINT', () => {
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  process.exit(0);
+});
+
+// ─── Entry point ───────────────────────────────────────────────────
+
+function main() {
+  const args = process.argv.slice(2);
+  const opts = parseArgs(args);
+
+  checkRsync();
+
+  const root = findProjectRoot(opts.projectRoot);
+  const { vaultPath, vaultPrefix } = readConfig(root, opts);
+
+  // Initial sync
+  runSync(root, vaultPath, vaultPrefix, opts);
+
+  // Enter watch mode if requested
+  if (opts.watch) {
+    startWatch(root, vaultPath, vaultPrefix, opts);
+  }
+}
+
+main();

--- a/packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.sh
+++ b/packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.sh
@@ -1,0 +1,533 @@
+#!/usr/bin/env bash
+#
+# sync-to-obsidian.sh — Unidirectional sync: project -> Obsidian vault
+#
+# Usage:
+#   sync-to-obsidian.sh [OPTIONS]
+#
+# Options:
+#   --check        Dry-run mode (show what would be synced)
+#   --watch        Continuous sync on file changes
+#   --safe-mode    Omit --delete from rsync (never remove vault files)
+#   --project-root DIR   Override project root (default: auto-detect)
+#   -h, --help     Show this help message
+#
+# Configuration:
+#   Reads vault settings from .claude/config.json:
+#     { "obsidian": { "vault_path": "/path", "vault_prefix": "name" } }
+
+set -euo pipefail
+
+# ─── Constants ───────────────────────────────────────────────────────
+
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly SCRIPT_VERSION="1.0.0"
+
+readonly RSYNC_EXCLUDES=(
+    ".git/"
+    "node_modules/"
+    "*.png"
+    "*.jpg"
+    "*.gif"
+    "*.mp4"
+    "__pycache__/"
+    ".env"
+)
+
+# Directories under .claude/ that get synced (mapped to visible vault paths)
+readonly CLAUDE_SYNC_DIRS=(
+    "agents"
+    "commands"
+    "rules"
+    "epics"
+    "prds"
+)
+
+# ─── Globals (set by parse_args / parse_config) ─────────────────────
+
+MODE_CHECK=false
+MODE_WATCH=false
+MODE_SAFE=false
+PROJECT_ROOT=""
+VAULT_PATH=""
+VAULT_PREFIX=""
+WATCHER_PID=""
+
+# ─── Output helpers ──────────────────────────────────────────────────
+
+sync_log()  { echo "[sync]  $*"; }
+watch_log() { echo "[watch] $*"; }
+err()       { echo "[error] $*" >&2; }
+
+# ─── Usage / help ────────────────────────────────────────────────────
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Sync project markdown to an Obsidian vault (unidirectional: project -> vault).
+
+Options:
+  --check          Dry-run: show what would be synced (rsync --dry-run)
+  --watch          Continuous sync on file changes
+  --safe-mode      Omit --delete from rsync (never remove vault files)
+  --project-root DIR  Override project root directory
+  -h, --help       Show this help message
+  -v, --version    Show version
+
+Modes can be combined: --watch --safe-mode
+
+Configuration (.claude/config.json):
+  {
+    "obsidian": {
+      "vault_path": "/path/to/vault",
+      "vault_prefix": "my-project",
+      "watch": false
+    }
+  }
+EOF
+}
+
+# ─── Argument parsing ────────────────────────────────────────────────
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --check)
+                MODE_CHECK=true
+                shift
+                ;;
+            --watch)
+                MODE_WATCH=true
+                shift
+                ;;
+            --safe-mode)
+                MODE_SAFE=true
+                shift
+                ;;
+            --project-root)
+                if [[ -z "${2:-}" ]]; then
+                    err "--project-root requires a directory argument"
+                    exit 1
+                fi
+                PROJECT_ROOT="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -v|--version)
+                echo "${SCRIPT_NAME} ${SCRIPT_VERSION}"
+                exit 0
+                ;;
+            --source-only)
+                # Used by test harness to source functions without running
+                return 1
+                ;;
+            *)
+                err "Unknown option: $1"
+                echo ""
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# ─── Project root detection ─────────────────────────────────────────
+
+find_project_root() {
+    if [[ -n "${PROJECT_ROOT}" ]]; then
+        echo "${PROJECT_ROOT}"
+        return 0
+    fi
+
+    # Walk up from script location looking for .claude/config.json
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "${dir}" != "/" ]]; do
+        if [[ -f "${dir}/.claude/config.json" ]]; then
+            echo "${dir}"
+            return 0
+        fi
+        dir="$(dirname "${dir}")"
+    done
+
+    err "Could not find project root (no .claude/config.json found)"
+    exit 1
+}
+
+# ─── JSON parsing (node or python3, no jq dependency) ────────────────
+
+json_extract() {
+    local file="$1"
+    local key_path="$2"  # e.g. "obsidian.vault_path"
+
+    # Try node first, then python3
+    if command -v node &>/dev/null; then
+        node -e "
+            const fs = require('fs');
+            try {
+                const cfg = JSON.parse(fs.readFileSync('${file}', 'utf8'));
+                const keys = '${key_path}'.split('.');
+                let val = cfg;
+                for (const k of keys) { val = val && val[k]; }
+                if (val !== undefined && val !== null) process.stdout.write(String(val));
+                else process.exit(1);
+            } catch(e) { process.exit(1); }
+        " 2>/dev/null
+    elif command -v python3 &>/dev/null; then
+        python3 -c "
+import json, sys
+try:
+    cfg = json.load(open('${file}'))
+    keys = '${key_path}'.split('.')
+    val = cfg
+    for k in keys:
+        val = val[k]
+    if val is not None:
+        sys.stdout.write(str(val))
+    else:
+        sys.exit(1)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null
+    else
+        err "Neither node nor python3 found. One is required to parse config."
+        exit 1
+    fi
+}
+
+# ─── Config loading ─────────────────────────────────────────────────
+
+parse_config() {
+    local root="$1"
+    local config_file="${root}/.claude/config.json"
+
+    if [[ ! -f "${config_file}" ]]; then
+        err "Config not found: ${config_file}"
+        err "Run the Obsidian setup wizard or add obsidian settings to .claude/config.json"
+        exit 1
+    fi
+
+    VAULT_PATH="$(json_extract "${config_file}" "obsidian.vault_path" || true)"
+    if [[ -z "${VAULT_PATH}" ]]; then
+        err "obsidian.vault_path not set in ${config_file}"
+        err "Add: { \"obsidian\": { \"vault_path\": \"/path/to/vault\" } }"
+        exit 1
+    fi
+
+    VAULT_PREFIX="$(json_extract "${config_file}" "obsidian.vault_prefix" || true)"
+    if [[ -z "${VAULT_PREFIX}" ]]; then
+        # Default to directory name
+        VAULT_PREFIX="$(basename "${root}")"
+    fi
+
+    # Check watch config (can be overridden by --watch flag)
+    if [[ "${MODE_WATCH}" == "false" ]]; then
+        local cfg_watch
+        cfg_watch="$(json_extract "${config_file}" "obsidian.watch" || echo "false")"
+        if [[ "${cfg_watch}" == "true" ]]; then
+            MODE_WATCH=true
+        fi
+    fi
+
+    # Validate vault path exists
+    if [[ ! -d "${VAULT_PATH}" ]]; then
+        err "Vault path does not exist: ${VAULT_PATH}"
+        err "Create it or update obsidian.vault_path in .claude/config.json"
+        exit 1
+    fi
+
+    # Validate vault path is writable
+    if [[ ! -w "${VAULT_PATH}" ]]; then
+        err "Vault path is not writable: ${VAULT_PATH}"
+        exit 1
+    fi
+}
+
+# ─── OS detection ────────────────────────────────────────────────────
+
+detect_os() {
+    local uname_out
+    uname_out="$(uname -s)"
+    case "${uname_out}" in
+        Linux)
+            if [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>/dev/null; then
+                echo "wsl"
+            else
+                echo "linux"
+            fi
+            ;;
+        Darwin)
+            echo "darwin"
+            ;;
+        *)
+            echo "linux"  # best-effort fallback
+            ;;
+    esac
+}
+
+# ─── Dependency checks ──────────────────────────────────────────────
+
+check_rsync() {
+    if ! command -v rsync &>/dev/null; then
+        err "rsync is required but not found"
+        err "Install: sudo apt install rsync  (Linux)  /  brew install rsync  (macOS)"
+        exit 1
+    fi
+}
+
+check_watch_tool() {
+    local os="$1"
+    case "${os}" in
+        linux|wsl)
+            if ! command -v inotifywait &>/dev/null; then
+                err "inotifywait is required for --watch mode on Linux/WSL"
+                err "Install: sudo apt install inotify-tools"
+                exit 1
+            fi
+            ;;
+        darwin)
+            if ! command -v fswatch &>/dev/null; then
+                err "fswatch is required for --watch mode on macOS"
+                err "Install: brew install fswatch"
+                exit 1
+            fi
+            ;;
+    esac
+}
+
+# ─── Build rsync arguments ──────────────────────────────────────────
+
+build_rsync_args() {
+    local -a args=( -av )
+
+    # Excludes must come before the include/exclude filter chain
+    for excl in "${RSYNC_EXCLUDES[@]}"; do
+        args+=( --exclude="${excl}" )
+    done
+
+    # Include only markdown files (and directories for traversal)
+    args+=( --include="*/" --include="*.md" --exclude="*" )
+
+    if [[ "${MODE_CHECK}" == "true" ]]; then
+        args+=( --dry-run )
+    fi
+
+    if [[ "${MODE_SAFE}" == "false" ]]; then
+        args+=( --delete )
+    fi
+
+    echo "${args[@]}"
+}
+
+# ─── Sync a single source dir to vault ───────────────────────────────
+
+sync_dir() {
+    local src="$1"
+    local dest="$2"
+    local label="$3"
+
+    if [[ ! -d "${src}" ]]; then
+        return 0  # Skip non-existent optional dirs silently
+    fi
+
+    sync_log "Syncing ${label} -> ${dest}"
+
+    # Ensure trailing slashes for rsync
+    local src_slash="${src%/}/"
+    local dest_slash="${dest%/}/"
+
+    # Only create destination in non-dry-run mode
+    if [[ "${MODE_CHECK}" == "false" ]]; then
+        mkdir -p "${dest_slash}" 2>/dev/null || true
+    fi
+
+    local -a rsync_args
+    read -ra rsync_args <<< "$(build_rsync_args)"
+
+    rsync "${rsync_args[@]}" "${src_slash}" "${dest_slash}" 2>&1 | \
+        grep -v "^$" | grep -v "^sending" | grep -v "^sent " | \
+        grep -v "^total " | grep -v "^$" || true
+}
+
+# ─── Sync root-level markdown files ─────────────────────────────────
+
+sync_root_markdown() {
+    local root="$1"
+    local dest="$2"
+
+    # Collect root .md files
+    local -a md_files=()
+    while IFS= read -r -d '' f; do
+        md_files+=("$f")
+    done < <(find "${root}" -maxdepth 1 -name "*.md" -type f -print0 2>/dev/null)
+
+    if [[ ${#md_files[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    sync_log "Syncing root *.md -> ${dest}"
+
+    if [[ "${MODE_CHECK}" == "true" ]]; then
+        for f in "${md_files[@]}"; do
+            echo "  $(basename "$f") (dry-run)"
+        done
+        return 0
+    fi
+
+    mkdir -p "${dest}" 2>/dev/null || true
+    for f in "${md_files[@]}"; do
+        cp -u "$f" "${dest}/" 2>/dev/null || cp "$f" "${dest}/"
+    done
+}
+
+# ─── Count synced files ─────────────────────────────────────────────
+
+count_vault_files() {
+    local dest="$1"
+    if [[ -d "${dest}" ]]; then
+        find "${dest}" -type f -name "*.md" 2>/dev/null | wc -l | tr -d ' '
+    else
+        echo "0"
+    fi
+}
+
+# ─── Main sync operation ────────────────────────────────────────────
+
+run_sync() {
+    local root="$1"
+    local vault_dest="${VAULT_PATH}/${VAULT_PREFIX}"
+
+    if [[ "${MODE_CHECK}" == "true" ]]; then
+        sync_log "Dry-run mode: showing what would be synced"
+    fi
+    if [[ "${MODE_SAFE}" == "true" ]]; then
+        sync_log "Safe mode: will not delete files in vault"
+    fi
+
+    sync_log "Starting sync: ${root} -> ${vault_dest}"
+
+    # Sync .claude/* subdirectories to visible vault paths
+    for dir_name in "${CLAUDE_SYNC_DIRS[@]}"; do
+        local src="${root}/.claude/${dir_name}"
+        local dest="${vault_dest}/${dir_name}"
+        sync_dir "${src}" "${dest}" ".claude/${dir_name}/"
+    done
+
+    # Sync issues/ if it exists
+    sync_dir "${root}/issues" "${vault_dest}/issues" "issues/"
+
+    # Sync root markdown files
+    sync_root_markdown "${root}" "${vault_dest}"
+
+    local file_count
+    if [[ "${MODE_CHECK}" == "false" ]]; then
+        file_count="$(count_vault_files "${vault_dest}")"
+        sync_log "Done: ${file_count} files synced"
+    else
+        sync_log "Done: dry-run complete (no files changed)"
+    fi
+}
+
+# ─── Watch mode ──────────────────────────────────────────────────────
+
+start_watch() {
+    local root="$1"
+    local os
+    os="$(detect_os)"
+
+    check_watch_tool "${os}"
+
+    watch_log "Watching for changes... (Ctrl+C to stop)"
+
+    case "${os}" in
+        linux|wsl)
+            watch_inotify "${root}"
+            ;;
+        darwin)
+            watch_fswatch "${root}"
+            ;;
+    esac
+}
+
+watch_inotify() {
+    local root="$1"
+    local -a watch_paths=()
+
+    # Build list of directories to watch
+    for dir_name in "${CLAUDE_SYNC_DIRS[@]}"; do
+        local d="${root}/.claude/${dir_name}"
+        [[ -d "${d}" ]] && watch_paths+=("${d}")
+    done
+    [[ -d "${root}/issues" ]] && watch_paths+=("${root}/issues")
+    watch_paths+=("${root}")  # root .md files
+
+    while true; do
+        inotifywait -r -e modify,create,delete,move \
+            --include '\.md$' \
+            "${watch_paths[@]}" 2>/dev/null || true
+
+        watch_log "Change detected, syncing..."
+        run_sync "${root}" || true
+    done
+}
+
+watch_fswatch() {
+    local root="$1"
+    local -a watch_paths=()
+
+    for dir_name in "${CLAUDE_SYNC_DIRS[@]}"; do
+        local d="${root}/.claude/${dir_name}"
+        [[ -d "${d}" ]] && watch_paths+=("${d}")
+    done
+    [[ -d "${root}/issues" ]] && watch_paths+=("${root}/issues")
+    watch_paths+=("${root}")
+
+    fswatch --include='\.md$' --exclude='.*' -r "${watch_paths[@]}" | \
+    while read -r _event; do
+        watch_log "Change detected, syncing..."
+        run_sync "${root}" || true
+    done
+}
+
+# ─── Signal handling / cleanup ───────────────────────────────────────
+
+cleanup() {
+    if [[ -n "${WATCHER_PID}" ]] && kill -0 "${WATCHER_PID}" 2>/dev/null; then
+        kill "${WATCHER_PID}" 2>/dev/null || true
+        wait "${WATCHER_PID}" 2>/dev/null || true
+    fi
+    # Clean up any temp files
+    rm -f /tmp/sync-to-obsidian-*.tmp 2>/dev/null || true
+}
+
+trap cleanup EXIT INT TERM
+
+# ─── Entry point ─────────────────────────────────────────────────────
+
+main() {
+    parse_args "$@" || return 0  # --source-only returns 1
+
+    check_rsync
+
+    local root
+    root="$(find_project_root)"
+
+    parse_config "${root}"
+
+    # Initial sync
+    run_sync "${root}"
+
+    # Enter watch mode if requested
+    if [[ "${MODE_WATCH}" == "true" ]]; then
+        start_watch "${root}"
+    fi
+}
+
+# Run main only when executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/packages/plugin-obsidian/templates/DASHBOARD.md.tmpl
+++ b/packages/plugin-obsidian/templates/DASHBOARD.md.tmpl
@@ -1,0 +1,63 @@
+---
+type: dashboard
+title: "{{PROJECT_NAME}} Dashboard"
+created: "{{CREATED_DATE}}"
+updated: "{{CREATED_DATE}}"
+tags: [dashboard, overview]
+---
+
+# {{PROJECT_NAME}} Dashboard
+
+## Status Overview
+
+### Open Issues
+```dataview
+LIST
+FROM "{{PREFIX}}/issues"
+WHERE status = "open" OR status = "in-progress"
+SORT status ASC
+```
+
+### In Progress
+```dataview
+TABLE status, tags
+FROM "{{PREFIX}}"
+WHERE status = "in-progress"
+SORT file.mtime DESC
+```
+
+### Recently Completed
+```dataview
+TABLE status, updated
+FROM "{{PREFIX}}"
+WHERE status = "closed" OR status = "completed"
+SORT updated DESC
+LIMIT 10
+```
+
+## Task Breakdown
+
+### By Status
+```dataview
+TABLE WITHOUT ID
+  status as "Status",
+  length(rows) as "Count"
+FROM "{{PREFIX}}/issues"
+GROUP BY status
+```
+
+### By Type
+```dataview
+TABLE WITHOUT ID
+  type as "Type",
+  length(rows) as "Count"
+FROM "{{PREFIX}}"
+WHERE type
+GROUP BY type
+```
+
+## Quick Links
+
+- [[{{PREFIX}}/MOC|Map of Content]]
+- [[{{PREFIX}}/agents|Agents]]
+- [[{{PREFIX}}/rules|Rules]]

--- a/packages/plugin-obsidian/templates/FRONTMATTER_SCHEMA.md
+++ b/packages/plugin-obsidian/templates/FRONTMATTER_SCHEMA.md
@@ -1,0 +1,40 @@
+# Canonical Frontmatter Schema
+
+Fields that Dataview and Breadcrumbs use for queries and navigation.
+
+## Required Fields (all types)
+
+| Field     | Type   | Description                    | Example                     |
+|-----------|--------|--------------------------------|-----------------------------|
+| `type`    | string | Document type                  | `issue`, `prd`, `epic`      |
+| `status`  | string | Current status                 | `open`, `in-progress`, `closed` |
+| `created` | string | ISO 8601 creation timestamp    | `2026-01-15T14:30:00Z`     |
+| `updated` | string | ISO 8601 last-modified timestamp | `2026-01-15T14:30:00Z`   |
+| `tags`    | array  | Categorization tags            | `[issue, auth]`             |
+
+## Optional Fields
+
+| Field      | Type   | Description                    | Example                     |
+|------------|--------|--------------------------------|-----------------------------|
+| `title`    | string | Human-readable title           | `Implement JWT auth`        |
+| `parent`   | string | Parent epic/issue reference    | `epic/authentication`       |
+| `assignee` | string | Who is working on this         | `@username`                 |
+| `priority` | string | Priority level                 | `high`, `medium`, `low`     |
+| `progress` | number | Completion percentage (epics)  | `75`                        |
+| `github`   | string | GitHub issue URL               | `https://github.com/.../42` |
+
+## Status Values
+
+- **Issues/Tasks**: `open`, `in-progress`, `closed`
+- **PRDs**: `backlog`, `in-progress`, `complete`
+- **Epics**: `backlog`, `in-progress`, `completed`
+
+## Type Values
+
+`issue`, `task`, `prd`, `epic`, `agent`, `rule`, `command`, `moc`, `dashboard`, `diagram`
+
+## Notes
+
+- Frontmatter is **additive only** — the setup wizard never overwrites existing custom keys
+- All timestamps use ISO 8601 UTC format
+- Tags should be lowercase, hyphenated

--- a/packages/plugin-obsidian/templates/MOC.md.tmpl
+++ b/packages/plugin-obsidian/templates/MOC.md.tmpl
@@ -1,0 +1,61 @@
+---
+type: moc
+title: "{{PROJECT_NAME}} — Map of Content"
+created: "{{CREATED_DATE}}"
+updated: "{{CREATED_DATE}}"
+tags: [moc, navigation]
+---
+
+# {{PROJECT_NAME}} — Map of Content
+
+## Epics
+
+```dataview
+TABLE status, created, updated
+FROM "{{PREFIX}}/epics"
+WHERE type = "epic"
+SORT status ASC, updated DESC
+```
+
+## Issues
+
+```dataview
+TABLE status, type, tags
+FROM "{{PREFIX}}/issues"
+WHERE type = "issue" OR type = "task"
+SORT status ASC, updated DESC
+```
+
+## PRDs
+
+```dataview
+TABLE status, created
+FROM "{{PREFIX}}/prds"
+WHERE type = "prd"
+SORT created DESC
+```
+
+## Agents
+
+```dataview
+LIST
+FROM "{{PREFIX}}/agents"
+SORT file.name ASC
+```
+
+## Rules
+
+```dataview
+LIST
+FROM "{{PREFIX}}/rules"
+SORT file.name ASC
+```
+
+## Recent Changes
+
+```dataview
+TABLE file.mtime as "Modified"
+FROM "{{PREFIX}}"
+SORT file.mtime DESC
+LIMIT 20
+```

--- a/packages/plugin-obsidian/templates/_templates/epic.md
+++ b/packages/plugin-obsidian/templates/_templates/epic.md
@@ -1,0 +1,30 @@
+---
+type: epic
+title: "<% tp.file.title %>"
+status: backlog
+created: "<% tp.date.now('YYYY-MM-DDTHH:mm:ss') %>Z"
+updated: "<% tp.date.now('YYYY-MM-DDTHH:mm:ss') %>Z"
+tags: [epic]
+progress: 0
+---
+
+# <% tp.file.title %>
+
+## Goal
+
+
+
+## Tasks
+
+```dataview
+TASK
+FROM "{{PREFIX}}/epics/<% tp.file.title %>"
+```
+
+## Status
+
+- **Progress**: 0%
+- **Started**: <% tp.date.now('YYYY-MM-DD') %>
+
+## Notes
+

--- a/packages/plugin-obsidian/templates/_templates/issue.md
+++ b/packages/plugin-obsidian/templates/_templates/issue.md
@@ -1,0 +1,28 @@
+---
+type: issue
+title: "<% tp.file.title %>"
+status: open
+created: "<% tp.date.now('YYYY-MM-DDTHH:mm:ss') %>Z"
+updated: "<% tp.date.now('YYYY-MM-DDTHH:mm:ss') %>Z"
+tags: [issue]
+parent: ""
+assignee: ""
+priority: ""
+---
+
+# <% tp.file.title %>
+
+## Description
+
+
+
+## Acceptance Criteria
+
+- [ ] 
+
+## Technical Details
+
+
+
+## Notes
+

--- a/packages/plugin-obsidian/templates/_templates/prd.md
+++ b/packages/plugin-obsidian/templates/_templates/prd.md
@@ -1,0 +1,29 @@
+---
+type: prd
+title: "<% tp.file.title %>"
+status: backlog
+created: "<% tp.date.now('YYYY-MM-DDTHH:mm:ss') %>Z"
+updated: "<% tp.date.now('YYYY-MM-DDTHH:mm:ss') %>Z"
+tags: [prd]
+---
+
+# <% tp.file.title %>
+
+## Problem Statement
+
+
+
+## Proposed Solution
+
+
+
+## Acceptance Criteria
+
+- [ ] 
+
+## Technical Approach
+
+
+
+## Out of Scope
+

--- a/packages/plugin-obsidian/templates/diagrams/01-architecture.md
+++ b/packages/plugin-obsidian/templates/diagrams/01-architecture.md
@@ -1,0 +1,38 @@
+---
+type: diagram
+title: Architecture Overview
+tags: [diagram, mermaid, architecture]
+---
+
+# Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "ClaudeAutoPM"
+        CLI[CLI / Install]
+        Core[plugin-core]
+        PM[plugin-pm]
+        Obsidian[plugin-obsidian]
+    end
+
+    subgraph "Obsidian Vault"
+        MOC[MOC.md]
+        Dashboard[DASHBOARD.md]
+        Issues[issues/]
+        Epics[epics/]
+        Agents[agents/]
+    end
+
+    CLI --> Core
+    CLI --> PM
+    CLI --> Obsidian
+    Obsidian -->|rsync| MOC
+    Obsidian -->|rsync| Dashboard
+    PM -->|source| Issues
+    PM -->|source| Epics
+    Core -->|source| Agents
+```
+
+## Notes
+
+Edit this diagram to match your project's architecture. Uses [Mermaid](https://mermaid.js.org/) syntax.

--- a/packages/plugin-obsidian/templates/diagrams/pizarra.excalidraw.md
+++ b/packages/plugin-obsidian/templates/diagrams/pizarra.excalidraw.md
@@ -1,0 +1,29 @@
+---
+type: diagram
+title: Whiteboard
+tags: [diagram, excalidraw, whiteboard]
+excalidraw-plugin: parsed
+---
+
+# Whiteboard
+
+Open this file in Excalidraw to start drawing.
+
+%%
+# Excalidraw Data
+
+## Drawing
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://github.com/zsviczian/obsidian-excalidraw-plugin",
+  "elements": [],
+  "appState": {
+    "gridSize": null,
+    "viewBackgroundColor": "#ffffff"
+  },
+  "files": {}
+}
+```
+%%

--- a/packages/plugin-obsidian/tests/docs.test.js
+++ b/packages/plugin-obsidian/tests/docs.test.js
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..', '..', '..');
+
+describe('plugin-obsidian documentation', () => {
+  describe('docs/plugins/obsidian.md', () => {
+    const docPath = resolve(root, 'docs', 'plugins', 'obsidian.md');
+
+    it('exists', () => {
+      assert.ok(existsSync(docPath), `${docPath} must exist`);
+    });
+
+    it('contains required sections', () => {
+      const content = readFileSync(docPath, 'utf8');
+      const required = [
+        'Overview',
+        'Prerequisites',
+        'Installation',
+        'Commands',
+        'Troubleshooting',
+      ];
+      for (const section of required) {
+        assert.ok(
+          content.includes(`## ${section}`),
+          `Missing required section: ## ${section}`
+        );
+      }
+    });
+  });
+
+  describe('packages/plugin-obsidian/README.md', () => {
+    const readmePath = resolve(root, 'packages', 'plugin-obsidian', 'README.md');
+
+    it('mentions obsidian:setup', () => {
+      const content = readFileSync(readmePath, 'utf8');
+      assert.ok(
+        content.includes('obsidian:setup'),
+        'README must mention obsidian:setup'
+      );
+    });
+
+    it('mentions obsidian:sync', () => {
+      const content = readFileSync(readmePath, 'utf8');
+      assert.ok(
+        content.includes('obsidian:sync'),
+        'README must mention obsidian:sync'
+      );
+    });
+
+    it('mentions obsidian:doctor', () => {
+      const content = readFileSync(readmePath, 'utf8');
+      assert.ok(
+        content.includes('obsidian:doctor'),
+        'README must mention obsidian:doctor'
+      );
+    });
+  });
+
+  describe('CHANGELOG.md', () => {
+    const changelogPath = resolve(root, 'CHANGELOG.md');
+
+    it('mentions plugin-obsidian under Unreleased', () => {
+      const content = readFileSync(changelogPath, 'utf8');
+      const unreleasedIdx = content.indexOf('## [Unreleased]');
+      assert.ok(unreleasedIdx !== -1, 'CHANGELOG must have an [Unreleased] section');
+
+      // Find the next version heading after Unreleased
+      const afterUnreleased = content.slice(unreleasedIdx + '## [Unreleased]'.length);
+      const nextVersionIdx = afterUnreleased.indexOf('\n## [');
+      const unreleasedSection = nextVersionIdx !== -1
+        ? afterUnreleased.slice(0, nextVersionIdx)
+        : afterUnreleased;
+
+      assert.ok(
+        unreleasedSection.includes('plugin-obsidian'),
+        'Unreleased section must mention plugin-obsidian'
+      );
+    });
+  });
+
+  describe('README.md', () => {
+    const readmePath = resolve(root, 'README.md');
+
+    it('scenario table mentions Obsidian', () => {
+      const content = readFileSync(readmePath, 'utf8');
+      assert.ok(
+        content.includes('Obsidian'),
+        'README scenario table must mention Obsidian'
+      );
+    });
+  });
+});

--- a/packages/plugin-obsidian/tests/doctor.test.js
+++ b/packages/plugin-obsidian/tests/doctor.test.js
@@ -1,0 +1,432 @@
+#!/usr/bin/env node
+/**
+ * Tests for doctor.js -- Obsidian integration diagnostics.
+ *
+ * Uses Node built-in test runner (node:test + node:assert).
+ * Run: node --test packages/plugin-obsidian/tests/doctor.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  symlinkSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SCRIPT_PATH = join(__dirname, '..', 'scripts', 'obsidian', 'doctor.js');
+
+// --- Helpers ----------------------------------------------------------------
+
+function makeTempDir() {
+  return mkdtempSync(join(tmpdir(), 'doctor-test-'));
+}
+
+function runDoctor(args = [], options = {}) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT_PATH, ...args], {
+      encoding: 'utf8',
+      timeout: 15000,
+      ...options,
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+    };
+  }
+}
+
+function setupProject(testDir, config = null) {
+  const project = join(testDir, 'project');
+  const vault = join(testDir, 'vault');
+
+  mkdirSync(join(project, '.claude'), { recursive: true });
+  mkdirSync(vault, { recursive: true });
+
+  if (config !== null) {
+    writeFileSync(
+      join(project, '.claude', 'config.json'),
+      JSON.stringify(config, null, 2)
+    );
+  }
+
+  return { project, vault };
+}
+
+function makeFullConfig(vault, prefix = 'test-project') {
+  return {
+    obsidian: {
+      vault_path: vault,
+      vault_prefix: prefix,
+    },
+  };
+}
+
+// --- Test: checkRsync -------------------------------------------------------
+
+describe('checkRsync', () => {
+  it('passes when rsync is available', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      // Create vault prefix structure so all checks can run
+      mkdirSync(join(vault, 'test-project', 'issues'), { recursive: true });
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      // rsync should show as pass (rsync is installed in CI and dev envs)
+      assert.match(result.stdout, /rsync/);
+      assert.match(result.stdout, /installed/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails gracefully when tool missing (uses PATH override)', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+
+      // Run with a PATH that includes node but not rsync
+      const nodeDir = dirname(process.execPath);
+      const result = runDoctor(['--project-root', project], {
+        env: { ...process.env, PATH: nodeDir },
+      });
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /rsync/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: checkVaultPath ---------------------------------------------------
+
+describe('checkVaultPath', () => {
+  it('passes for existing writable directory', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      assert.match(result.stdout, /[Vv]ault\s*path/);
+      assert.match(result.stdout, /ok/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails for non-existent path', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(
+          { obsidian: { vault_path: '/tmp/nonexistent-vault-xyz', vault_prefix: 'x' } },
+          null,
+          2
+        )
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      assert.notEqual(result.status, 0);
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /[Vv]ault/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when config has no obsidian section', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupProject(testDir, { version: '1.0' });
+
+      const result = runDoctor(['--project-root', project]);
+      assert.notEqual(result.status, 0);
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /obsidian|vault_path|config/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: checkDotfolderIssues ---------------------------------------------
+
+describe('checkDotfolderIssues', () => {
+  it('warns when .claude/issues exists but issues/ does not', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+      // Create .claude/issues as a real directory (not symlink)
+      mkdirSync(join(project, '.claude', 'issues'), { recursive: true });
+      writeFileSync(join(project, '.claude', 'issues', 'issue-1.md'), '# Issue 1\n');
+
+      const result = runDoctor(['--project-root', project]);
+      assert.match(result.stdout, /dotfolder|invisible/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when issues/ exists', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+      mkdirSync(join(project, 'issues'), { recursive: true });
+
+      const result = runDoctor(['--project-root', project]);
+      assert.match(result.stdout, /[Ii]ssues\s*location/);
+      // Should not have the error indicator for issues location
+      assert.ok(
+        !result.stdout.match(/Issues\s*location.*dotfolder/i),
+        'Should not warn about dotfolder when issues/ exists'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when neither exists (no issues yet)', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      // Should pass or skip -- no error for issues location
+      assert.ok(
+        !result.stdout.match(/Issues\s*location.*dotfolder/i),
+        'Should not warn when no issues directory exists at all'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: checkDataviewPrefix ----------------------------------------------
+
+describe('checkDataviewPrefix', () => {
+  it('passes when vault/{prefix}/ structure exists', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault, 'my-proj'), null, 2)
+      );
+      // Create the expected vault structure
+      mkdirSync(join(vault, 'my-proj', 'issues'), { recursive: true });
+
+      const result = runDoctor(['--project-root', project]);
+      assert.match(result.stdout, /[Dd]ataview\s*prefix/);
+      assert.match(result.stdout, /correct|ok/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: checkSymlink -----------------------------------------------------
+
+describe('checkSymlink', () => {
+  it('passes when symlink target exists', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+      // Create issues/ and symlink .claude/issues -> ../../issues
+      mkdirSync(join(project, 'issues'), { recursive: true });
+      symlinkSync(
+        join(project, 'issues'),
+        join(project, '.claude', 'issues')
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      assert.match(result.stdout, /[Ss]ymlink/);
+      assert.match(result.stdout, /ok/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when symlink is broken', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+      // Create a symlink pointing to non-existent target
+      symlinkSync(
+        join(project, 'nonexistent-issues'),
+        join(project, '.claude', 'issues')
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      assert.match(result.stdout, /[Ss]ymlink/);
+      assert.match(result.stdout, /broken/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when no symlink exists (not migrated)', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      // No error about symlink
+      assert.ok(
+        !result.stdout.match(/[Ss]ymlink.*broken/i),
+        'Should not warn about broken symlink when none exists'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: full doctor run --------------------------------------------------
+
+describe('full doctor run', () => {
+  it('returns exit 0 when all checks pass', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+      // Create vault prefix directory so Dataview check passes
+      mkdirSync(join(vault, 'test-project'), { recursive: true });
+      // Create issues/ so dotfolder check passes
+      mkdirSync(join(project, 'issues'), { recursive: true });
+
+      const result = runDoctor(['--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /passed/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns exit 1 when a check fails', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(
+          { obsidian: { vault_path: '/tmp/nonexistent-vault-xyz', vault_prefix: 'x' } },
+          null,
+          2
+        )
+      );
+
+      const result = runDoctor(['--project-root', project]);
+      assert.equal(result.status, 1);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: output format ----------------------------------------------------
+
+describe('output format', () => {
+  it('matches expected pattern with header and summary', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProject(testDir);
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify(makeFullConfig(vault), null, 2)
+      );
+      mkdirSync(join(vault, 'test-project'), { recursive: true });
+      mkdirSync(join(project, 'issues'), { recursive: true });
+
+      const result = runDoctor(['--project-root', project]);
+      assert.equal(result.status, 0);
+
+      // Header
+      assert.match(result.stdout, /Obsidian Doctor/);
+      // Separator (Unicode double-line: U+2550)
+      assert.match(result.stdout, /[\u2550]+/);
+      // Summary line with counts
+      assert.match(result.stdout, /\d+\s+passed/i);
+      // Status indicators
+      assert.ok(
+        result.stdout.includes('\u2705') || result.stdout.includes('PASS'),
+        'Should contain pass indicators'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Test: --help flag ------------------------------------------------------
+
+describe('help flag', () => {
+  it('shows usage on --help', () => {
+    const result = runDoctor(['--help']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /[Uu]sage/);
+    assert.match(result.stdout, /--project-root/);
+  });
+
+  it('shows usage on -h', () => {
+    const result = runDoctor(['-h']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /[Uu]sage/);
+  });
+});

--- a/packages/plugin-obsidian/tests/installer-wiring.test.js
+++ b/packages/plugin-obsidian/tests/installer-wiring.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..', '..');
+const INSTALL_JS = join(ROOT, 'install', 'install.js');
+const POST_INSTALL_JS = join(ROOT, 'install', 'post-install-check.js');
+const CLAUDE_MD_SECTION = join(ROOT, 'packages', 'plugin-obsidian', 'claude-md', 'obsidian-section.md');
+
+describe('Installer wiring for plugin-obsidian', () => {
+  const installSrc = fs.readFileSync(INSTALL_JS, 'utf8');
+  const postInstallSrc = fs.readFileSync(POST_INSTALL_JS, 'utf8');
+
+  it('install.js contains obsidian scenario key in configs', () => {
+    assert.match(installSrc, /obsidian:\s*\{/);
+  });
+
+  it('install.js scenario menu mentions Obsidian', () => {
+    assert.match(installSrc, /Obsidian/);
+  });
+
+  it('install.js choice map has an entry mapping to obsidian', () => {
+    assert.match(installSrc, /['"]?\d['"]?\s*:\s*['"]obsidian['"]/);
+  });
+
+  it('install.js obsidian config includes plugin-core, plugin-pm, plugin-obsidian', () => {
+    const obsidianBlock = installSrc.match(/obsidian:\s*\{[\s\S]*?plugins:\s*\[([^\]]*)\]/);
+    assert.ok(obsidianBlock, 'obsidian config block with plugins array not found');
+    const plugins = obsidianBlock[1];
+    assert.match(plugins, /plugin-core/);
+    assert.match(plugins, /plugin-pm/);
+    assert.match(plugins, /plugin-obsidian/);
+  });
+
+  it('post-install-check.js references obsidian or vault', () => {
+    assert.match(postInstallSrc, /obsidian|vault/i);
+  });
+
+  it('claude-md/obsidian-section.md exists and contains required sections', () => {
+    assert.ok(fs.existsSync(CLAUDE_MD_SECTION), 'obsidian-section.md does not exist');
+    const content = fs.readFileSync(CLAUDE_MD_SECTION, 'utf8');
+    assert.match(content, /Vault Sync/);
+    assert.match(content, /Frontmatter Convention/);
+    assert.match(content, /Important Rules/);
+  });
+
+  it('claude-md/obsidian-section.md mentions unidirectional sync', () => {
+    const content = fs.readFileSync(CLAUDE_MD_SECTION, 'utf8');
+    assert.match(content, /unidirectional/i);
+  });
+
+  it('claude-md/obsidian-section.md includes frontmatter convention', () => {
+    const content = fs.readFileSync(CLAUDE_MD_SECTION, 'utf8');
+    assert.match(content, /type:\s*issue\|prd\|epic\|agent\|rule/);
+    assert.match(content, /status:\s*open\|in-progress\|closed/);
+  });
+});

--- a/packages/plugin-obsidian/tests/setup.test.js
+++ b/packages/plugin-obsidian/tests/setup.test.js
@@ -1,0 +1,536 @@
+#!/usr/bin/env node
+/**
+ * Tests for setup.js — Obsidian setup wizard backend.
+ *
+ * Uses Node built-in test runner (node:test + node:assert).
+ * Run: node --test packages/plugin-obsidian/tests/setup.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  lstatSync,
+  readlinkSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SCRIPT_PATH = join(__dirname, '..', 'scripts', 'obsidian', 'setup.js');
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function makeTempDir() {
+  return mkdtempSync(join(tmpdir(), 'setup-test-'));
+}
+
+function runSetup(args = [], options = {}) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT_PATH, ...args], {
+      encoding: 'utf8',
+      timeout: 15000,
+      ...options,
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+    };
+  }
+}
+
+function setupProjectDir(testDir, extraConfig = {}) {
+  const project = join(testDir, 'project');
+  const vault = join(testDir, 'vault');
+
+  mkdirSync(join(project, '.claude'), { recursive: true });
+  mkdirSync(vault, { recursive: true });
+
+  if (Object.keys(extraConfig).length > 0) {
+    writeFileSync(
+      join(project, '.claude', 'config.json'),
+      JSON.stringify(extraConfig, null, 2)
+    );
+  }
+
+  return { project, vault };
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+// ─── Test: detectEnvironment ────────────────────────────────────────
+
+describe('detectEnvironment', () => {
+  it('returns linux, macos, or wsl', () => {
+    // We test this indirectly via the config output
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+      const result = runSetup(
+        ['--vault-path', vault, '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.ok(
+        ['linux', 'macos', 'wsl'].includes(config.obsidian.environment),
+        `Expected environment to be linux, macos, or wsl, got: ${config.obsidian.environment}`
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: mergeConfig ──────────────────────────────────────────────
+
+describe('mergeConfig', () => {
+  it('preserves existing keys when adding obsidian section', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir, {
+        version: '3.5.1',
+        tools: { docker: { enabled: false } },
+        plugins: ['plugin-core'],
+      });
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'test-proj', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.version, '3.5.1');
+      assert.deepEqual(config.tools, { docker: { enabled: false } });
+      assert.deepEqual(config.plugins, ['plugin-core']);
+      assert.equal(config.obsidian.vault_path, vault);
+      assert.equal(config.obsidian.vault_prefix, 'test-proj');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates new config file when none exists', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+      // No config.json written
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'new-proj', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      assert.ok(existsSync(join(project, '.claude', 'config.json')));
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.obsidian.vault_path, vault);
+      assert.equal(config.obsidian.vault_prefix, 'new-proj');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: substituteTemplate ───────────────────────────────────────
+
+describe('substituteTemplate', () => {
+  it('replaces {{PREFIX}}, {{PROJECT_NAME}}, {{CREATED_DATE}}', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'my-proj', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      // Check MOC.md for substitutions
+      const mocPath = join(vault, 'my-proj', 'MOC.md');
+      assert.ok(existsSync(mocPath), 'MOC.md should exist');
+      const mocContent = readFileSync(mocPath, 'utf8');
+
+      assert.ok(!mocContent.includes('{{PREFIX}}'), 'Should not contain {{PREFIX}}');
+      assert.ok(!mocContent.includes('{{PROJECT_NAME}}'), 'Should not contain {{PROJECT_NAME}}');
+      assert.ok(!mocContent.includes('{{CREATED_DATE}}'), 'Should not contain {{CREATED_DATE}}');
+      assert.ok(mocContent.includes('my-proj'), 'Should contain the prefix');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: generateTemplates ────────────────────────────────────────
+
+describe('generateTemplates', () => {
+  it('creates all expected files in vault directory', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'gen-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const prefix = join(vault, 'gen-test');
+
+      // MOC and DASHBOARD
+      assert.ok(existsSync(join(prefix, 'MOC.md')), 'MOC.md');
+      assert.ok(existsSync(join(prefix, 'DASHBOARD.md')), 'DASHBOARD.md');
+
+      // _templates
+      assert.ok(existsSync(join(prefix, '_templates', 'issue.md')), '_templates/issue.md');
+      assert.ok(existsSync(join(prefix, '_templates', 'prd.md')), '_templates/prd.md');
+      assert.ok(existsSync(join(prefix, '_templates', 'epic.md')), '_templates/epic.md');
+
+      // diagrams
+      assert.ok(
+        existsSync(join(prefix, 'diagrams', '01-architecture.md')),
+        'diagrams/01-architecture.md'
+      );
+      assert.ok(
+        existsSync(join(prefix, 'diagrams', 'pizarra.excalidraw.md')),
+        'diagrams/pizarra.excalidraw.md'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: applyCanonicalFrontmatter ────────────────────────────────
+
+describe('applyCanonicalFrontmatter', () => {
+  it('adds missing fields to a markdown file', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      // Create issues directory with a file that has partial frontmatter
+      mkdirSync(join(project, 'issues'), { recursive: true });
+      writeFileSync(
+        join(project, 'issues', 'test-issue.md'),
+        '---\ntitle: Test Issue\n---\n\n# Test Issue\n'
+      );
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'fm-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const content = readFileSync(join(project, 'issues', 'test-issue.md'), 'utf8');
+      assert.ok(content.includes('type:'), 'Should have type field');
+      assert.ok(content.includes('status:'), 'Should have status field');
+      assert.ok(content.includes('created:'), 'Should have created field');
+      assert.ok(content.includes('updated:'), 'Should have updated field');
+      assert.ok(content.includes('tags:'), 'Should have tags field');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT overwrite existing fields', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      mkdirSync(join(project, 'issues'), { recursive: true });
+      writeFileSync(
+        join(project, 'issues', 'existing.md'),
+        '---\ntitle: My Title\nstatus: in-progress\ntype: task\n---\n\n# Content\n'
+      );
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'fm-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const content = readFileSync(join(project, 'issues', 'existing.md'), 'utf8');
+      assert.ok(content.includes('status: in-progress'), 'status should remain in-progress');
+      assert.ok(content.includes('type: task'), 'type should remain task');
+      assert.ok(content.includes('title: My Title'), 'title should remain My Title');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips files without frontmatter', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      mkdirSync(join(project, 'issues'), { recursive: true });
+      const originalContent = '# No Frontmatter\n\nJust plain markdown.\n';
+      writeFileSync(join(project, 'issues', 'plain.md'), originalContent);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'fm-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const content = readFileSync(join(project, 'issues', 'plain.md'), 'utf8');
+      assert.equal(content, originalContent, 'File without frontmatter should be unchanged');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: vault path validation ────────────────────────────────────
+
+describe('vault path validation', () => {
+  it('rejects non-existent path', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupProjectDir(testDir);
+      const fakePath = join(testDir, 'nonexistent', 'vault');
+
+      const result = runSetup(
+        ['--vault-path', fakePath, '--project-root', project],
+        { cwd: project }
+      );
+      assert.notEqual(result.status, 0);
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /does not exist/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: argument parsing ─────────────────────────────────────────
+
+describe('argument parsing', () => {
+  it('--vault-path argument parsing works correctly', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'arg-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.obsidian.vault_path, vault);
+      assert.equal(config.obsidian.vault_prefix, 'arg-test');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints usage and exits 1 when --vault-path is missing', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupProjectDir(testDir);
+
+      const result = runSetup(['--project-root', project], { cwd: project });
+      assert.notEqual(result.status, 0);
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /--vault-path/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults prefix to directory name when not provided', () => {
+    const testDir = makeTempDir();
+    try {
+      const project = join(testDir, 'my-awesome-project');
+      const vault = join(testDir, 'vault');
+      mkdirSync(join(project, '.claude'), { recursive: true });
+      mkdirSync(vault, { recursive: true });
+
+      const result = runSetup(
+        ['--vault-path', vault, '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.obsidian.vault_prefix, 'my-awesome-project');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--watch flag sets watch to true in config', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--watch', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.obsidian.watch, true);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--no-watch flag sets watch to false in config', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--no-watch', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.obsidian.watch, false);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: full setup flow ──────────────────────────────────────────
+
+describe('full setup flow', () => {
+  it('creates config, generates templates, handles missing issues/prds gracefully', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+      // No issues/ or prds/ directories
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'full-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      // Config should be created
+      assert.ok(existsSync(join(project, '.claude', 'config.json')));
+      const config = readJson(join(project, '.claude', 'config.json'));
+      assert.equal(config.obsidian.vault_path, vault);
+
+      // Templates should be generated
+      assert.ok(existsSync(join(vault, 'full-test', 'MOC.md')));
+      assert.ok(existsSync(join(vault, 'full-test', 'DASHBOARD.md')));
+
+      // Output should indicate success
+      assert.match(result.stdout, /setup complete/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies frontmatter to existing issues when issues/ exists', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      // Create issues and prds directories
+      mkdirSync(join(project, 'issues'), { recursive: true });
+      mkdirSync(join(project, 'prds'), { recursive: true });
+
+      writeFileSync(
+        join(project, 'issues', 'issue-1.md'),
+        '---\ntitle: Issue 1\n---\n\n# Issue 1\n'
+      );
+      writeFileSync(
+        join(project, 'prds', 'prd-1.md'),
+        '---\ntitle: PRD 1\n---\n\n# PRD 1\n'
+      );
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'fm-flow', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      // Issues should have canonical fields
+      const issueContent = readFileSync(join(project, 'issues', 'issue-1.md'), 'utf8');
+      assert.ok(issueContent.includes('type:'), 'Issue should have type field');
+
+      // PRDs should have canonical fields
+      const prdContent = readFileSync(join(project, 'prds', 'prd-1.md'), 'utf8');
+      assert.ok(prdContent.includes('type:'), 'PRD should have type field');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles .claude/issues migration to issues/', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      // Create .claude/issues/ (no top-level issues/)
+      mkdirSync(join(project, '.claude', 'issues'), { recursive: true });
+      writeFileSync(
+        join(project, '.claude', 'issues', 'migrated.md'),
+        '---\ntitle: Migrated\n---\n\n# Migrated\n'
+      );
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'migrate-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      // issues/ should exist at top level
+      assert.ok(existsSync(join(project, 'issues')), 'issues/ should exist');
+      assert.ok(
+        existsSync(join(project, 'issues', 'migrated.md')),
+        'migrated.md should be in issues/'
+      );
+
+      // .claude/issues should be a symlink
+      const stat = lstatSync(join(project, '.claude', 'issues'));
+      assert.ok(stat.isSymbolicLink(), '.claude/issues should be a symlink');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints next steps on completion', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupProjectDir(testDir);
+
+      const result = runSetup(
+        ['--vault-path', vault, '--prefix', 'next-test', '--project-root', project],
+        { cwd: project }
+      );
+      assert.equal(result.status, 0);
+
+      assert.match(result.stdout, /next steps/i);
+      assert.match(result.stdout, /Dataview/i);
+      assert.match(result.stdout, /obsidian:sync/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/plugin-obsidian/tests/sync-to-obsidian-node.test.js
+++ b/packages/plugin-obsidian/tests/sync-to-obsidian-node.test.js
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+/**
+ * Tests for sync-to-obsidian.js — Node.js fallback sync script.
+ *
+ * Uses Node built-in test runner (node:test + node:assert).
+ * Run: node --test packages/plugin-obsidian/tests/sync-to-obsidian-node.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SCRIPT_PATH = join(__dirname, '..', 'scripts', 'obsidian', 'sync-to-obsidian.js');
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function makeTempDir() {
+  return mkdtempSync(join(tmpdir(), 'sync-node-test-'));
+}
+
+function setupFakeProject(testDir) {
+  const project = join(testDir, 'project');
+  const vault = join(testDir, 'vault');
+
+  mkdirSync(join(project, '.claude'), { recursive: true });
+  mkdirSync(vault, { recursive: true });
+
+  writeFileSync(
+    join(project, '.claude', 'config.json'),
+    JSON.stringify(
+      {
+        obsidian: {
+          vault_path: vault,
+          vault_prefix: 'test-project',
+          watch: false,
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  // Create source directories with content
+  mkdirSync(join(project, '.claude', 'agents'), { recursive: true });
+  mkdirSync(join(project, '.claude', 'rules'), { recursive: true });
+  mkdirSync(join(project, '.claude', 'commands'), { recursive: true });
+
+  writeFileSync(join(project, '.claude', 'agents', 'test-agent.md'), '# Agent doc\n');
+  writeFileSync(join(project, '.claude', 'rules', 'test-rule.md'), '# Rule doc\n');
+  writeFileSync(join(project, 'README.md'), '# README\n');
+
+  return { project, vault };
+}
+
+function runScript(args = [], options = {}) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT_PATH, ...args], {
+      encoding: 'utf8',
+      timeout: 15000,
+      ...options,
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+    };
+  }
+}
+
+// ─── Test: parseArgs ────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('correctly parses --check flag', () => {
+    // We can verify --check by checking for dry-run output
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /dry.run|Dry/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('correctly parses --watch flag (accepted without error)', () => {
+    // Watch mode is tested by just ensuring the flag is accepted
+    // We use --check too so it doesn't actually start watching
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      // Using --check to prevent actual watch loop; just verify --watch is accepted
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('correctly parses --safe-mode flag', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--safe-mode', '--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /[Ss]afe/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('correctly parses --project-root flag', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, new RegExp(project.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unknown flags', () => {
+    const result = runScript(['--banana']);
+    assert.notEqual(result.status, 0);
+    const combined = result.stdout + result.stderr;
+    assert.match(combined, /[Uu]nknown|[Uu]sage/);
+  });
+});
+
+// ─── Test: readConfig ───────────────────────────────────────────────
+
+describe('readConfig', () => {
+  it('reads vault_path and vault_prefix from config JSON', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupFakeProject(testDir);
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+      // Output should reference the vault path
+      assert.match(result.stdout, new RegExp(vault.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      // Output should reference the prefix
+      assert.match(result.stdout, /test-project/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when config file missing', () => {
+    const testDir = makeTempDir();
+    try {
+      const project = join(testDir, 'no-project');
+      mkdirSync(join(project, '.claude'), { recursive: true });
+      // No config.json created
+      const result = runScript(['--project-root', project]);
+      assert.notEqual(result.status, 0);
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /config|not found/i);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when vault_path not set', () => {
+    const testDir = makeTempDir();
+    try {
+      const project = join(testDir, 'project');
+      mkdirSync(join(project, '.claude'), { recursive: true });
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify({ obsidian: { vault_prefix: 'test' } })
+      );
+      const result = runScript(['--project-root', project]);
+      assert.notEqual(result.status, 0);
+      const combined = result.stdout + result.stderr;
+      assert.match(combined, /vault_path/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: buildRsyncArgs ───────────────────────────────────────────
+
+describe('buildRsyncArgs', () => {
+  it('includes --dry-run when check mode', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      // In check mode the script should pass --dry-run to rsync
+      // We verify by observing the dry-run output message
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /[Dd]ry.run/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits --delete when safe-mode', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupFakeProject(testDir);
+
+      // Pre-populate vault with an extra file
+      mkdirSync(join(vault, 'test-project', 'agents'), { recursive: true });
+      writeFileSync(join(vault, 'test-project', 'agents', 'extra.md'), 'extra');
+
+      const result = runScript(['--safe-mode', '--project-root', project]);
+      assert.equal(result.status, 0);
+
+      // Extra file should still exist (safe-mode = no --delete)
+      assert.ok(
+        existsSync(join(vault, 'test-project', 'agents', 'extra.md')),
+        'Extra file should survive in safe-mode'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('includes --delete when NOT safe-mode', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupFakeProject(testDir);
+
+      // Pre-populate vault with an extra file
+      mkdirSync(join(vault, 'test-project', 'agents'), { recursive: true });
+      writeFileSync(join(vault, 'test-project', 'agents', 'extra.md'), 'extra');
+
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+
+      // Extra file should be gone (default = --delete)
+      assert.ok(
+        !existsSync(join(vault, 'test-project', 'agents', 'extra.md')),
+        'Extra file should be deleted in default mode'
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: findProjectRoot ──────────────────────────────────────────
+
+describe('findProjectRoot', () => {
+  it('finds project root by walking up from script dir', () => {
+    // The script itself, when run without --project-root, walks up
+    // from its own location. We test with --project-root override.
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+      // Should reference the project path in its output
+      assert.match(result.stdout, new RegExp(project.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: --help flag ──────────────────────────────────────────────
+
+describe('help flag', () => {
+  it('exits with help text on --help flag', () => {
+    const result = runScript(['--help']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /[Uu]sage/);
+    assert.match(result.stdout, /--check/);
+    assert.match(result.stdout, /--watch/);
+    assert.match(result.stdout, /--safe-mode/);
+    assert.match(result.stdout, /--project-root/);
+  });
+
+  it('exits with help text on -h flag', () => {
+    const result = runScript(['-h']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /[Uu]sage/);
+  });
+});
+
+// ─── Test: output format ────────────────────────────────────────────
+
+describe('output format', () => {
+  it('output includes [sync] prefix', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /\[sync\]/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('output reports done/synced on completion', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /[Dd]one|synced/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('[error] prefix on stderr for errors', () => {
+    const testDir = makeTempDir();
+    try {
+      const project = join(testDir, 'no-config');
+      mkdirSync(project, { recursive: true });
+      // No .claude/config.json
+      const result = runScript(['--project-root', project]);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /\[error\]/);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: version flag ─────────────────────────────────────────────
+
+describe('version flag', () => {
+  it('shows version with --version flag', () => {
+    const result = runScript(['--version']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /1\.0\.0/);
+  });
+
+  it('shows version with -v flag', () => {
+    const result = runScript(['-v']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /1\.0\.0/);
+  });
+});
+
+// ─── Test: sync behaviour ───────────────────────────────────────────
+
+describe('sync behaviour', () => {
+  it('copies markdown files from .claude subdirs to vault', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupFakeProject(testDir);
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+
+      assert.ok(existsSync(join(vault, 'test-project', 'agents', 'test-agent.md')));
+      assert.ok(existsSync(join(vault, 'test-project', 'rules', 'test-rule.md')));
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('copies root markdown files to vault', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupFakeProject(testDir);
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+
+      assert.ok(existsSync(join(vault, 'test-project', 'README.md')));
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips non-existent optional directories without error', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      // .claude/prds/ and issues/ don't exist
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('dry-run mode does not create files in vault', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project, vault } = setupFakeProject(testDir);
+      const result = runScript(['--check', '--project-root', project]);
+      assert.equal(result.status, 0);
+
+      // Vault prefix directory should NOT have been created
+      assert.ok(!existsSync(join(vault, 'test-project', 'agents')));
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults vault_prefix to project directory name when not set', () => {
+    const testDir = makeTempDir();
+    try {
+      const project = join(testDir, 'my-cool-project');
+      const vault = join(testDir, 'vault');
+      mkdirSync(join(project, '.claude', 'agents'), { recursive: true });
+      mkdirSync(vault, { recursive: true });
+
+      writeFileSync(
+        join(project, '.claude', 'config.json'),
+        JSON.stringify({ obsidian: { vault_path: vault } })
+      );
+      writeFileSync(join(project, '.claude', 'agents', 'a.md'), '# A\n');
+
+      const result = runScript(['--project-root', project]);
+      assert.equal(result.status, 0);
+
+      // Should use directory name as prefix
+      assert.ok(existsSync(join(vault, 'my-cool-project', 'agents', 'a.md')));
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: combined modes ───────────────────────────────────────────
+
+describe('combined modes', () => {
+  it('--check --safe-mode works together', () => {
+    const testDir = makeTempDir();
+    try {
+      const { project } = setupFakeProject(testDir);
+      const result = runScript(['--check', '--safe-mode', '--project-root', project]);
+      assert.equal(result.status, 0);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Test: --project-root requires argument ─────────────────────────
+
+describe('--project-root validation', () => {
+  it('errors when --project-root given without a directory', () => {
+    const result = runScript(['--project-root']);
+    assert.notEqual(result.status, 0);
+    const combined = result.stdout + result.stderr;
+    assert.match(combined, /project.root|requires|directory/i);
+  });
+});

--- a/packages/plugin-obsidian/tests/sync-to-obsidian.bats
+++ b/packages/plugin-obsidian/tests/sync-to-obsidian.bats
@@ -1,0 +1,266 @@
+#!/usr/bin/env bats
+# Tests for sync-to-obsidian.sh
+# Requires: bats-core (https://github.com/bats-core/bats-core)
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+SYNC_SCRIPT="${SCRIPT_DIR}/../scripts/obsidian/sync-to-obsidian.sh"
+
+setup() {
+    export TEST_DIR
+    TEST_DIR="$(mktemp -d)"
+
+    # Create a fake project root with .claude/config.json
+    export FAKE_PROJECT="${TEST_DIR}/project"
+    mkdir -p "${FAKE_PROJECT}/.claude"
+
+    # Create a fake vault
+    export FAKE_VAULT="${TEST_DIR}/vault"
+    mkdir -p "${FAKE_VAULT}"
+
+    # Write a valid config
+    cat > "${FAKE_PROJECT}/.claude/config.json" <<CONF
+{
+  "obsidian": {
+    "vault_path": "${FAKE_VAULT}",
+    "vault_prefix": "test-project",
+    "watch": false
+  }
+}
+CONF
+
+    # Create some source directories with content
+    mkdir -p "${FAKE_PROJECT}/.claude/agents"
+    mkdir -p "${FAKE_PROJECT}/.claude/rules"
+    mkdir -p "${FAKE_PROJECT}/.claude/commands"
+    echo "# Agent doc" > "${FAKE_PROJECT}/.claude/agents/test-agent.md"
+    echo "# Rule doc" > "${FAKE_PROJECT}/.claude/rules/test-rule.md"
+    echo "# README" > "${FAKE_PROJECT}/README.md"
+}
+
+teardown() {
+    rm -rf "${TEST_DIR}"
+}
+
+# ---------- Help / Usage ----------
+
+@test "shows help with --help flag" {
+    run "${SYNC_SCRIPT}" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage" ]] || [[ "$output" =~ "usage" ]]
+}
+
+@test "shows help with -h flag" {
+    run "${SYNC_SCRIPT}" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage" ]] || [[ "$output" =~ "usage" ]]
+}
+
+# ---------- Missing dependencies ----------
+
+@test "fails with clear error when rsync is missing" {
+    # Create a wrapper that shadows rsync with a failing command
+    local fake_bin="${TEST_DIR}/fake_bin"
+    mkdir -p "${fake_bin}"
+    # Create a fake 'rsync' that always fails to be found
+    # by hiding real rsync behind a PATH that lacks it
+    cat > "${fake_bin}/rsync" <<'WRAPPER'
+#!/bin/bash
+exit 127
+WRAPPER
+    # Don't make it executable so 'command -v rsync' fails
+    # Instead, use PATH without the real rsync location
+    local clean_path="${fake_bin}"
+    # We need bash and basic tools but not rsync
+    for p in /usr/bin /bin /usr/local/bin; do
+        if [[ -d "$p" ]] && [[ ! -x "$p/rsync" ]]; then
+            clean_path="${clean_path}:${p}"
+        fi
+    done
+    # If rsync is in all standard paths, just test the error message content
+    # by checking the script's check_rsync function behavior
+    if command -v rsync &>/dev/null; then
+        skip "rsync is installed; cannot easily hide it from PATH in bats"
+    fi
+    run env PATH="${clean_path}" "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "rsync" ]]
+}
+
+# ---------- Config validation ----------
+
+@test "fails when no config file exists" {
+    rm "${FAKE_PROJECT}/.claude/config.json"
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "config" ]] || [[ "$output" =~ "not found" ]]
+}
+
+@test "fails when vault_path is not set in config" {
+    cat > "${FAKE_PROJECT}/.claude/config.json" <<CONF
+{
+  "obsidian": {
+    "vault_prefix": "test-project"
+  }
+}
+CONF
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "vault_path" ]] || [[ "$output" =~ "vault" ]]
+}
+
+@test "fails when obsidian key is missing from config" {
+    cat > "${FAKE_PROJECT}/.claude/config.json" <<CONF
+{
+  "version": "1.0.0"
+}
+CONF
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "obsidian" ]] || [[ "$output" =~ "vault" ]]
+}
+
+@test "fails when vault path does not exist" {
+    rm -rf "${FAKE_VAULT}"
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "exist" ]] || [[ "$output" =~ "not found" ]] || [[ "$output" =~ "vault" ]]
+}
+
+# ---------- Flag handling ----------
+
+@test "handles --check flag (dry-run mode)" {
+    run "${SYNC_SCRIPT}" --check --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dry" ]] || [[ "$output" =~ "Dry" ]] || [[ "$output" =~ "check" ]]
+}
+
+@test "handles --safe-mode flag (no --delete)" {
+    run "${SYNC_SCRIPT}" --safe-mode --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "safe" ]] || [[ "$output" =~ "Safe" ]]
+}
+
+@test "rejects unknown flags gracefully" {
+    run "${SYNC_SCRIPT}" --banana
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "unknown" ]] || [[ "$output" =~ "Unknown" ]] || [[ "$output" =~ "Usage" ]] || [[ "$output" =~ "usage" ]]
+}
+
+# ---------- OS detection ----------
+
+@test "detect_os function returns linux, darwin, or wsl" {
+    # Source the script to get access to functions
+    source "${SYNC_SCRIPT}" --source-only 2>/dev/null || true
+
+    if type detect_os &>/dev/null; then
+        run detect_os
+        [ "$status" -eq 0 ]
+        [[ "$output" =~ ^(linux|darwin|wsl)$ ]]
+    else
+        skip "detect_os not exported as standalone function"
+    fi
+}
+
+# ---------- Config parsing ----------
+
+@test "config parsing extracts vault_path correctly" {
+    run "${SYNC_SCRIPT}" --check --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "${FAKE_VAULT}" ]]
+}
+
+@test "config parsing extracts vault_prefix correctly" {
+    run "${SYNC_SCRIPT}" --check --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "test-project" ]]
+}
+
+# ---------- Sync behavior ----------
+
+@test "one-shot sync copies markdown files to vault" {
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+
+    # Verify files landed in the vault under the prefix
+    [ -d "${FAKE_VAULT}/test-project" ]
+    [ -f "${FAKE_VAULT}/test-project/agents/test-agent.md" ]
+    [ -f "${FAKE_VAULT}/test-project/rules/test-rule.md" ]
+}
+
+@test "one-shot sync copies root markdown files" {
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+
+    [ -f "${FAKE_VAULT}/test-project/README.md" ]
+}
+
+@test "sync excludes binary files" {
+    # Create files that should be excluded
+    touch "${FAKE_PROJECT}/image.png"
+    touch "${FAKE_PROJECT}/photo.jpg"
+
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "${FAKE_VAULT}/test-project/image.png" ]
+    [ ! -f "${FAKE_VAULT}/test-project/photo.jpg" ]
+}
+
+@test "sync skips non-existent optional directories without error" {
+    # .claude/prds/ and issues/ don't exist in our fake project
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+}
+
+@test "dry-run mode does not create files" {
+    run "${SYNC_SCRIPT}" --check --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+
+    # Vault prefix directory should NOT have been created (dry-run)
+    [ ! -d "${FAKE_VAULT}/test-project/agents" ]
+}
+
+@test "safe-mode sync does not delete extra files in vault" {
+    # Pre-populate vault with a file that is NOT in the source
+    mkdir -p "${FAKE_VAULT}/test-project/agents"
+    echo "extra" > "${FAKE_VAULT}/test-project/agents/extra-file.md"
+
+    run "${SYNC_SCRIPT}" --safe-mode --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+
+    # The extra file should still be there (safe-mode = no --delete)
+    [ -f "${FAKE_VAULT}/test-project/agents/extra-file.md" ]
+}
+
+@test "default mode deletes extra files in vault" {
+    # Pre-populate vault with a file that is NOT in the source
+    mkdir -p "${FAKE_VAULT}/test-project/agents"
+    echo "extra" > "${FAKE_VAULT}/test-project/agents/extra-file.md"
+
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+
+    # The extra file should be gone (default = --delete)
+    [ ! -f "${FAKE_VAULT}/test-project/agents/extra-file.md" ]
+}
+
+# ---------- Combined modes ----------
+
+@test "combined --check --safe-mode works" {
+    run "${SYNC_SCRIPT}" --check --safe-mode --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+}
+
+# ---------- Output format ----------
+
+@test "output includes [sync] prefix" {
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[sync]" ]]
+}
+
+@test "output reports files synced" {
+    run "${SYNC_SCRIPT}" --project-root "${FAKE_PROJECT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "synced" ]] || [[ "$output" =~ "Done" ]] || [[ "$output" =~ "done" ]]
+}

--- a/packages/plugin-obsidian/tests/templates.test.js
+++ b/packages/plugin-obsidian/tests/templates.test.js
@@ -1,0 +1,125 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEMPLATES_DIR = join(process.cwd(), 'packages/plugin-obsidian/templates');
+
+describe('Obsidian templates', () => {
+  const expectedFiles = [
+    'MOC.md.tmpl',
+    'DASHBOARD.md.tmpl',
+    '_templates/issue.md',
+    '_templates/prd.md',
+    '_templates/epic.md',
+    'diagrams/01-architecture.md',
+    'diagrams/pizarra.excalidraw.md',
+    'FRONTMATTER_SCHEMA.md',
+  ];
+
+  describe('file existence', () => {
+    for (const file of expectedFiles) {
+      it(`${file} exists`, () => {
+        const filePath = join(TEMPLATES_DIR, file);
+        assert.ok(existsSync(filePath), `Missing template: ${file}`);
+      });
+    }
+  });
+
+  describe('MOC.md.tmpl', () => {
+    it('contains {{PREFIX}} placeholder', () => {
+      const content = readFileSync(join(TEMPLATES_DIR, 'MOC.md.tmpl'), 'utf8');
+      assert.ok(content.includes('{{PREFIX}}'), 'MOC.md.tmpl must contain {{PREFIX}} placeholder');
+    });
+  });
+
+  describe('DASHBOARD.md.tmpl', () => {
+    it('contains {{PREFIX}} placeholder', () => {
+      const content = readFileSync(join(TEMPLATES_DIR, 'DASHBOARD.md.tmpl'), 'utf8');
+      assert.ok(
+        content.includes('{{PREFIX}}'),
+        'DASHBOARD.md.tmpl must contain {{PREFIX}} placeholder'
+      );
+    });
+  });
+
+  describe('Templater templates', () => {
+    const templaterFiles = ['_templates/issue.md', '_templates/prd.md', '_templates/epic.md'];
+
+    for (const file of templaterFiles) {
+      it(`${file} contains Templater syntax`, () => {
+        const content = readFileSync(join(TEMPLATES_DIR, file), 'utf8');
+        assert.ok(
+          content.includes('<% tp.'),
+          `${file} must contain Templater syntax (<% tp.)`
+        );
+      });
+    }
+  });
+
+  describe('diagrams/01-architecture.md', () => {
+    it('contains valid Mermaid code block', () => {
+      const content = readFileSync(
+        join(TEMPLATES_DIR, 'diagrams/01-architecture.md'),
+        'utf8'
+      );
+      assert.ok(content.includes('```mermaid'), 'Must contain a ```mermaid code block');
+      assert.ok(
+        content.includes('graph') || content.includes('flowchart'),
+        'Mermaid block must contain a graph or flowchart directive'
+      );
+    });
+  });
+
+  describe('diagrams/pizarra.excalidraw.md', () => {
+    it('contains Excalidraw JSON', () => {
+      const content = readFileSync(
+        join(TEMPLATES_DIR, 'diagrams/pizarra.excalidraw.md'),
+        'utf8'
+      );
+      assert.ok(
+        content.includes('"type": "excalidraw"'),
+        'Must contain Excalidraw JSON with type field'
+      );
+    });
+  });
+
+  describe('FRONTMATTER_SCHEMA.md', () => {
+    it('documents all required fields', () => {
+      const content = readFileSync(
+        join(TEMPLATES_DIR, 'FRONTMATTER_SCHEMA.md'),
+        'utf8'
+      );
+      const requiredFields = ['type', 'status', 'created', 'updated', 'tags'];
+      for (const field of requiredFields) {
+        assert.ok(
+          content.includes(`\`${field}\``),
+          `FRONTMATTER_SCHEMA.md must document the "${field}" field`
+        );
+      }
+    });
+  });
+
+  describe('no hardcoded paths', () => {
+    const templatedFiles = [
+      'MOC.md.tmpl',
+      'DASHBOARD.md.tmpl',
+      '_templates/epic.md',
+    ];
+
+    for (const file of templatedFiles) {
+      it(`${file} has no hardcoded vault paths`, () => {
+        const content = readFileSync(join(TEMPLATES_DIR, file), 'utf8');
+        // Paths like FROM "my-project/issues" would be hardcoded.
+        // All folder references in dataview FROM clauses must use {{PREFIX}}.
+        const fromClauses = content.match(/FROM\s+"([^"]+)"/g) || [];
+        for (const clause of fromClauses) {
+          assert.ok(
+            clause.includes('{{PREFIX}}'),
+            `Hardcoded path found in ${file}: ${clause} — should use {{PREFIX}}`
+          );
+        }
+      });
+    }
+  });
+});

--- a/packages/plugin-obsidian/tests/test-sync-basic.sh
+++ b/packages/plugin-obsidian/tests/test-sync-basic.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Basic validation tests for sync-to-obsidian.sh
+# Runs without bats — just needs bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC_SCRIPT="${SCRIPT_DIR}/../scripts/obsidian/sync-to-obsidian.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
+
+echo "=== sync-to-obsidian.sh basic tests ==="
+echo ""
+
+# ---- Test: script exists and is executable ----
+if [[ -x "${SYNC_SCRIPT}" ]]; then
+    pass "script is executable"
+else
+    fail "script is not executable"
+fi
+
+# ---- Test: --help exits 0 and prints usage ----
+help_out=$("${SYNC_SCRIPT}" --help 2>&1) && help_rc=0 || help_rc=$?
+if [[ $help_rc -eq 0 ]] && echo "${help_out}" | grep -qi "usage"; then
+    pass "--help shows usage"
+else
+    fail "--help did not show usage (rc=${help_rc})"
+fi
+
+# ---- Test: unknown flag exits non-zero ----
+if "${SYNC_SCRIPT}" --banana 2>&1; then
+    fail "--banana should have failed"
+else
+    pass "unknown flag rejected"
+fi
+
+# ---- Test: missing config exits non-zero ----
+TMP_DIR="$(mktemp -d)"
+mkdir -p "${TMP_DIR}/.claude"
+if "${SYNC_SCRIPT}" --project-root "${TMP_DIR}" 2>&1; then
+    fail "should fail when config missing"
+else
+    pass "fails when config missing"
+fi
+
+# ---- Test: missing vault_path in config exits non-zero ----
+cat > "${TMP_DIR}/.claude/config.json" <<EOF
+{ "obsidian": { "vault_prefix": "x" } }
+EOF
+if "${SYNC_SCRIPT}" --project-root "${TMP_DIR}" 2>&1; then
+    fail "should fail when vault_path missing"
+else
+    pass "fails when vault_path missing"
+fi
+
+# ---- Test: one-shot sync works end-to-end ----
+VAULT_DIR="${TMP_DIR}/vault"
+mkdir -p "${VAULT_DIR}"
+mkdir -p "${TMP_DIR}/.claude/rules"
+echo "# test" > "${TMP_DIR}/.claude/rules/example.md"
+echo "# readme" > "${TMP_DIR}/README.md"
+cat > "${TMP_DIR}/.claude/config.json" <<EOF
+{ "obsidian": { "vault_path": "${VAULT_DIR}", "vault_prefix": "basic-test" } }
+EOF
+
+if command -v rsync &>/dev/null; then
+    sync_out=$("${SYNC_SCRIPT}" --project-root "${TMP_DIR}" 2>&1) && sync_rc=0 || sync_rc=$?
+    if [[ $sync_rc -eq 0 ]]; then
+        pass "one-shot sync exits 0"
+    else
+        fail "one-shot sync exited ${sync_rc}"
+    fi
+
+    if [[ -f "${VAULT_DIR}/basic-test/rules/example.md" ]]; then
+        pass "rules synced to vault"
+    else
+        fail "rules not found in vault"
+    fi
+
+    if [[ -f "${VAULT_DIR}/basic-test/README.md" ]]; then
+        pass "root markdown synced to vault"
+    else
+        fail "root markdown not found in vault"
+    fi
+else
+    skip "rsync not installed — skipping sync tests"
+fi
+
+# ---- Test: --check (dry-run) does not create files ----
+VAULT_DIR2="${TMP_DIR}/vault2"
+mkdir -p "${VAULT_DIR2}"
+cat > "${TMP_DIR}/.claude/config.json" <<EOF
+{ "obsidian": { "vault_path": "${VAULT_DIR2}", "vault_prefix": "dry-test" } }
+EOF
+
+if command -v rsync &>/dev/null; then
+    "${SYNC_SCRIPT}" --check --project-root "${TMP_DIR}" >/dev/null 2>&1 || true
+    if [[ ! -d "${VAULT_DIR2}/dry-test/rules" ]]; then
+        pass "--check does not create files"
+    else
+        fail "--check created files (should be dry-run)"
+    fi
+else
+    skip "rsync not installed — skipping dry-run test"
+fi
+
+# ---- Cleanup ----
+rm -rf "${TMP_DIR}"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped ==="
+
+if [[ ${FAIL} -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements the complete `plugin-obsidian` package — a new install scenario that bootstraps a read-only Obsidian vault mirror with Dataview, Mermaid, Excalidraw and canonical frontmatter support.

Closes #537

### What's included

- **Plugin scaffold** (`packages/plugin-obsidian/`) with schema 2.0 manifest, npm package, peer dep on plugin-core
- **Sync engine** — cross-platform rsync-based unidirectional sync (project → vault)
  - Shell script (`sync-to-obsidian.sh`, 533 lines) + Node.js fallback (`sync-to-obsidian.js`)
  - Modes: one-shot, `--watch` (inotifywait/fswatch), `--check` (dry-run), `--safe-mode`
  - Maps `.claude/*` dotfolders to visible vault paths (Obsidian ignores dotfolders)
- **Setup wizard** (`obsidian:setup`) — environment detection (WSL2/macOS/Linux), config persistence, template generation, frontmatter application, `.claude/issues/` migration with symlink
- **Doctor diagnostics** (`obsidian:doctor`) — 5 canonical checks: missing tools, vault path, dotfolder issues, Dataview prefix, broken symlinks
- **Templates** — MOC, Dashboard, issue/prd/epic Templater templates, Mermaid architecture diagram, Excalidraw whiteboard stub, canonical frontmatter schema
- **Installer wiring** — new `obsidian` scenario (option 7) in `install.js`, post-install check row, CLAUDE.md fragment
- **Documentation** — full user guide (`docs/plugins/obsidian.md`), troubleshooting matrix, CHANGELOG entry, README updates

### Sub-issues (all closed)

- #538 Plugin scaffold and manifest
- #539 Sync engine (shell script)
- #540 Sync engine (Node.js fallback)
- #541 Templates and canonical frontmatter
- #542 Setup wizard command and backend
- #543 Doctor diagnostics command
- #544 Installer wiring and post-install check
- #545 Obsidian sync command (slash command wrapper)
- #546 Documentation and CHANGELOG

## Test plan

- [x] 95 tests passing across 6 test suites (docs: 7, doctor: 17, installer: 8, setup: 18, node-sync: 26, templates: 19)
- [x] 9 bash basic tests + 23 bats tests for shell sync engine
- [x] Plugin manifest validates (`node -e "require('./plugin.json')"`)
- [x] Plugin resolves in installer filesystem scan (14 plugins detected)
- [x] Cross-platform sync script: no GNU-only flags
- [ ] Manual: run `autopm install --scenario=obsidian` end-to-end
- [ ] Manual: verify Obsidian opens vault with Dataview queries working
- [ ] Manual: test on WSL2, macOS, Linux-native

🤖 Generated with [Claude Code](https://claude.com/claude-code)