### PR TITLE
chore: release 3.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.23.2] - 2026-04-15
+
+### Changed
+- Bumped dependencies via Dependabot:
+  - `@playwright/mcp` 0.0.68 → 0.0.70 (#536)
+  - `inquirer` 12.11.1 → 13.3.2 (#535)
+  - `marked` 16.4.2 → 17.0.6 (#533)
+  - `c8` 10.x → 11.0.0 (#532)
+  - `actions/setup-node` 4 → 6 (#531)
+  - `actions/deploy-pages` 4 → 5 (#530)
+  - `actions/configure-pages` 4 → 6 (#529)
+
 ## [3.21.0] - 2026-04-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.23.1",
+      "version": "3.23.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump version 3.23.1 → 3.23.2
- Accumulated Dependabot dependency bumps since v3.23.1

## Publish flow
- On merge to `main`, create and push tag `v3.23.2` to trigger `.github/workflows/npm-publish.yml`
- No manual `npm publish` — GitHub Actions only

## Changes since v3.23.1
- `@playwright/mcp` 0.0.68 → 0.0.70 (#536)
- `inquirer` 12.11.1 → 13.3.2 (#535)
- `marked` 16.4.2 → 17.0.6 (#533)
- `c8` → 11.0.0 (#532)
- `actions/setup-node` → 6 (#531)
- `actions/deploy-pages` → 5 (#530)
- `actions/configure-pages` → 6 (#529)

## Test plan
- [ ] CI green on this branch
- [ ] Merge via GitHub UI (manual approval)
- [ ] Push tag `v3.23.2` after merge
- [ ] Verify npm-publish workflow succeeds