### PR TITLE
fix(pm): standardize task file lookup for sequential naming #557

### DIFF
--- a/.claude/commands/pm:issue-analyze.md
+++ b/.claude/commands/pm:issue-analyze.md
@@ -1,0 +1,209 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# Issue Analyze
+
+Analyze an issue to identify parallel work streams for maximum efficiency.
+
+## Usage
+```
+/pm:issue-analyze <issue_number>
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before analyzing issues, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/issue-analysis` - Issue analysis and breakdown patterns
+- `mcp://context7/agile/parallel-work` - Parallel work stream identification
+- `mcp://context7/project-management/task-dependencies` - Dependency analysis
+- `mcp://context7/agile/estimation` - Effort estimation techniques
+- `mcp://context7/collaboration/conflict-resolution` - File conflict detection
+
+**Why This is Required:**
+- Ensures accurate parallel work stream identification
+- Applies proven patterns for conflict risk assessment
+- Validates dependency analysis against best practices
+- Prevents inefficient parallelization strategies
+
+## Quick Check
+
+1. **Find local task file:**
+   ```bash
+   # Primary: search frontmatter for github issue URL (works with any filename)
+   task_file=$(grep -rl "github:.*issues/$ARGUMENTS" .claude/epics/ 2>/dev/null | head -1)
+   if [ -z "$task_file" ]; then
+     # Fallback: check for issue-number filename
+     task_file=$(find .claude/epics -name "$ARGUMENTS.md" 2>/dev/null | head -1)
+   fi
+   ```
+   - If not found: "❌ No local task for issue #$ARGUMENTS. Run: /pm:import first"
+   - Use `$task_file` as the canonical path for ALL subsequent steps
+
+2. **Check for existing analysis:**
+   ```bash
+   test -f .claude/epics/*/$ARGUMENTS-analysis.md && echo "⚠️ Analysis already exists. Overwrite? (yes/no)"
+   ```
+
+## Instructions
+
+### 1. Read Issue Context
+
+Get issue details from GitHub:
+```bash
+gh issue view $ARGUMENTS --json title,body,labels
+```
+
+Read local task file to understand:
+- Technical requirements
+- Acceptance criteria
+- Dependencies
+- Effort estimate
+
+### 2. Identify Parallel Work Streams
+
+Analyze the issue to identify independent work that can run in parallel:
+
+**Common Patterns:**
+- **Database Layer**: Schema, migrations, models
+- **Service Layer**: Business logic, data access
+- **API Layer**: Endpoints, validation, middleware
+- **UI Layer**: Components, pages, styles
+- **Test Layer**: Unit tests, integration tests
+- **Documentation**: API docs, README updates
+
+**Key Questions:**
+- What files will be created/modified?
+- Which changes can happen independently?
+- What are the dependencies between changes?
+- Where might conflicts occur?
+
+### 3. Create Analysis File
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Create `.claude/epics/{epic_name}/$ARGUMENTS-analysis.md`:
+
+```markdown
+---
+issue: $ARGUMENTS
+title: {issue_title}
+analyzed: {current_datetime}
+estimated_hours: {total_hours}
+parallelization_factor: {1.0-5.0}
+---
+
+# Parallel Work Analysis: Issue #$ARGUMENTS
+
+## Overview
+{Brief description of what needs to be done}
+
+## Parallel Streams
+
+### Stream A: {Stream Name}
+**Scope**: {What this stream handles}
+**Files**:
+- {file_pattern_1}
+- {file_pattern_2}
+**Agent Type**: {backend|frontend|fullstack|database}-specialist
+**Can Start**: immediately
+**Estimated Hours**: {hours}
+**Dependencies**: none
+
+### Stream B: {Stream Name}
+**Scope**: {What this stream handles}
+**Files**:
+- {file_pattern_1}
+- {file_pattern_2}
+**Agent Type**: {agent_type}
+**Can Start**: immediately
+**Estimated Hours**: {hours}
+**Dependencies**: none
+
+### Stream C: {Stream Name}
+**Scope**: {What this stream handles}
+**Files**:
+- {file_pattern_1}
+**Agent Type**: {agent_type}
+**Can Start**: after Stream A completes
+**Estimated Hours**: {hours}
+**Dependencies**: Stream A
+
+## Coordination Points
+
+### Shared Files
+{List any files multiple streams need to modify}:
+- `src/types/index.ts` - Streams A & B (coordinate type updates)
+- `package.json` - Stream B (add dependencies)
+
+### Sequential Requirements
+{List what must happen in order}:
+1. Database schema before API endpoints
+2. API types before UI components
+3. Core logic before tests
+
+## Conflict Risk Assessment
+- **Low Risk**: Streams work on different directories
+- **Medium Risk**: Some shared type files, manageable with coordination
+- **High Risk**: Multiple streams modifying same core files
+
+## Parallelization Strategy
+
+**Recommended Approach**: {sequential|parallel|hybrid}
+
+{If parallel}: Launch Streams A, B simultaneously. Start C when A completes.
+{If sequential}: Complete Stream A, then B, then C.
+{If hybrid}: Start A & B together, C depends on A, D depends on B & C.
+
+## Expected Timeline
+
+With parallel execution:
+- Wall time: {max_stream_hours} hours
+- Total work: {sum_all_hours} hours
+- Efficiency gain: {percentage}%
+
+Without parallel execution:
+- Wall time: {sum_all_hours} hours
+
+## Notes
+{Any special considerations, warnings, or recommendations}
+```
+
+### 4. Validate Analysis
+
+Ensure:
+- All major work is covered by streams
+- File patterns don't unnecessarily overlap
+- Dependencies are logical
+- Agent types match the work type
+- Time estimates are reasonable
+
+### 5. Output
+
+```
+✅ Analysis complete for issue #$ARGUMENTS
+
+Identified {count} parallel work streams:
+  Stream A: {name} ({hours}h)
+  Stream B: {name} ({hours}h)
+  Stream C: {name} ({hours}h)
+  
+Parallelization potential: {factor}x speedup
+  Sequential time: {total}h
+  Parallel time: {reduced}h
+
+Files at risk of conflict:
+  {list shared files if any}
+
+Next: Start work with /pm:issue-start $ARGUMENTS
+```
+
+## Important Notes
+
+- Analysis is local only - not synced to GitHub
+- Focus on practical parallelization, not theoretical maximum
+- Consider agent expertise when assigning streams
+- Account for coordination overhead in estimates
+- Prefer clear separation over maximum parallelization

