### PR TITLE
fix: PluginManager discovers global npm plugins and handles schema v2.0

### DIFF
--- a/bin/commands/plugin.js
+++ b/bin/commands/plugin.js
@@ -266,8 +266,10 @@ async function handleInstall(manager, pluginName, argv) {
     console.log(chalk.gray(`npm package already installed: @claudeautopm/${fullPluginName}`));
   }
 
-  // Install plugin agents
-  console.log(chalk.gray('Installing plugin agents...'));
+  // Discover and install plugin resources
+  console.log(chalk.gray('Discovering plugins...'));
+  await manager.initialize();
+  console.log(chalk.gray('Installing plugin resources...'));
   const result = await manager.installPlugin(fullPluginName);
 
   console.log(chalk.green(`\n✓ Plugin installed successfully!`));

--- a/lib/plugins/PluginManager.js
+++ b/lib/plugins/PluginManager.js
@@ -131,23 +131,64 @@ class PluginManager extends EventEmitter {
   }
 
   /**
-   * Discover all installed plugins in node_modules
+   * Discover all installed plugins in node_modules (local, global, and bundled)
    * Based on npm workspaces pattern from Context7
    */
   async discoverPlugins() {
     const pluginPattern = `${this.options.scopePrefix}/plugin-`;
-    const nodeModulesPath = this.options.pluginDir;
 
+    // Check multiple locations: local node_modules, global npm prefix, bundled packages/
+    const searchPaths = [this.options.pluginDir];
+
+    // Add global npm path
     try {
-      // Check if scoped directory exists
-      const scopePath = path.join(nodeModulesPath, this.options.scopePrefix);
-
-      if (!fs.existsSync(scopePath)) {
-        this.emit('discover:no-plugins', { scopePath });
-        return;
+      const { execSync } = require('child_process');
+      const globalPath = execSync('npm root -g', { encoding: 'utf8' }).trim();
+      if (globalPath && !searchPaths.includes(globalPath)) {
+        searchPaths.push(globalPath);
       }
+    } catch {
+      // npm not available or error — skip global
+    }
 
-      const scopedPackages = fs.readdirSync(scopePath);
+    // Add bundled packages/ directory (for development / autopm source repo)
+    const bundledPath = path.join(this.options.projectRoot, 'packages');
+    if (fs.existsSync(bundledPath)) {
+      // Bundled plugins are at packages/plugin-*/plugin.json (not under @claudeautopm scope)
+      try {
+        const entries = fs.readdirSync(bundledPath);
+        for (const entry of entries) {
+          if (!entry.startsWith('plugin-')) continue;
+          const pluginJsonPath = path.join(bundledPath, entry, 'plugin.json');
+          if (!fs.existsSync(pluginJsonPath)) continue;
+
+          try {
+            const metadata = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+            const fullName = `${this.options.scopePrefix}/${entry}`;
+            if (!this.plugins.has(fullName)) {
+              this.plugins.set(fullName, {
+                name: fullName,
+                path: path.join(bundledPath, entry),
+                metadata,
+                loaded: false
+              });
+              this.emit('discover:found', { name: fullName, source: 'bundled' });
+            }
+          } catch { /* skip invalid */ }
+        }
+      } catch { /* skip unreadable */ }
+    }
+
+    for (const nodeModulesPath of searchPaths) {
+      try {
+        // Check if scoped directory exists
+        const scopePath = path.join(nodeModulesPath, this.options.scopePrefix);
+
+        if (!fs.existsSync(scopePath)) {
+          continue;
+        }
+
+        const scopedPackages = fs.readdirSync(scopePath);
 
       for (const packageName of scopedPackages) {
         if (!packageName.startsWith('plugin-')) {
@@ -186,8 +227,9 @@ class PluginManager extends EventEmitter {
       }
     } catch (error) {
       this.emit('discover:error', { error: error.message });
-      throw new Error(`Plugin discovery failed: ${error.message}`);
+      // Continue to next search path instead of failing
     }
+    } // end for searchPaths
   }
 
   /**
@@ -223,7 +265,10 @@ class PluginManager extends EventEmitter {
    * Implements factory pattern from unplugin Context7 research
    */
   async loadPlugin(pluginName) {
-    const plugin = this.plugins.get(pluginName);
+    let plugin = this.plugins.get(pluginName);
+    if (!plugin && !pluginName.includes('/')) {
+      plugin = this.plugins.get(`${this.options.scopePrefix}/${pluginName}`);
+    }
 
     if (!plugin) {
       throw new Error(`Plugin not found: ${pluginName}`);
@@ -252,7 +297,7 @@ class PluginManager extends EventEmitter {
 
       this.emit('load:complete', {
         name: pluginName,
-        agentCount: plugin.metadata.agents.length
+        agentCount: (plugin.metadata.agents || []).length
       });
 
       return plugin;
@@ -268,7 +313,7 @@ class PluginManager extends EventEmitter {
   async registerAgents(plugin) {
     const { metadata, path: pluginPath } = plugin;
 
-    for (const agentMeta of metadata.agents) {
+    for (const agentMeta of (metadata.agents || [])) {
       const agentId = `${plugin.name}:${agentMeta.name}`;
       const agentFilePath = path.join(pluginPath, agentMeta.file);
 
@@ -302,7 +347,11 @@ class PluginManager extends EventEmitter {
    * Supports: agents, commands, rules, hooks, scripts (Schema v2.0)
    */
   async installPlugin(pluginName) {
-    const plugin = this.plugins.get(pluginName);
+    // Normalize name: accept both "plugin-obsidian" and "@claudeautopm/plugin-obsidian"
+    let plugin = this.plugins.get(pluginName);
+    if (!plugin && !pluginName.includes('/')) {
+      plugin = this.plugins.get(`${this.options.scopePrefix}/${pluginName}`);
+    }
 
     if (!plugin) {
       throw new Error(`Plugin not found: ${pluginName}`);
@@ -451,6 +500,26 @@ class PluginManager extends EventEmitter {
     const installed = [];
 
     for (const command of metadata.commands) {
+      // Handle auto-discovery from subdirectory
+      if (command.subdirectory && command.discovery === 'auto') {
+        const commandsSourceDir = path.join(pluginPath, command.subdirectory);
+        if (fs.existsSync(commandsSourceDir)) {
+          const files = fs.readdirSync(commandsSourceDir).filter(f => f.endsWith('.md'));
+          for (const file of files) {
+            const sourcePath = path.join(commandsSourceDir, file);
+            const targetPath = path.join(targetDir, file);
+            if (!fs.existsSync(targetPath)) {
+              fs.copyFileSync(sourcePath, targetPath);
+              installed.push({ name: file.replace('.md', ''), file: targetPath });
+              this.emit('install:command', { command: file, path: targetPath });
+            }
+          }
+        }
+        continue;
+      }
+
+      // Handle individual command files
+      if (!command.file) continue;
       const sourcePath = path.join(pluginPath, command.file);
       const targetPath = path.join(targetDir, path.basename(command.file));
 


### PR DESCRIPTION
## Summary

Fixes `autopm plugin install obsidian` (and any globally-installed plugin). Four bugs:

1. **Global npm path not searched** — PluginManager only checked local `node_modules/`, never the global npm prefix where `npm install -g` puts packages
2. **Plugin name mismatch** — `installPlugin('plugin-obsidian')` failed because map key is `@claudeautopm/plugin-obsidian`. Now normalizes both forms
3. **No auto-discovery for commands** — `installCommands` expected `command.file` but schema v2.0 uses `subdirectory` + `discovery: "auto"`. Added auto-discovery support
4. **Crash on missing agents array** — `loadPlugin` assumed `metadata.agents` always exists

## Verified

```bash
$ autopm plugin install obsidian

📦 Installing plugin: obsidian

npm package already installed: @claudeautopm/plugin-obsidian
Discovering plugins...
Installing plugin resources...

✓ Plugin installed successfully!

  Obsidian Vault Integration
  Category: integration
```

Commands installed to `.claude/commands/`: `obsidian:init.md`, `obsidian:setup.md`, `obsidian:sync.md`, `obsidian:doctor.md`

## Test plan

- [x] `autopm plugin install obsidian` succeeds after global npm install
- [x] 4 obsidian commands installed to `.claude/commands/`
- [x] 4 obsidian scripts installed to `scripts/obsidian/`
- [x] Existing plugin install flow unchanged (local node_modules still checked first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)