### PR TITLE
chore: release 3.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.25.2] - 2026-04-19
+
+### Fixed
+- **PluginManager**: Discover plugins from global npm path — `autopm plugin install` now works for globally installed plugins (#561)
+- **PluginManager**: Normalize plugin names (accept both `plugin-obsidian` and `@claudeautopm/plugin-obsidian`)
+- **PluginManager**: Handle schema v2.0 auto-discovery for commands subdirectory
+- **PluginManager**: Guard against missing `agents` array in plugin manifest
+
 ## [3.25.1] - 2026-04-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-autopm",
-  "version": "3.25.1",
+  "version": "3.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-autopm",
-      "version": "3.25.1",
+      "version": "3.25.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.25.1",
+  "version": "3.25.2",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [


### PR DESCRIPTION
## Release 3.25.2

### Fixed
- PluginManager discovers global npm plugins — `autopm plugin install obsidian` now works (#561)
- Plugin name normalization, schema v2.0 auto-discovery, missing agents guard

### After merge
Tag and push to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)