### PR TITLE
chore: release 3.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.2] - 2026-04-18
+
+### Fixed
+- **plugin-obsidian**: Auto-convert Windows paths to WSL format (`C:\Users\...` → `/mnt/c/Users/...`) (#553)
+- **plugin-obsidian**: Show helpful hint when vault path uses Windows format on WSL
+
 ## [3.24.1] - 2026-04-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.24.1",
+  "version": "3.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.24.1",
+      "version": "3.24.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.24.1",
+  "version": "3.24.2",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Release 3.24.2

### Fixed
- **plugin-obsidian**: Auto-convert Windows paths to WSL format (#553)

### After merge
Tag and push to publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)