### PR TITLE
chore: release 3.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.1] - 2026-04-18
+
+### Fixed
+- **plugin-obsidian**: Register `setup.js` and `doctor.js` in plugin manifest — were missing from install (#551)
+- **plugin-obsidian**: CLI resolves scripts from `.claude/scripts/obsidian/` (installed) instead of hardcoded `packages/` path
+- **plugin-obsidian**: Template finder checks for `MOC.md.tmpl` marker instead of matching wrong `.claude/templates/` directory
+
 ## [3.24.0] - 2026-04-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.24.0",
+      "version": "3.24.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Release 3.24.1

### Fixed
- **plugin-obsidian**: Register `setup.js` and `doctor.js` in plugin manifest — were missing from install (#551)
- **plugin-obsidian**: CLI resolves scripts from `.claude/scripts/obsidian/` (installed) instead of hardcoded `packages/` path
- **plugin-obsidian**: Template finder checks for `MOC.md.tmpl` marker instead of matching wrong `.claude/templates/` directory

### After merge
```bash
git checkout main && git pull
git tag v3.24.1
git push origin v3.24.1
```
This triggers `npm-publish.yml` → publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)