### PR TITLE
chore: add plugin-obsidian to plugin publish workflow

### DIFF
--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -32,6 +32,7 @@ jobs:
           - plugin-pm-azure
           - plugin-pm-github
           - plugin-testing
+          - plugin-obsidian
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Adds `plugin-obsidian` to the plugin-publish.yml matrix so it gets published to npm as `@claudeautopm/plugin-obsidian`.

This enables users to add Obsidian to any existing scenario:
```bash
autopm install              # Select Azure, GitHub, etc.
autopm plugin install obsidian  # Add Obsidian on top
autopm obsidian setup --vault-path "..."
```

### After merge
Trigger the publish workflow manually:
```
gh workflow run plugin-publish.yml -f plugin=plugin-obsidian
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)