--- a/.claude/commands/pm:issue-close.md
+++ b/.claude/commands/pm:issue-close.md
@@ -1,0 +1,126 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# Issue Close
+
+Mark an issue as complete and close it on GitHub.
+
+## Usage
+```
+/pm:issue-close <issue_number> [completion_notes]
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Find Local Task File
+
+```bash
+# Primary: search frontmatter for github issue URL (works with any filename)
+task_file=$(grep -rl "github:.*issues/$ARGUMENTS" .claude/epics/ 2>/dev/null | head -1)
+if [ -z "$task_file" ]; then
+  # Fallback: check for issue-number filename
+  task_file=$(find .claude/epics -name "$ARGUMENTS.md" 2>/dev/null | head -1)
+fi
+```
+If not found: "❌ No local task for issue #$ARGUMENTS"
+Use `$task_file` as the canonical path for ALL subsequent steps.
+
+### 2. Update Local Status
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Update task file frontmatter:
+```yaml
+status: closed
+updated: {current_datetime}
+```
+
+### 3. Update Progress File
+
+If progress file exists at `.claude/epics/{epic}/updates/$ARGUMENTS/progress.md`:
+- Set completion: 100%
+- Add completion note with timestamp
+- Update last_sync with current datetime
+
+### 4. Close on GitHub
+
+Add completion comment and close:
+```bash
+# Add final comment
+echo "✅ Task completed
+
+$ARGUMENTS
+
+---
+Closed at: {timestamp}" | gh issue comment $ARGUMENTS --body-file -
+
+# Close the issue
+gh issue close $ARGUMENTS
+```
+
+### 5. Update Epic Task List on GitHub
+
+Check the task checkbox in the epic issue:
+
+```bash
+# Get epic name from local task file path
+epic_name={extract_from_path}
+
+# Get epic issue number from epic.md
+epic_issue=$(grep 'github:' .claude/epics/$epic_name/epic.md | grep -oE '[0-9]+$')
+
+if [ ! -z "$epic_issue" ]; then
+  # Get current epic body
+  gh issue view $epic_issue --json body -q .body > /tmp/epic-body.md
+  
+  # Check off this task
+  sed -i "s/- \[ \] #$ARGUMENTS/- [x] #$ARGUMENTS/" /tmp/epic-body.md
+  
+  # Update epic issue
+  gh issue edit $epic_issue --body-file /tmp/epic-body.md
+  
+  echo "✓ Updated epic progress on GitHub"
+fi
+```
+
+### 6. Update Epic Progress
+
+- Count total tasks in epic
+- Count closed tasks
+- Calculate new progress percentage
+- Update epic.md frontmatter progress field
+
+### 7. Output
+
+```
+✅ Closed issue #$ARGUMENTS
+  Local: Task marked complete
+  GitHub: Issue closed & epic updated
+  Epic progress: {new_progress}% ({closed}/{total} tasks complete)
+  
+Next: Run /pm:next for next priority task
+```
+
+## Important Notes
+
+Follow `/rules/frontmatter-operations.md` for updates.
+Follow `/rules/github-operations.md` for GitHub commands.
+Always sync local state before GitHub.

--- a/.claude/commands/pm:issue-edit.md
+++ b/.claude/commands/pm:issue-edit.md
@@ -1,0 +1,99 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# Issue Edit
+
+Edit issue details locally and on GitHub.
+
+## Usage
+```
+/pm:issue-edit <issue_number>
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Get Current Issue State
+
+```bash
+# Get from GitHub
+gh issue view $ARGUMENTS --json title,body,labels
+
+# Find local task file (frontmatter-first, filename-fallback)
+# Primary: search frontmatter for github issue URL (works with any filename)
+task_file=$(grep -rl "github:.*issues/$ARGUMENTS" .claude/epics/ 2>/dev/null | head -1)
+if [ -z "$task_file" ]; then
+  # Fallback: check for issue-number filename
+  task_file=$(find .claude/epics -name "$ARGUMENTS.md" 2>/dev/null | head -1)
+fi
+# Use $task_file as canonical path for all subsequent steps
+```
+
+### 2. Interactive Edit
+
+Ask user what to edit:
+- Title
+- Description/Body
+- Labels
+- Acceptance criteria (local only)
+- Priority/Size (local only)
+
+### 3. Update Local File
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Update task file with changes:
+- Update frontmatter `name` if title changed
+- Update body content if description changed
+- Update `updated` field with current datetime
+
+### 4. Update GitHub
+
+If title changed:
+```bash
+gh issue edit $ARGUMENTS --title "{new_title}"
+```
+
+If body changed:
+```bash
+gh issue edit $ARGUMENTS --body-file {updated_task_file}
+```
+
+If labels changed:
+```bash
+gh issue edit $ARGUMENTS --add-label "{new_labels}"
+gh issue edit $ARGUMENTS --remove-label "{removed_labels}"
+```
+
+### 5. Output
+
+```
+✅ Updated issue #$ARGUMENTS
+  Changes:
+    {list_of_changes_made}
+  
+Synced to GitHub: ✅
+```
+
+## Important Notes
+
+Always update local first, then GitHub.
+Preserve frontmatter fields not being edited.
+Follow `/rules/frontmatter-operations.md`.

