### PR TITLE
fix: getCoreVersion reads autopm version, not user's project version

### DIFF
--- a/lib/plugins/PluginManager.js
+++ b/lib/plugins/PluginManager.js
@@ -1381,13 +1381,27 @@ class PluginManager extends EventEmitter {
    * Get core version from package.json
    */
   getCoreVersion() {
+    // Read autopm framework version, not the user's project version
     try {
-      const pkgPath = path.join(process.cwd(), 'package.json');
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-      return pkg.version || this.options.minCoreVersion;
-    } catch {
-      return this.options.minCoreVersion;
-    }
+      // First try: autopm's own package.json (two levels up from lib/plugins/)
+      const autopmPkgPath = path.join(__dirname, '..', '..', 'package.json');
+      if (fs.existsSync(autopmPkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(autopmPkgPath, 'utf-8'));
+        if (pkg.name === 'claude-autopm') {
+          return pkg.version;
+        }
+      }
+    } catch { /* fall through */ }
+
+    try {
+      // Fallback: check global npm install
+      const { execSync } = require('child_process');
+      const version = execSync('npm list -g claude-autopm --depth=0 2>/dev/null | grep claude-autopm', { encoding: 'utf8' });
+      const match = version.match(/@(\d+\.\d+\.\d+)/);
+      if (match) return match[1];
+    } catch { /* fall through */ }
+
+    return this.options.minCoreVersion;
   }
 
   /**


### PR DESCRIPTION
## Summary

`getCoreVersion()` was reading `package.json` from `process.cwd()` (the user's project) instead of the autopm framework. A user project at v1.0.0 would fail the `>=3.0.0` compatibility check, blocking all plugin installs.

Now reads autopm's own `package.json` (resolved relative to `lib/plugins/`).

## Test plan

- [x] `getCoreVersion()` returns `3.25.3` (not user's project version)
- [x] `autopm plugin install obsidian` succeeds without compatibility error

🤖 Generated with [Claude Code](https://claude.com/claude-code)