### PR TITLE
feat(plugin-obsidian): add wikilink injection for Obsidian Graph View

### DIFF
--- a/lib/cli/commands/obsidian.js
+++ b/lib/cli/commands/obsidian.js
@@ -114,6 +114,35 @@ async function obsidianSync(argv) {
 }
 
 /**
+ * autopm obsidian link
+ */
+async function obsidianLink(argv) {
+  const root = findProjectRoot();
+  checkPlugin(root);
+
+  // Check multiple locations for link-vault.js
+  const candidates = [
+    path.join(root, '.claude', 'scripts', 'obsidian', 'link-vault.js'),
+    path.join(root, 'packages', 'plugin-obsidian', 'scripts', 'obsidian', 'link-vault.js'),
+  ];
+  const scriptPath = candidates.find(p => fs.existsSync(p));
+  if (!scriptPath) {
+    console.error('❌ Link script not found. Reinstall plugin-obsidian.');
+    process.exit(1);
+  }
+
+  const args = ['--project-root', root];
+  if (argv.dryRun) args.push('--dry-run');
+
+  const child = spawn('node', [scriptPath, ...args], {
+    stdio: 'inherit',
+    cwd: root
+  });
+
+  child.on('close', (code) => process.exit(code || 0));
+}
+
+/**
  * autopm obsidian doctor
  */
 async function obsidianDoctor(argv) {
@@ -192,6 +221,21 @@ function builder(yargs) {
       obsidianSync
     )
     .command(
+      'link',
+      'Inject [[wikilinks]] into project files for Obsidian Graph View',
+      (yargs) => {
+        return yargs
+          .option('dry-run', {
+            describe: 'Show what would be linked without modifying files',
+            type: 'boolean',
+            default: false
+          })
+          .example('autopm obsidian link', 'Link all project files')
+          .example('autopm obsidian link --dry-run', 'Preview changes');
+      },
+      obsidianLink
+    )
+    .command(
       'doctor',
       'Diagnose common Obsidian integration issues',
       (yargs) => {
@@ -214,6 +258,7 @@ module.exports = {
     console.log('Commands:');
     console.log('  setup    Configure Obsidian vault integration');
     console.log('  sync     Sync project files to Obsidian vault');
+    console.log('  link     Inject [[wikilinks]] for Graph View');
     console.log('  doctor   Diagnose common integration issues');
     console.log('\nRun autopm obsidian <command> --help for details\n');
   }

--- a/packages/plugin-obsidian/claude-md/obsidian-section.md
+++ b/packages/plugin-obsidian/claude-md/obsidian-section.md
@@ -23,6 +23,20 @@ tags: [relevant, tags]
 ---
 ```
 
+### Wikilinks (MANDATORY)
+
+All markdown files in issues, epics, PRDs, and the vault MUST use `[[wikilinks]]` to connect related content. This powers Obsidian's Graph View.
+
+**Link format:**
+- Issues: `[[issues/NNN|#NNN]]`
+- Epics: `[[epics/{name}/epic|{name}]]`
+- Tasks: `[[epics/{name}/{num}|Task #{num}]]`
+- PRDs: `[[prds/{name}|{name}]]`
+
+**Every markdown file MUST end with a `## Related` section** containing wikilinks to connected content. Never leave orphan files.
+
+**Re-link existing files:** Run `/obsidian:link` or `autopm obsidian link` to scan and inject wikilinks into all project files.
+
 ### Important Rules
 
 - **Never edit files in the Obsidian vault directly** — changes will be overwritten on next sync

--- a/packages/plugin-obsidian/commands/obsidian:init.md
+++ b/packages/plugin-obsidian/commands/obsidian:init.md
@@ -352,9 +352,31 @@ Open this file in Excalidraw to start drawing.
 %%
 ```
 
-### 8. Run Sync
+### 8. Inject Wikilinks
 
-After generating all files, run a sync to push everything to the vault:
+After generating vault files, scan ALL project markdown files (issues, epics, PRDs) and inject `[[wikilinks]]` to connect related content. This powers Obsidian's Graph View.
+
+For each file in `issues/`, `.claude/issues/`, `.claude/epics/`, `.claude/prds/`, `prds/`:
+- Scan for `#NNN` references → convert to `[[issues/NNN|#NNN]]`
+- Scan frontmatter `depends_on` → link to referenced tasks
+- Scan frontmatter `github` → link to issue number
+- Link tasks to their parent epic: `[[epics/{name}/epic|{name}]]`
+- Link PRDs to matching epics if they exist
+- Add or update a `## Related` section at the end of each file with all discovered links
+- **Never overwrite existing content** — only add/update the Related section
+
+```bash
+# Run link script
+if [ -f ".claude/scripts/obsidian/link-vault.js" ]; then
+  node .claude/scripts/obsidian/link-vault.js
+elif [ -f "packages/plugin-obsidian/scripts/obsidian/link-vault.js" ]; then
+  node packages/plugin-obsidian/scripts/obsidian/link-vault.js
+fi
+```
+
+### 9. Run Sync
+
+After generating files and injecting links, sync everything to the vault:
 
 ```bash
 # Find and run sync script
@@ -365,7 +387,7 @@ elif [ -f "packages/plugin-obsidian/scripts/obsidian/sync-to-obsidian.sh" ]; the
 fi
 ```
 
-### 9. Output Summary
+### 10. Output Summary
 
 ```
 Obsidian vault initialized for {project_name}

--- a/packages/plugin-obsidian/commands/obsidian:link.md
+++ b/packages/plugin-obsidian/commands/obsidian:link.md
@@ -1,0 +1,53 @@
+---
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
+# Obsidian Link
+
+Scan all project markdown files and inject `[[wikilinks]]` for Obsidian Graph View.
+
+## Usage
+
+```
+/obsidian:link [--dry-run]
+```
+
+Options:
+- `--dry-run` — Show what would be linked without modifying files
+
+Also available as: `autopm obsidian link`
+
+## Instructions
+
+### 1. Run the link script
+
+```bash
+# Find the script
+if [ -f ".claude/scripts/obsidian/link-vault.js" ]; then
+  node .claude/scripts/obsidian/link-vault.js
+elif [ -f "packages/plugin-obsidian/scripts/obsidian/link-vault.js" ]; then
+  node packages/plugin-obsidian/scripts/obsidian/link-vault.js
+else
+  echo "❌ link-vault.js not found. Reinstall plugin-obsidian."
+  exit 1
+fi
+```
+
+### 2. After linking, run a sync to push changes to the vault
+
+```bash
+if [ -f ".claude/scripts/obsidian/sync-to-obsidian.sh" ]; then
+  bash .claude/scripts/obsidian/sync-to-obsidian.sh
+fi
+```
+
+### 3. Output
+
+```
+[link]  Linked: issues/123.md (3 links)
+[link]  Linked: .claude/epics/auth/001.md (2 links)
+
+42 files linked (87 links) out of 150 scanned
+
+Sync completed. Open Obsidian to see the updated Graph View.
+```

--- a/packages/plugin-obsidian/plugin.json
+++ b/packages/plugin-obsidian/plugin.json
@@ -55,6 +55,15 @@
       "executable": true,
       "category": "sync",
       "tags": ["sync", "node", "vault"]
+    },
+    {
+      "name": "link-vault",
+      "file": "scripts/obsidian/link-vault.js",
+      "description": "Inject wikilinks into project files for Obsidian Graph View",
+      "type": "utility",
+      "executable": true,
+      "category": "linking",
+      "tags": ["wikilinks", "graph", "vault"]
     }
   ],
   "commands": [

--- a/packages/plugin-obsidian/scripts/obsidian/link-vault.js
+++ b/packages/plugin-obsidian/scripts/obsidian/link-vault.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * link-vault.js — Scan project markdown files and inject [[wikilinks]]
+ *
+ * Adds a `## Related` section to each file with wikilinks to connected content.
+ * Scans issues, epics, PRDs for cross-references (#NNN, epic names, PR references).
+ *
+ * Usage:
+ *   node link-vault.js [--project-root DIR] [--dry-run]
+ *
+ * Node built-ins only.
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, basename, dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ─── Output helpers ─────────────────────────────────────────────────
+
+function log(msg)  { process.stdout.write(`[link]  ${msg}\n`); }
+function warn(msg) { process.stderr.write(`[warn]  ${msg}\n`); }
+
+// ─── Argument parsing ───────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { projectRoot: null, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--project-root':
+        args.projectRoot = argv[++i];
+        break;
+      case '--dry-run':
+      case '--check':
+        args.dryRun = true;
+        break;
+      case '-h':
+      case '--help':
+        console.log('Usage: link-vault.js [--project-root DIR] [--dry-run]');
+        console.log('  Scans project files and injects [[wikilinks]] for Obsidian Graph View');
+        process.exit(0);
+    }
+  }
+  return args;
+}
+
+// ─── File discovery ─────────────────────────────────────────────────
+
+function findMarkdownFiles(dir) {
+  const files = [];
+  if (!existsSync(dir)) return files;
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+      files.push(...findMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+// ─── Frontmatter parsing ────────────────────────────────────────────
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      let value = line.slice(colonIdx + 1).trim();
+      // Strip quotes
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      fm[key] = value;
+    }
+  }
+  return fm;
+}
+
+// ─── Reference detection ────────────────────────────────────────────
+
+function findReferences(content, filePath, projectRoot) {
+  const refs = new Set();
+
+  // Find #NNN issue references (not inside wikilinks already)
+  const issueRefs = content.matchAll(/(?<!\[\[)#(\d{1,5})(?!\d)(?!\|)(?!\])/g);
+  for (const match of issueRefs) {
+    const num = match[1];
+    // Check if issue file exists
+    const issueFile = join(projectRoot, 'issues', `${num}.md`);
+    const claudeIssueFile = join(projectRoot, '.claude', 'issues', `${num}.md`);
+    if (existsSync(issueFile) || existsSync(claudeIssueFile)) {
+      refs.add(`[[issues/${num}|#${num}]]`);
+    }
+  }
+
+  // Find epic references in depends_on, parent fields
+  const fm = parseFrontmatter(content);
+
+  if (fm.depends_on) {
+    // Parse array-like: [538, 539]
+    const deps = fm.depends_on.replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean);
+    for (const dep of deps) {
+      // Find which epic this task belongs to
+      const epicDirs = existsSync(join(projectRoot, '.claude', 'epics'))
+        ? readdirSync(join(projectRoot, '.claude', 'epics'))
+        : [];
+      for (const epicName of epicDirs) {
+        const taskFile = join(projectRoot, '.claude', 'epics', epicName, `${dep}.md`);
+        if (existsSync(taskFile)) {
+          refs.add(`[[epics/${epicName}/${dep}|Task #${dep}]]`);
+        }
+      }
+    }
+  }
+
+  if (fm.github && fm.github.includes('/issues/')) {
+    const ghNum = fm.github.match(/\/issues\/(\d+)/);
+    if (ghNum) {
+      refs.add(`[[issues/${ghNum[1]}|#${ghNum[1]}]]`);
+    }
+  }
+
+  // Detect parent epic from file path
+  const relPath = relative(projectRoot, filePath);
+  const epicMatch = relPath.match(/\.claude\/epics\/([^/]+)\//);
+  if (epicMatch) {
+    const epicName = epicMatch[1];
+    const taskNum = basename(filePath, '.md');
+    // Link to parent epic if this is a task file
+    if (/^\d+$/.test(taskNum)) {
+      refs.add(`[[epics/${epicName}/epic|${epicName}]]`);
+    }
+  }
+
+  // Find PRD references
+  if (fm.prd) {
+    refs.add(`[[prds/${fm.prd}|${fm.prd}]]`);
+  }
+
+  return [...refs];
+}
+
+// ─── Wikilink injection ─────────────────────────────────────────────
+
+function injectRelatedSection(content, links) {
+  if (links.length === 0) return { content, changed: false };
+
+  const relatedSection = `\n## Related\n\n${links.map(l => `- ${l}`).join('\n')}\n`;
+
+  // Check if ## Related already exists
+  const relatedIdx = content.indexOf('\n## Related');
+  if (relatedIdx !== -1) {
+    // Find end of existing Related section (next ## heading or EOF)
+    const afterRelated = content.slice(relatedIdx + 1);
+    const nextHeadingIdx = afterRelated.search(/\n## (?!Related)/);
+    const endIdx = nextHeadingIdx !== -1
+      ? relatedIdx + 1 + nextHeadingIdx
+      : content.length;
+
+    // Replace existing Related section
+    const before = content.slice(0, relatedIdx);
+    const after = content.slice(endIdx);
+    return { content: before + relatedSection + after, changed: true };
+  }
+
+  // Append Related section
+  return { content: content.trimEnd() + '\n' + relatedSection, changed: true };
+}
+
+// ─── Main ───────────────────────────────────────────────────────────
+
+function main() {
+  const userArgs = process.argv.slice(2);
+  const args = parseArgs(userArgs);
+
+  const projectRoot = args.projectRoot ? resolve(args.projectRoot) : process.cwd();
+
+  // Directories to scan for wikilink injection
+  const scanDirs = [
+    join(projectRoot, 'issues'),
+    join(projectRoot, '.claude', 'issues'),
+    join(projectRoot, '.claude', 'epics'),
+    join(projectRoot, '.claude', 'prds'),
+    join(projectRoot, 'prds'),
+  ];
+
+  let totalFiles = 0;
+  let linkedFiles = 0;
+  let totalLinks = 0;
+
+  for (const dir of scanDirs) {
+    const files = findMarkdownFiles(dir);
+    for (const filePath of files) {
+      totalFiles++;
+
+      const content = readFileSync(filePath, 'utf8');
+      const links = findReferences(content, filePath, projectRoot);
+
+      if (links.length === 0) continue;
+
+      const { content: newContent, changed } = injectRelatedSection(content, links);
+
+      if (changed) {
+        if (args.dryRun) {
+          log(`Would link: ${relative(projectRoot, filePath)} (${links.length} links)`);
+        } else {
+          writeFileSync(filePath, newContent, 'utf8');
+          log(`Linked: ${relative(projectRoot, filePath)} (${links.length} links)`);
+        }
+        linkedFiles++;
+        totalLinks += links.length;
+      }
+    }
+  }
+
+  console.log('');
+  if (args.dryRun) {
+    console.log(`Dry-run: ${linkedFiles} files would be linked (${totalLinks} links) out of ${totalFiles} scanned`);
+  } else {
+    console.log(`${linkedFiles} files linked (${totalLinks} links) out of ${totalFiles} scanned`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds `[[wikilink]]` injection to plugin-obsidian so Obsidian's Graph View shows connected project content instead of orphan nodes.

## What's new

- **`link-vault.js`** script: scans issues, epics, PRDs for cross-references and injects `[[wikilinks]]` + `## Related` sections
- **`/obsidian:link`** slash command + **`autopm obsidian link`** CLI
- **`/obsidian:init`** now runs wikilink injection as step 8 (before sync)
- **CLAUDE.md fragment** updated with mandatory wikilink rules for ongoing work
- Script registered in `plugin.json` manifest

## Link format

```
Issues: [[issues/NNN|#NNN]]
Epics:  [[epics/{name}/epic|{name}]]
Tasks:  [[epics/{name}/{num}|Task #{num}]]
PRDs:   [[prds/{name}|{name}]]
```

## Test plan

- [x] `autopm obsidian link --dry-run` — 11 files, 40 links detected
- [x] `autopm obsidian link` — injects ## Related sections
- [x] CLI and slash command both work
- [x] `/obsidian:init` includes link step

🤖 Generated with [Claude Code](https://claude.com/claude-code)