--- a/.claude/commands/pm:issue-reopen.md
+++ b/.claude/commands/pm:issue-reopen.md
@@ -1,0 +1,95 @@
+---
+allowed-tools: Bash, Read, Write, LS
+---
+
+# Issue Reopen
+
+Reopen a closed issue.
+
+## Usage
+```
+/pm:issue-reopen <issue_number> [reason]
+```
+
+## Required Documentation Access
+
+**MANDATORY:** Before project management workflows, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/epic-management` - epic management best practices
+- `mcp://context7/project-management/issue-tracking` - issue tracking best practices
+- `mcp://context7/agile/task-breakdown` - task breakdown best practices
+- `mcp://context7/project-management/workflow` - workflow best practices
+
+**Why This is Required:**
+- Ensures adherence to current industry standards and best practices
+- Prevents outdated or incorrect implementation patterns
+- Provides access to latest framework/tool documentation
+- Reduces errors from stale knowledge or assumptions
+
+
+## Instructions
+
+### 1. Find Local Task File
+
+```bash
+# Primary: search frontmatter for github issue URL (works with any filename)
+task_file=$(grep -rl "github:.*issues/$ARGUMENTS" .claude/epics/ 2>/dev/null | head -1)
+if [ -z "$task_file" ]; then
+  # Fallback: check for issue-number filename
+  task_file=$(find .claude/epics -name "$ARGUMENTS.md" 2>/dev/null | head -1)
+fi
+```
+If not found: "❌ No local task for issue #$ARGUMENTS"
+Use `$task_file` as the canonical path for ALL subsequent steps.
+
+### 2. Update Local Status
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Update task file frontmatter:
+```yaml
+status: open
+updated: {current_datetime}
+```
+
+### 3. Reset Progress
+
+If progress file exists:
+- Keep original started date
+- Reset completion to previous value or 0%
+- Add note about reopening with reason
+
+### 4. Reopen on GitHub
+
+```bash
+# Reopen with comment
+echo "🔄 Reopening issue
+
+Reason: $ARGUMENTS
+
+---
+Reopened at: {timestamp}" | gh issue comment $ARGUMENTS --body-file -
+
+# Reopen the issue
+gh issue reopen $ARGUMENTS
+```
+
+### 5. Update Epic Progress
+
+Recalculate epic progress with this task now open again.
+
+### 6. Output
+
+```
+🔄 Reopened issue #$ARGUMENTS
+  Reason: {reason_if_provided}
+  Epic progress: {updated_progress}%
+  
+Start work with: /pm:issue-start $ARGUMENTS
+```
+
+## Important Notes
+
+Preserve work history in progress files.
+Don't delete previous progress, just reset status.

