### PR TITLE
chore: release 3.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.25.0] - 2026-04-18
+
+### Added
+- **plugin-obsidian**: `/obsidian:init` command — reads project structure and generates project-aware MOC, Dashboard, templates, and architecture diagrams for Obsidian vault (#555)
+
 ## [3.24.2] - 2026-04-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.24.2",
+  "version": "3.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.24.2",
+      "version": "3.25.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.24.2",
+  "version": "3.25.0",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Release 3.25.0

### Added
- **plugin-obsidian**: `/obsidian:init` command — project-aware vault file generation (#555)

### After merge
Tag and push to publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)