### PR TITLE
fix: PluginManager installs scripts to .claude/scripts/

### DIFF
--- a/lib/plugins/PluginManager.js
+++ b/lib/plugins/PluginManager.js
@@ -695,7 +695,7 @@ class PluginManager extends EventEmitter {
    */
   async installScripts(plugin, pluginPath) {
     const { metadata } = plugin;
-    const targetBaseDir = path.join(this.options.projectRoot, 'scripts');
+    const targetBaseDir = path.join(this.options.projectRoot, '.claude', 'scripts');
 
     // Create scripts directory if it doesn't exist
     if (!fs.existsSync(targetBaseDir)) {


### PR DESCRIPTION
## Summary

Scripts from `autopm plugin install` went to `{project}/scripts/` but the CLI (`autopm obsidian setup/sync/doctor`) and the main installer both expect them at `{project}/.claude/scripts/`. One-line fix.

## Test plan

- [x] `autopm plugin install obsidian` puts scripts in `.claude/scripts/obsidian/`
- [x] `autopm obsidian setup --vault-path <tmp>` finds and runs setup.js
- [x] Commands installed to `.claude/commands/` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)