### PR TITLE
Issue #581: Bug: create-task-issues.sh passes labels as comma-separated string, causing gh CLI failure

### DIFF
--- a/.claude/scripts/lib/github-utils.sh
+++ b/.claude/scripts/lib/github-utils.sh
@@ -93,7 +93,7 @@ create_github_issue() {
     check_gh_auth
 
     # Create issue with split label flags
-    local label_flags
+    local -a label_flags
     mapfile -t label_flags < <(build_label_flags "$labels")
     local issue_number
     if ! issue_output=$(gh issue create \
@@ -123,7 +123,7 @@ create_github_subissue() {
     log_info "Creating GitHub sub-issue under #$parent_issue: $title"
 
     # Build split label flags
-    local label_flags
+    local -a label_flags
     mapfile -t label_flags < <(build_label_flags "$labels")
 
     # Check if gh-sub-issue extension is available

--- a/.claude/scripts/lib/github-utils.sh
+++ b/.claude/scripts/lib/github-utils.sh
@@ -60,6 +60,16 @@ check_repo_protection() {
     return 0
 }
 
+# Build separate --label flags from a comma-separated label string
+build_label_flags() {
+    local labels="$1"
+    local IFS=','
+    for label in $labels; do
+        echo "--label"
+        echo "$label"
+    done
+}
+
 # Create GitHub issue with proper error handling
 create_github_issue() {
     local title="$1"
@@ -82,12 +92,14 @@ create_github_issue() {
     # Check authentication
     check_gh_auth
 
-    # Create issue
+    # Create issue with split label flags
+    local label_flags
+    mapfile -t label_flags < <(build_label_flags "$labels")
     local issue_number
     if ! issue_output=$(gh issue create \
         --title "$title" \
         --body-file "$body_file" \
-        --label "$labels" \
+        "${label_flags[@]}" \
         --json number 2>/dev/null); then
         log_error "Failed to create GitHub issue"
         return 1
@@ -110,6 +122,10 @@ create_github_subissue() {
 
     log_info "Creating GitHub sub-issue under #$parent_issue: $title"
 
+    # Build split label flags
+    local label_flags
+    mapfile -t label_flags < <(build_label_flags "$labels")
+
     # Check if gh-sub-issue extension is available
     if gh extension list | grep -q "yahsan2/gh-sub-issue"; then
         local issue_number
@@ -117,7 +133,7 @@ create_github_subissue() {
             --parent "$parent_issue" \
             --title "$title" \
             --body-file "$body_file" \
-            --label "$labels" \
+            "${label_flags[@]}" \
             --json number -q .number 2>/dev/null); then
             log_error "Failed to create GitHub sub-issue"
             return 1

--- a/autopm/.claude/scripts/lib/github-utils.sh
+++ b/autopm/.claude/scripts/lib/github-utils.sh
@@ -93,7 +93,7 @@ create_github_issue() {
     check_gh_auth
 
     # Create issue with split label flags
-    local label_flags
+    local -a label_flags
     mapfile -t label_flags < <(build_label_flags "$labels")
     local issue_number
     if ! issue_output=$(gh issue create \
@@ -123,7 +123,7 @@ create_github_subissue() {
     log_info "Creating GitHub sub-issue under #$parent_issue: $title"
 
     # Build split label flags
-    local label_flags
+    local -a label_flags
     mapfile -t label_flags < <(build_label_flags "$labels")
 
     # Check if gh-sub-issue extension is available

--- a/autopm/.claude/scripts/lib/github-utils.sh
+++ b/autopm/.claude/scripts/lib/github-utils.sh
@@ -60,6 +60,16 @@ check_repo_protection() {
     return 0
 }
 
+# Build separate --label flags from a comma-separated label string
+build_label_flags() {
+    local labels="$1"
+    local IFS=','
+    for label in $labels; do
+        echo "--label"
+        echo "$label"
+    done
+}
+
 # Create GitHub issue with proper error handling
 create_github_issue() {
     local title="$1"
@@ -82,12 +92,14 @@ create_github_issue() {
     # Check authentication
     check_gh_auth
 
-    # Create issue
+    # Create issue with split label flags
+    local label_flags
+    mapfile -t label_flags < <(build_label_flags "$labels")
     local issue_number
     if ! issue_output=$(gh issue create \
         --title "$title" \
         --body-file "$body_file" \
-        --label "$labels" \
+        "${label_flags[@]}" \
         --json number 2>/dev/null); then
         log_error "Failed to create GitHub issue"
         return 1
@@ -110,6 +122,10 @@ create_github_subissue() {
 
     log_info "Creating GitHub sub-issue under #$parent_issue: $title"
 
+    # Build split label flags
+    local label_flags
+    mapfile -t label_flags < <(build_label_flags "$labels")
+
     # Check if gh-sub-issue extension is available
     if gh extension list | grep -q "yahsan2/gh-sub-issue"; then
         local issue_number
@@ -117,7 +133,7 @@ create_github_subissue() {
             --parent "$parent_issue" \
             --title "$title" \
             --body-file "$body_file" \
-            --label "$labels" \
+            "${label_flags[@]}" \
             --json number -q .number 2>/dev/null); then
             log_error "Failed to create GitHub sub-issue"
             return 1

--- a/packages/plugin-core/scripts/lib/github-utils.sh
+++ b/packages/plugin-core/scripts/lib/github-utils.sh
@@ -93,7 +93,7 @@ create_github_issue() {
     check_gh_auth
 
     # Create issue with split label flags
-    local label_flags
+    local -a label_flags
     mapfile -t label_flags < <(build_label_flags "$labels")
     local issue_number
     if ! issue_output=$(gh issue create \
@@ -123,7 +123,7 @@ create_github_subissue() {
     log_info "Creating GitHub sub-issue under #$parent_issue: $title"
 
     # Build split label flags
-    local label_flags
+    local -a label_flags
     mapfile -t label_flags < <(build_label_flags "$labels")
 
     # Check if gh-sub-issue extension is available

--- a/packages/plugin-core/scripts/lib/github-utils.sh
+++ b/packages/plugin-core/scripts/lib/github-utils.sh
@@ -60,6 +60,16 @@ check_repo_protection() {
     return 0
 }
 
+# Build separate --label flags from a comma-separated label string
+build_label_flags() {
+    local labels="$1"
+    local IFS=','
+    for label in $labels; do
+        echo "--label"
+        echo "$label"
+    done
+}
+
 # Create GitHub issue with proper error handling
 create_github_issue() {
     local title="$1"
@@ -82,12 +92,14 @@ create_github_issue() {
     # Check authentication
     check_gh_auth
 
-    # Create issue
+    # Create issue with split label flags
+    local label_flags
+    mapfile -t label_flags < <(build_label_flags "$labels")
     local issue_number
     if ! issue_output=$(gh issue create \
         --title "$title" \
         --body-file "$body_file" \
-        --label "$labels" \
+        "${label_flags[@]}" \
         --json number 2>/dev/null); then
         log_error "Failed to create GitHub issue"
         return 1
@@ -110,6 +122,10 @@ create_github_subissue() {
 
     log_info "Creating GitHub sub-issue under #$parent_issue: $title"
 
+    # Build split label flags
+    local label_flags
+    mapfile -t label_flags < <(build_label_flags "$labels")
+
     # Check if gh-sub-issue extension is available
     if gh extension list | grep -q "yahsan2/gh-sub-issue"; then
         local issue_number
@@ -117,7 +133,7 @@ create_github_subissue() {
             --parent "$parent_issue" \
             --title "$title" \
             --body-file "$body_file" \
-            --label "$labels" \
+            "${label_flags[@]}" \
             --json number -q .number 2>/dev/null); then
             log_error "Failed to create GitHub sub-issue"
             return 1

--- a/packages/plugin-pm/scripts/pm/epic-sync/create-epic-issue.sh
+++ b/packages/plugin-pm/scripts/pm/epic-sync/create-epic-issue.sh
@@ -45,15 +45,15 @@ task_count=$(find ".claude/epics/$EPIC_NAME" -name "[0-9]*.md" -type f 2>/dev/nu
 
 # Detect epic type (bug vs feature)
 if echo "$epic_content" | grep -qi "bug\|fix\|error\|issue"; then
-    labels="epic,bug"
+    epic_type="bug"
 else
-    labels="epic,feature"
+    epic_type="feature"
 fi
 
 # Create issue
 echo "📝 Creating epic issue for: $EPIC_NAME" >&2
 echo "   Tasks: $task_count" >&2
-echo "   Labels: $labels" >&2
+echo "   Labels: epic, $epic_type" >&2
 
 # Write body to temp file for --body-file
 body_tmpfile=$(mktemp /tmp/epic-body-XXXXXX.md)
@@ -71,7 +71,8 @@ EOF
 issue_url=$(gh issue create \
     --title "Epic: $EPIC_NAME" \
     --body-file "$body_tmpfile" \
-    --label "$labels")
+    --label "epic" \
+    --label "$epic_type")
 rm -f "$body_tmpfile"
 
 epic_number=$(echo "$issue_url" | grep -o '[0-9]\+$')

--- a/packages/plugin-pm/scripts/pm/epic-sync/create-task-issues.sh
+++ b/packages/plugin-pm/scripts/pm/epic-sync/create-task-issues.sh
@@ -73,7 +73,8 @@ EOF
     issue_url=$(gh issue create \
         --title "$task_title" \
         --body-file "$body_tmpfile" \
-        --label "task,epic:$EPIC_NAME")
+        --label "task" \
+        --label "epic:$EPIC_NAME")
     rm -f "$body_tmpfile"
 
     issue_number=$(echo "$issue_url" | grep -o '[0-9]\+$')

--- a/test/jest-tests/epic-sync-scripts-jest.test.js
+++ b/test/jest-tests/epic-sync-scripts-jest.test.js
@@ -223,6 +223,71 @@ Just content, no horizontal rules.
     });
   });
 
+  describe('Bug #6: comma-separated labels in --label flag', () => {
+    test('create-task-issues.sh should use separate --label flags', () => {
+      const script = fs.readFileSync(
+        path.join(SCRIPTS_DIR, 'create-task-issues.sh'),
+        'utf8'
+      );
+
+      // Must NOT contain comma-separated labels in a single --label flag
+      expect(script).not.toMatch(/--label\s+"[^"]*,[^"]*"/);
+      // Must have separate --label "task" and --label "epic:
+      expect(script).toMatch(/--label\s+"task"/);
+      expect(script).toMatch(/--label\s+"epic:/);
+    });
+
+    test('create-epic-issue.sh should use separate --label flags', () => {
+      const script = fs.readFileSync(
+        path.join(SCRIPTS_DIR, 'create-epic-issue.sh'),
+        'utf8'
+      );
+
+      // Must NOT contain comma-separated labels in a single --label flag
+      expect(script).not.toMatch(/--label\s+"[^"]*,[^"]*"/);
+      // Must NOT pass $labels as a single --label (which contained comma-separated values)
+      expect(script).not.toMatch(/--label\s+"\$labels"/);
+    });
+
+    test('github-utils.sh create_github_issue should use build_label_flags', () => {
+      const script = fs.readFileSync(
+        path.join(__dirname, '..', '..', '.claude', 'scripts', 'lib', 'github-utils.sh'),
+        'utf8'
+      );
+
+      // Should have a build_label_flags function
+      expect(script).toContain('build_label_flags()');
+      // create_github_issue should NOT use --label "$labels" directly
+      expect(script).not.toMatch(/gh issue create[\s\S]*?--label "\$labels"/);
+      // Should use "${label_flags[@]}" instead
+      expect(script).toContain('"${label_flags[@]}"');
+    });
+
+    test('github-utils.sh create_github_subissue should use build_label_flags', () => {
+      const script = fs.readFileSync(
+        path.join(__dirname, '..', '..', '.claude', 'scripts', 'lib', 'github-utils.sh'),
+        'utf8'
+      );
+
+      // The sub-issue create block should NOT use --label "$labels"
+      const subissueBlock = script.split('create_github_subissue')[1] || '';
+      expect(subissueBlock).not.toMatch(/--label "\$labels"/);
+      // Should use label_flags
+      expect(subissueBlock).toContain('label_flags');
+    });
+
+    test('no comma-separated labels in any epic-sync script', () => {
+      const scriptFiles = fs.readdirSync(SCRIPTS_DIR)
+        .filter(f => f.endsWith('.sh'));
+
+      for (const file of scriptFiles) {
+        const content = fs.readFileSync(path.join(SCRIPTS_DIR, file), 'utf8');
+        const commaLabelMatches = content.match(/--label\s+"[^"]*,[^"]*"/g);
+        expect(commaLabelMatches).toBeNull();
+      }
+    });
+  });
+
   describe('Bug #5: title fallback', () => {
     test('create-task-issues.sh should have separate fallback for empty title', () => {
       const script = fs.readFileSync(

--- a/test/jest-tests/epic-sync-scripts-jest.test.js
+++ b/test/jest-tests/epic-sync-scripts-jest.test.js
@@ -246,7 +246,7 @@ Just content, no horizontal rules.
       // Must NOT contain comma-separated labels in a single --label flag
       expect(script).not.toMatch(/--label\s+"[^"]*,[^"]*"/);
       // Must NOT pass $labels as a single --label (which contained comma-separated values)
-      expect(script).not.toMatch(/--label\s+"\$labels"/);
+      expect(script).not.toMatch(/--label\s+"\$\{?labels\}?"/);
     });
 
     test('github-utils.sh create_github_issue should use build_label_flags', () => {
@@ -258,7 +258,7 @@ Just content, no horizontal rules.
       // Should have a build_label_flags function
       expect(script).toContain('build_label_flags()');
       // create_github_issue should NOT use --label "$labels" directly
-      expect(script).not.toMatch(/gh issue create[\s\S]*?--label "\$labels"/);
+      expect(script).not.toMatch(/gh issue create[\s\S]*?--label "\$\{?labels\}?"/);
       // Should use "${label_flags[@]}" instead
       expect(script).toContain('"${label_flags[@]}"');
     });
@@ -271,7 +271,7 @@ Just content, no horizontal rules.
 
       // The sub-issue create block should NOT use --label "$labels"
       const subissueBlock = script.split('create_github_subissue')[1] || '';
-      expect(subissueBlock).not.toMatch(/--label "\$labels"/);
+      expect(subissueBlock).not.toMatch(/--label "\$\{?labels\}?"/);
       // Should use label_flags
       expect(subissueBlock).toContain('label_flags');
     });


### PR DESCRIPTION
Closes #581

The branch `cortex/issue-581/coder` doesn't exist locally or remotely. Let me check if the changes were made on the current branch or if there's a worktree.

The branch doesn't exist yet. I need to create it with the changes described in the issue. Let me first check the current state of the files that need to be fixed.

None of the target files from the issue spec exist in this repository. The `packages/plugin-pm/`, `packages/plugin-core/`, `autopm/`, `.claude/scripts/lib/`, and `test/jest-tests/` directories are not present. The issue description itself notes this: "the epic-sync scripts do not currently exist in this repository's working tree."

The "Execution Status" claims a coder completed on branch `cortex/issue-581/coder`, but that branch doesn't exist locally or remotely. There's nothing to create a PR from.

The branch `cortex/issue-581/coder` doesn't exist (locally or remotely) and none of the target files referenced in the issue exist in this repository:

- No `packages/plugin-pm/` directory
- No `packages/plugin-core/` directory  
- No `autopm/` directory
- No `.claude/scripts/lib/github-utils.sh`
- No `test/jest-tests/` directory

The issue itself acknowledges this: *"the epic-sync scripts do not currently exist in this repository's working tree."*

The "Execution Status" section claims the coder completed, but the branch was never created. **There is nothing to create a PR from.** The coder task needs to run first to produce the changes before a PR can be opened.