--- a/.claude/commands/pm:issue-start.md
+++ b/.claude/commands/pm:issue-start.md
@@ -1,0 +1,269 @@
+---
+allowed-tools: Bash, Read, Write, LS, Task
+---
+
+# Issue Start
+
+Begin work on a GitHub issue with parallel agents based on work stream analysis.
+
+## Usage
+```
+/pm:issue-start <issue_number> [--analyze]
+```
+
+## Argument Parsing
+
+**CRITICAL**: `$ARGUMENTS` may contain both the issue number and flags (e.g. `123 --analyze`).
+Always extract the issue number and flags separately before proceeding:
+
+```bash
+# Extract issue number (first numeric argument) and flags from $ARGUMENTS
+ISSUE_NUMBER=$(echo "$ARGUMENTS" | grep -oE '^[0-9]+')
+HAS_ANALYZE=$(echo "$ARGUMENTS" | grep -q '\-\-analyze' && echo "true" || echo "false")
+```
+
+All subsequent steps MUST use `$ISSUE_NUMBER` (not raw `$ARGUMENTS`) wherever an issue number is expected.
+
+## Quick Check
+
+1. **Get issue details:**
+   ```bash
+   gh issue view $ISSUE_NUMBER --json state,title,labels,body
+   ```
+   If it fails: "❌ Cannot access issue #$ISSUE_NUMBER. Check number or run: gh auth login"
+
+2. **Find local task file:**
+   ```bash
+   # Primary: search frontmatter for github issue URL (works with any filename)
+   task_file=$(grep -rl "github:.*issues/$ISSUE_NUMBER" .claude/epics/ 2>/dev/null | head -1)
+   if [ -z "$task_file" ]; then
+     # Fallback: check for issue-number filename
+     task_file=$(find .claude/epics -name "$ISSUE_NUMBER.md" 2>/dev/null | head -1)
+   fi
+   ```
+   - If not found: "❌ No local task for issue #$ISSUE_NUMBER. This issue may have been created outside the PM system."
+   - Use `$task_file` as the canonical path for ALL subsequent steps
+
+3. **Check for analysis (when NOT using --analyze flag):**
+   - Extract epic name from `$task_file` path: `epic_name=$(echo "$task_file" | sed 's|.claude/epics/||' | cut -d/ -f1)`
+   - If `$HAS_ANALYZE` is "false", check if analysis file exists
+   - Analysis file location: `.claude/epics/$epic_name/$ISSUE_NUMBER-analysis.md`
+   - If no analysis AND `$HAS_ANALYZE` is "false": Stop and suggest using `--analyze` flag
+
+## Required Documentation Access
+
+**MANDATORY:** Before starting work on issues, query Context7 for best practices:
+
+**Documentation Queries:**
+- `mcp://context7/agile/issue-planning` - Issue planning and breakdown
+- `mcp://context7/tdd/workflow` - Test-Driven Development workflow
+- `mcp://context7/git/branching` - Git branching strategies
+- `mcp://context7/collaboration/parallel-work` - Parallel development patterns
+
+**Why This is Required:**
+- Ensures work follows current TDD best practices
+- Applies proven patterns for parallel development
+- Validates task coordination strategies
+- Prevents common pitfalls in distributed work
+
+## TDD REMINDER - READ THIS FIRST
+
+**CRITICAL: This project follows Test-Driven Development (TDD).**
+
+Before ANY coding work begins, you MUST follow the RED-GREEN-REFACTOR cycle:
+
+1. **RED Phase**: Write failing test that describes the desired behavior
+2. **GREEN Phase**: Write minimum code to make test pass
+3. **REFACTOR Phase**: Clean up code while keeping tests green
+
+**For this issue:**
+- Read the task requirements from the task file
+- Identify what tests are needed BEFORE any implementation
+- All agents must start with test creation
+- No implementation without tests first
+
+See `.claude/rules/tdd.enforcement.md` for complete TDD requirements.
+
+---
+
+## Instructions
+
+### 0. Handle --analyze Flag (if provided)
+
+If `$HAS_ANALYZE` is "true", delegate to the Node.js script:
+```bash
+node .claude/scripts/pm/issue-start.cjs $ISSUE_NUMBER --analyze
+```
+
+This script will:
+1. Find the task file for the issue
+2. Generate analysis file with parallel work streams
+3. Create workspace structure
+4. Launch parallel agents based on analysis
+5. Handle all subsequent steps automatically
+
+**STOP HERE** if using `--analyze` flag - the script handles everything.
+
+---
+
+### 1. Ensure Branch Exists (Non-analyze workflow)
+
+Check if epic branch exists:
+```bash
+# Find epic name from task file
+epic_name={extracted_from_path}
+
+# Check branch
+if ! git branch -a | grep -q "epic/$epic_name"; then
+  echo "❌ No branch for epic. Run: /pm:epic-start $epic_name"
+  exit 1
+fi
+
+# Check out the branch
+git checkout epic/$epic_name
+git pull origin epic/$epic_name
+```
+
+### 2. Read Analysis
+
+Read `.claude/epics/{epic_name}/$ISSUE_NUMBER-analysis.md`:
+- Parse parallel streams
+- Identify which can start immediately
+- Note dependencies between streams
+
+### 3. Setup Progress Tracking
+
+Get current datetime: `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+Create workspace structure:
+```bash
+mkdir -p .claude/epics/{epic_name}/updates/$ISSUE_NUMBER
+```
+
+Update task file frontmatter `updated` field with current datetime.
+
+### 4. Launch Parallel Agents
+
+For each stream that can start immediately:
+
+Create `.claude/epics/{epic_name}/updates/$ISSUE_NUMBER/stream-{X}.md`:
+```markdown
+---
+issue: $ISSUE_NUMBER
+stream: {stream_name}
+agent: {agent_type}
+started: {current_datetime}
+status: in_progress
+---
+
+# Stream {X}: {stream_name}
+
+## Scope
+{stream_description}
+
+## Files
+{file_patterns}
+
+## Progress
+- Starting implementation
+```
+
+Launch agent using Task tool:
+```yaml
+Task:
+  description: "Issue #$ISSUE_NUMBER Stream {X}"
+  subagent_type: "{agent_type}"
+  prompt: |
+    **CRITICAL RULE #1: Test-Driven Development (TDD) is MANDATORY**
+
+    You MUST follow the RED-GREEN-REFACTOR cycle:
+    1. **RED**: Write a FAILING test first that describes the desired behavior
+    2. **GREEN**: Write MINIMUM code to make the test pass
+    3. **REFACTOR**: Clean up code while keeping all tests green
+
+    **NO CODE WITHOUT TESTS FIRST.** Zero exceptions.
+    - Every function starts with a test
+    - Every bug fix starts with a test that reproduces it
+    - Every feature starts with failing acceptance tests
+
+    See `.claude/rules/tdd.enforcement.md` for complete requirements.
+
+    ---
+
+    **CRITICAL RULE #2: This project uses 'Docker-first development'.**
+    - All commands (dependency installation, tests, running the application) MUST be executed inside a Docker container using `docker compose run --rm <service_name> <command>`.
+    - DO NOT run `npm`, `pip`, `pytest`, etc., directly on the host.
+    - The source code is mounted as a VOLUME, so file changes will be immediately visible in the container (hot-reloading).
+    - Full rules can be found in `.claude/rules/docker-first-development.md`.
+
+    ---
+
+    You are working on Issue #$ISSUE_NUMBER in the epic branch.
+
+    Branch: epic/{epic_name}
+    Your stream: {stream_name}
+
+    Your scope:
+    - Files to modify: {file_patterns}
+    - Work to complete: {stream_description}
+
+    Requirements:
+    1. Read full task from: .claude/epics/{epic_name}/{task_file}
+    2. **START WITH TESTS**: Write failing tests BEFORE any implementation
+    3. Work ONLY in your assigned files
+    4. Follow TDD cycle: RED (test fails) → GREEN (minimal code) → REFACTOR (cleanup)
+    5. Commit frequently with format: "Issue #$ISSUE_NUMBER: {specific change}"
+    6. Update progress in: .claude/epics/{epic_name}/updates/$ISSUE_NUMBER/stream-{X}.md
+    7. Follow coordination rules in /rules/agent-coordination.md
+
+    If you need to modify files outside your scope:
+    - Check if another stream owns them
+    - Wait if necessary
+    - Update your progress file with coordination notes
+
+    Complete your stream's work and mark as completed when done.
+```
+
+### 5. GitHub Assignment
+
+```bash
+# Assign to self and mark in-progress
+gh issue edit $ISSUE_NUMBER --add-assignee @me --add-label "in-progress"
+```
+
+### 6. Output
+
+```
+Started parallel work on issue #$ISSUE_NUMBER
+
+Epic: {epic_name}
+Branch: epic/{epic_name}
+
+Launching {count} parallel agents:
+  Stream A: {name} (Agent-1) - Started
+  Stream B: {name} (Agent-2) - Started
+  Stream C: {name} - Waiting (depends on A)
+
+Progress tracking:
+  .claude/epics/{epic_name}/updates/$ISSUE_NUMBER/
+
+TDD CHECKLIST - All agents MUST follow:
+  1. RED: Write failing test
+  2. GREEN: Make test pass (minimal code)
+  3. REFACTOR: Clean up code
+
+Monitor with: /pm:epic-status {epic_name}
+Sync updates: /pm:issue-sync $ISSUE_NUMBER
+```
+
+## Error Handling
+
+If any step fails, report clearly:
+- "❌ {What failed}: {How to fix}"
+- Continue with what's possible
+- Never leave partial state
+
+## Important Notes
+
+Follow `/rules/datetime.md` for timestamps.
+Keep it simple - trust that GitHub and file system work.

--- a/.claude/epics/imported/557.md
+++ b/.claude/epics/imported/557.md
@@ -1,0 +1,75 @@
+---
+name: fix-pm-issue-start-sequential-naming
+status: in-progress
+created: 2026-04-19T11:13:22Z
+updated: 2026-04-19T11:18:35Z
+github: https://github.com/rafeekpro/ClaudeAutoPM/issues/557
+imported: true
+---
+
+# fix(pm): issue-start fails to find task files with sequential naming
+
+## Bug Report
+
+### Summary
+
+`/pm:issue-start <issue_number>` fails to locate task files when they use sequential naming (`001.md`, `002.md`) instead of issue-number naming (`45.md`). This is the default output format of `/pm:epic-decompose`.
+
+### Steps to Reproduce
+
+1. Run `/pm:epic-decompose` on an epic — produces files like:
+   ```
+   .claude/epics/issue-refinement-pipeline/
+     ├── 001.md  → #45
+     ├── 002.md  → #46
+     └── ...
+   ```
+2. Run `/pm:issue-start 45`
+3. Command fails with "No local task for issue #45"
+
+### Root Cause
+
+The lookup logic in `pm:issue-start` (`.claude/commands/pm/issue-start.md`) has two steps:
+
+1. **Name-based search**: checks for `.claude/epics/*/45.md` — fails because file is `001.md`
+2. **Frontmatter grep**: searches for `github:.*issues/45` — this **does match** `001.md`, but the result isn't reliably used as the canonical path for all subsequent steps
+
+The two commands have diverged conventions:
+- `pm:epic-decompose` outputs sequential names (`001.md`, `002.md`, ...)
+- `pm:issue-start` expects issue-number names (`45.md`, `46.md`, ...)
+
+### Proposed Fix (Both)
+
+#### A) Update `pm:epic-decompose` to name files by issue number
+
+After GitHub sync assigns issue numbers, rename files from `001.md` → `45.md` (matching their GitHub issue number). This makes the simple lookup work.
+
+#### B) Update `pm:issue-start` lookup to be more resilient
+
+Replace the current two-step lookup with a single robust search:
+
+```bash
+# Find task file by github issue URL in frontmatter
+task_file=$(grep -rl "github:.*issues/45" .claude/epics/ | head -1)
+if [ -z "$task_file" ]; then
+  # Fallback to filename match
+  task_file=$(find .claude/epics -name "45.md" | head -1)
+fi
+if [ -z "$task_file" ]; then
+  echo "❌ No local task for issue #45"
+  exit 1
+fi
+```
+
+This way, regardless of file naming convention, the command finds the right file.
+
+### Affected Commands
+
+- `.claude/commands/pm/issue-start.md` — lookup logic
+- `.claude/commands/pm/epic-decompose.md` — output file naming
+- Potentially also: `pm:issue-sync`, `pm:issue-status`, `pm:issue-close` (any command that looks up task files by issue number)
+
+### Environment
+
+- ClaudeAutoPM version: latest (as of 2026-04-19)
+- Discovered in: paperclip-server project


### PR DESCRIPTION
## Summary
- Standardizes task file lookup across 5 PM commands (`issue-start`, `issue-close`, `issue-reopen`, `issue-edit`, `issue-analyze`) to search frontmatter `github:` URLs first, with issue-number filename as fallback
- Fixes #557 where `pm:issue-start` failed to find task files created by `pm:epic-decompose` using sequential naming (`001.md`, `002.md`) instead of issue-number naming (`45.md`)
- Adds imported task file for issue tracking

## Test plan
- [ ] Run `/pm:issue-start <issue_number>` on an issue whose task file uses sequential naming (e.g. `001.md`) — should find it via frontmatter
- [ ] Run `/pm:issue-start <issue_number>` on an issue whose task file uses issue-number naming (e.g. `45.md`) — should still work via fallback
- [ ] Verify `/pm:issue-close`, `/pm:issue-reopen`, `/pm:issue-edit`, and `/pm:issue-analyze` all resolve task files correctly with both naming conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)