### PR TITLE
fix(plugin-obsidian): fix script resolution and register all scripts

### DIFF
--- a/lib/cli/commands/obsidian.js
+++ b/lib/cli/commands/obsidian.js
@@ -7,9 +7,6 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-const PLUGIN_DIR = 'packages/plugin-obsidian';
-const SCRIPTS_DIR = path.join(PLUGIN_DIR, 'scripts', 'obsidian');
-
 /**
  * Find project root by walking up from cwd
  */
@@ -26,15 +23,29 @@ function findProjectRoot() {
 }
 
 /**
- * Check if plugin-obsidian is installed
+ * Find scripts directory — checks installed location first, then source repo
+ */
+function findScriptsDir(root) {
+  const installed = path.join(root, '.claude', 'scripts', 'obsidian');
+  if (fs.existsSync(installed)) return installed;
+
+  const source = path.join(root, 'packages', 'plugin-obsidian', 'scripts', 'obsidian');
+  if (fs.existsSync(source)) return source;
+
+  return null;
+}
+
+/**
+ * Check if plugin-obsidian is installed, return scripts dir
  */
 function checkPlugin(root) {
-  const pluginJson = path.join(root, PLUGIN_DIR, 'plugin.json');
-  if (!fs.existsSync(pluginJson)) {
+  const scriptsDir = findScriptsDir(root);
+  if (!scriptsDir) {
     console.error('❌ plugin-obsidian not installed.');
     console.error('   Run: autopm install --scenario=obsidian');
     process.exit(1);
   }
+  return scriptsDir;
 }
 
 /**
@@ -42,9 +53,9 @@ function checkPlugin(root) {
  */
 async function obsidianSetup(argv) {
   const root = findProjectRoot();
-  checkPlugin(root);
+  const scriptsDir = checkPlugin(root);
 
-  const scriptPath = path.join(root, SCRIPTS_DIR, 'setup.js');
+  const scriptPath = path.join(scriptsDir, 'setup.js');
   if (!fs.existsSync(scriptPath)) {
     console.error('❌ Setup script not found:', scriptPath);
     process.exit(1);
@@ -70,11 +81,11 @@ async function obsidianSetup(argv) {
  */
 async function obsidianSync(argv) {
   const root = findProjectRoot();
-  checkPlugin(root);
+  const scriptsDir = checkPlugin(root);
 
   // Prefer shell script, fall back to Node
-  const shPath = path.join(root, SCRIPTS_DIR, 'sync-to-obsidian.sh');
-  const jsPath = path.join(root, SCRIPTS_DIR, 'sync-to-obsidian.js');
+  const shPath = path.join(scriptsDir, 'sync-to-obsidian.sh');
+  const jsPath = path.join(scriptsDir, 'sync-to-obsidian.js');
 
   const args = [];
   if (argv.watch) args.push('--watch');
@@ -107,9 +118,9 @@ async function obsidianSync(argv) {
  */
 async function obsidianDoctor(argv) {
   const root = findProjectRoot();
-  checkPlugin(root);
+  const scriptsDir = checkPlugin(root);
 
-  const scriptPath = path.join(root, SCRIPTS_DIR, 'doctor.js');
+  const scriptPath = path.join(scriptsDir, 'doctor.js');
   if (!fs.existsSync(scriptPath)) {
     console.error('❌ Doctor script not found:', scriptPath);
     process.exit(1);

--- a/packages/plugin-obsidian/plugin.json
+++ b/packages/plugin-obsidian/plugin.json
@@ -21,6 +21,24 @@
   },
   "scripts": [
     {
+      "name": "setup",
+      "file": "scripts/obsidian/setup.js",
+      "description": "Interactive vault configuration wizard",
+      "type": "workflow",
+      "executable": true,
+      "category": "setup",
+      "tags": ["setup", "wizard", "vault"]
+    },
+    {
+      "name": "doctor",
+      "file": "scripts/obsidian/doctor.js",
+      "description": "Diagnostic checks for common integration issues",
+      "type": "utility",
+      "executable": true,
+      "category": "diagnostics",
+      "tags": ["doctor", "diagnostics", "vault"]
+    },
+    {
       "name": "sync-to-obsidian",
       "file": "scripts/obsidian/sync-to-obsidian.sh",
       "description": "Cross-platform rsync-based project-to-vault sync",

--- a/packages/plugin-obsidian/scripts/obsidian/setup.js
+++ b/packages/plugin-obsidian/scripts/obsidian/setup.js
@@ -158,7 +158,12 @@ function substituteTemplate(content, vars) {
 // ─── Template generation ────────────────────────────────────────────
 
 function generateTemplates(vaultDest, prefix, projectRoot) {
-  const templatesDir = join(__dirname, '..', '..', 'templates');
+  // Find templates: check relative to script first, then source repo from project root
+  const candidates = [
+    join(__dirname, '..', '..', 'templates'),
+    join(projectRoot, 'packages', 'plugin-obsidian', 'templates'),
+  ];
+  const templatesDir = candidates.find(d => existsSync(join(d, 'MOC.md.tmpl'))) || candidates[0];
   const createdDate = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
   const projectName = prefix;
 


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented `autopm obsidian setup/sync/doctor` from working after install.

## Bugs fixed

1. **`plugin.json` missing `setup.js` and `doctor.js`** — only sync scripts were registered, so setup and doctor never got copied to `.claude/scripts/obsidian/` during `autopm install`

2. **CLI looked in `packages/` instead of `.claude/`** — `lib/cli/commands/obsidian.js` hardcoded `packages/plugin-obsidian/scripts/obsidian/` which only exists in the source repo, not in user projects. Now checks `.claude/scripts/obsidian/` first (installed location) with fallback to `packages/` (dev)

3. **Template finder matched wrong directory** — `setup.js` used `existsSync(dir)` to find templates, which matched `.claude/templates/` (contains XML files, not Obsidian templates). Now checks for `MOC.md.tmpl` marker file

## Dry-run verified

```
=== SETUP ===
[setup] Generated 7 template files
✅ Obsidian setup complete!

=== DOCTOR ===
✅ rsync, vault path, issues, prefix, symlink — 5 passed, 1 warning

=== SYNC --check ===
[sync] Dry-run mode: showing what would be synced
```

## Test plan

- [x] 95/95 tests pass (6 suites)
- [x] `autopm obsidian setup --vault-path <tmpdir>` generates 7 templates
- [x] `autopm obsidian doctor` runs all 6 checks
- [x] `autopm obsidian sync --check` performs dry-run
- [x] All three work from simulated installed location (`.claude/scripts/obsidian/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)