### PR TITLE
chore: release 3.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.25.1] - 2026-04-19
+
+### Fixed
+- **plugin-pm**: Standardize task file lookup across all issue commands to support sequential naming (`001.md`) from `epic-decompose` (#557)
+
 ## [3.25.0] - 2026-04-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.25.0",
+      "version": "3.25.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump version to 3.25.1
- Changelog entry for task file lookup fix (#557)

## Changes since 3.25.0
- **fix(pm)**: Standardize task file lookup across all issue commands to support sequential naming from `epic-decompose` (#558)

🤖 Generated with [Claude Code](https://claude.com/claude-code)