### PR TITLE
feat(plugin-pm-github): improve issue import discoverability

### DIFF
--- a/packages/plugin-pm-github/commands/pm:import.md
+++ b/packages/plugin-pm-github/commands/pm:import.md
@@ -8,13 +8,24 @@ Import existing GitHub issues into the PM system.
 
 ## Usage
 ```
-/pm:import [--epic <epic_name>] [--label <label>]
+/pm:import                              # Import all untracked issues
+/pm:import <issue_number>               # Import a single issue
+/pm:import --epic <epic_name>           # Import into specific epic
+/pm:import --label <label>              # Import only issues with specific label
 ```
 
 Options:
+- `<issue_number>` - Import a single issue by number (e.g. `/pm:import 820`)
 - `--epic` - Import into specific epic
 - `--label` - Import only issues with specific label
 - No args - Import all untracked issues
+
+**Common case:** You created an issue via `gh issue create` (or someone else did) and now want to start work on it locally:
+
+```
+/pm:import 820        # Import just issue #820
+/pm:issue-start 820   # Now start work
+```
 
 ## Required Documentation Access
 
@@ -37,14 +48,30 @@ Options:
 
 ### 1. Fetch GitHub Issues
 
+Detect mode from `$ARGUMENTS`:
+
 ```bash
-# Get issues based on filters
-if [[ "$ARGUMENTS" == *"--label"* ]]; then
+# Single-issue mode: $ARGUMENTS is a number (e.g. "820")
+if [[ "$ARGUMENTS" =~ ^[0-9]+$ ]]; then
+  gh issue view "$ARGUMENTS" --json number,title,body,state,labels,createdAt,updatedAt
+
+# Label filter mode
+elif [[ "$ARGUMENTS" == *"--label"* ]]; then
   gh issue list --label "{label}" --limit 1000 --json number,title,body,state,labels,createdAt,updatedAt
+
+# Bulk mode: import all untracked issues
 else
   gh issue list --limit 1000 --json number,title,body,state,labels,createdAt,updatedAt
 fi
 ```
+
+**Single-issue mode behavior:**
+- Skip the "identify untracked" check — user explicitly chose this issue
+- If a local task file already exists for this issue, tell the user and stop:
+  ```
+  ⚠️ Issue #820 is already imported at: .claude/epics/{epic}/820.md
+  ```
+- Otherwise proceed with import (steps 3-5)
 
 ### 2. Identify Untracked Issues
 

--- a/packages/plugin-pm-github/commands/pm:issue-start.md
+++ b/packages/plugin-pm-github/commands/pm:issue-start.md
@@ -22,7 +22,16 @@ Begin work on a GitHub issue with parallel agents based on work stream analysis.
 2. **Find local task file:**
    - First check if `.claude/epics/*/$ARGUMENTS.md` exists (new naming)
    - If not found, search for file containing `github:.*issues/$ARGUMENTS` in frontmatter (old naming)
-   - If not found: "❌ No local task for issue #$ARGUMENTS. This issue may have been created outside the PM system."
+   - If not found, the issue exists on GitHub but isn't tracked locally yet. Tell the user:
+     ```
+     ❌ No local task for issue #$ARGUMENTS.
+
+     This issue exists on GitHub but isn't tracked locally yet.
+     Import it first, then run /pm:issue-start $ARGUMENTS again:
+
+       /pm:import $ARGUMENTS    # Import this single issue
+       /pm:import               # Import all untracked issues
+     ```
 
 3. **Check for analysis (when NOT using --analyze flag):**
    - If user didn't use `--analyze` flag, check if analysis file exists


### PR DESCRIPTION
## Summary

Closes the DX gap where users create issues via \`gh issue create\` and hit a wall when running \`/pm:issue-start\`. The error said the issue might be "outside the PM system" but didn't tell users about the bridge command.

## Changes

1. **\`pm:issue-start\` error message** now explicitly points to \`/pm:import\`:
   \`\`\`
   ❌ No local task for issue #820.

   This issue exists on GitHub but isn't tracked locally yet.
   Import it first, then run /pm:issue-start 820 again:

     /pm:import 820    # Import this single issue
     /pm:import        # Import all untracked issues
   \`\`\`

2. **\`/pm:import\` accepts a single issue number** for targeted imports:
   \`\`\`
   /pm:import 820        # Import just issue #820 (new)
   /pm:import            # Import all untracked (existing)
   /pm:import --label X  # Import by label (existing)
   \`\`\`

## Real-world scenario

> User creates issue #820 via \`gh issue create\`, tries \`/pm:issue-start 820\`, gets confused error, spends 10 min figuring out the right command.

After this fix: error message tells them exactly what to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)