### PR TITLE
chore: release 3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.0] - 2026-04-15
+
 ### Added
-- **plugin-obsidian**: `autopm obsidian` CLI subcommands (setup, sync, doctor) — no longer requires Claude Code session
+- **plugin-obsidian**: `autopm obsidian` CLI subcommands (setup, sync, doctor) — no longer requires Claude Code session (#549)
 - **plugin-obsidian**: Quoted path examples per platform (WSL, macOS, Linux) in post-install next steps
 - **plugin-obsidian**: `autopm validate` shows Obsidian vault configuration status
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.23.2",
+      "version": "3.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Summary

Minor release bumping version from 3.23.2 → 3.24.0.

Promotes CHANGELOG `[Unreleased]` entries to `[3.24.0]`.

## Included since 3.23.2

From #549 (merged after 3.23.2):
- **plugin-obsidian**: `autopm obsidian` CLI subcommands (setup, sync, doctor) — no longer requires Claude Code session
- **plugin-obsidian**: Quoted path examples per platform (WSL, macOS, Linux) in post-install next steps
- **plugin-obsidian**: `autopm validate` shows Obsidian vault configuration status

## Files changed

- `package.json` — version bump
- `package-lock.json` — version bump
- `CHANGELOG.md` — promote Unreleased → 3.24.0

## Test plan

- [ ] CI green
- [ ] Copilot review passes
- [ ] npm publish GitHub Action triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)