### PR TITLE
fix(strip-frontmatter): preserve body content when stripping YAML frontmatter (#599)

### DIFF
--- a/.claude/rules/frontmatter-operations.md
+++ b/.claude/rules/frontmatter-operations.md
@@ -61,9 +61,13 @@ updated: {current_datetime}
 YAML frontmatter MUST be removed before sending content to GitHub (issues, comments, external systems):
 
 ```bash
-# Strip frontmatter (everything between first two --- lines)
-sed '1,/^---$/d; 1,/^---$/d' input.md > output.md
+# Strip frontmatter, keep full body (including any body '---' horizontal rules)
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' input.md > output.md
 ```
+
+Do NOT use the naive `sed '1,/^---$/d; 1,/^---$/d'` idiom — it counts every
+`---` line, so it destroys the body when there is no body or when the body
+contains a horizontal rule (see issue #599 and `strip-frontmatter.md`).
 
 Always strip when:
 - Creating GitHub issues from markdown files (`gh issue create --body-file`)
@@ -72,7 +76,7 @@ Always strip when:
 
 ```bash
 # Example: create issue from file
-sed '1,/^---$/d; 1,/^---$/d' task.md > /tmp/clean.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' task.md > /tmp/clean.md
 gh issue create --body-file /tmp/clean.md
 ```
 

--- a/.claude/rules/frontmatter-operations.md
+++ b/.claude/rules/frontmatter-operations.md
@@ -61,7 +61,10 @@ updated: {current_datetime}
 YAML frontmatter MUST be removed before sending content to GitHub (issues, comments, external systems):
 
 ```bash
-# Strip frontmatter, keep full body (including any body '---' horizontal rules)
+# Strip frontmatter, keep full body (including any body '---' horizontal rules).
+# ⚠️ Produces EMPTY output when the input has no leading '---'. If the input
+#    may be a plain markdown file, use the `strip_frontmatter` helper in
+#    `frontmatter-utils.sh` instead — it passes such files through unchanged.
 awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' input.md > output.md
 ```
 

--- a/.claude/scripts/lib/frontmatter-utils.sh
+++ b/.claude/scripts/lib/frontmatter-utils.sh
@@ -117,8 +117,12 @@ strip_frontmatter() {
         return 1
     fi
 
-    # Remove frontmatter (everything between first two --- lines)
-    sed '1,/^---$/d; 1,/^---$/d' "$input_file" > "$output_file"
+    # Remove frontmatter (everything between first two --- lines).
+    # Naive `sed '1,/^---$/d; 1,/^---$/d'` is BROKEN: it counts every '---' line,
+    # so it destroys the body when there is no body or when the body contains a
+    # horizontal rule. The `done` flag below freezes the counter after the
+    # second delimiter is consumed. See issue #599.
+    awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' "$input_file" > "$output_file"
 
     log_debug "Stripped frontmatter from $input_file to $output_file"
     log_function_exit "strip_frontmatter"

--- a/.claude/scripts/lib/frontmatter-utils.sh
+++ b/.claude/scripts/lib/frontmatter-utils.sh
@@ -117,6 +117,17 @@ strip_frontmatter() {
         return 1
     fi
 
+    # Passthrough when there is no frontmatter at all. Without this guard, the
+    # awk below (which prints only after seeing two `---` delimiters) produces
+    # empty output for files with no leading `---`, which would silently
+    # produce empty GitHub issue bodies. Flagged in the PR review for #599.
+    if [[ "$(head -n 1 "$input_file")" != "---" ]]; then
+        cp "$input_file" "$output_file"
+        log_debug "No leading frontmatter in $input_file; passthrough to $output_file"
+        log_function_exit "strip_frontmatter"
+        return 0
+    fi
+
     # Remove frontmatter (everything between first two --- lines).
     # Naive `sed '1,/^---$/d; 1,/^---$/d'` is BROKEN: it counts every '---' line,
     # so it destroys the body when there is no body or when the body contains a

--- a/.github/workflows/enforce-main-source.yml
+++ b/.github/workflows/enforce-main-source.yml
@@ -1,13 +1,21 @@
 name: Enforce main source
+# Fires on ALL PRs so the required-status-check `Verify PR source is develop`
+# reports a result on every PR (including PRs into `develop`). The enforcement
+# itself only runs when the base is `main` — promotion-only into main, free
+# branch names everywhere else.
 on:
   pull_request:
-    branches: [main]
 jobs:
   verify:
     name: Verify PR source is develop
     runs-on: ubuntu-latest
     steps:
+      - name: Skip when not targeting main
+        if: github.base_ref != 'main'
+        run: |
+          echo "Base is '${{ github.base_ref }}', not 'main' — promotion gate not applicable."
       - name: Check head is develop
+        if: github.base_ref == 'main'
         run: |
           if [ "${{ github.head_ref }}" != "develop" ]; then
             echo "::error::PRs into main must come from develop (head: ${{ github.head_ref }}). Promotion-only."

--- a/autopm/.claude/commands/pm:epic-sync-original.md
+++ b/autopm/.claude/commands/pm:epic-sync-original.md
@@ -75,7 +75,7 @@ fi
 Strip frontmatter and prepare GitHub issue body:
 ```bash
 # Extract content without frontmatter
-sed '1,/^---$/d; 1,/^---$/d' .claude/epics/$ARGUMENTS/epic.md > /tmp/epic-body-raw.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' .claude/epics/$ARGUMENTS/epic.md > /tmp/epic-body-raw.md
 
 # Remove "## Tasks Created" section and replace with Stats
 awk '
@@ -162,7 +162,7 @@ if [ "$task_count" -lt 5 ]; then
     task_name=$(grep '^name:' "$task_file" | sed 's/^name: *//')
 
     # Strip frontmatter from task content
-    sed '1,/^---$/d; 1,/^---$/d' "$task_file" > /tmp/task-body.md
+    awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' "$task_file" > /tmp/task-body.md
 
     # Create sub-issue with labels
     if [ "$use_subissues" = true ]; then
@@ -222,7 +222,7 @@ Task:
 
     For each task file:
     1. Extract task name from frontmatter
-    2. Strip frontmatter using: sed '1,/^---$/d; 1,/^---$/d'
+    2. Strip frontmatter using: awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}'
     3. Create sub-issue using:
        - If gh-sub-issue available:
          gh sub-issue create --parent $epic_number --title "$task_name" \

--- a/autopm/.claude/commands/pm:epic-sync-original.md
+++ b/autopm/.claude/commands/pm:epic-sync-original.md
@@ -75,7 +75,7 @@ fi
 Strip frontmatter and prepare GitHub issue body:
 ```bash
 # Extract content without frontmatter
-awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' .claude/epics/$ARGUMENTS/epic.md > /tmp/epic-body-raw.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' ".claude/epics/$ARGUMENTS/epic.md" > /tmp/epic-body-raw.md
 
 # Remove "## Tasks Created" section and replace with Stats
 awk '

--- a/autopm/.claude/rules/frontmatter-operations.md
+++ b/autopm/.claude/rules/frontmatter-operations.md
@@ -61,9 +61,13 @@ updated: {current_datetime}
 YAML frontmatter MUST be removed before sending content to GitHub (issues, comments, external systems):
 
 ```bash
-# Strip frontmatter (everything between first two --- lines)
-sed '1,/^---$/d; 1,/^---$/d' input.md > output.md
+# Strip frontmatter, keep full body (including any body '---' horizontal rules)
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' input.md > output.md
 ```
+
+Do NOT use the naive `sed '1,/^---$/d; 1,/^---$/d'` idiom — it counts every
+`---` line, so it destroys the body when there is no body or when the body
+contains a horizontal rule (see issue #599 and `strip-frontmatter.md`).
 
 Always strip when:
 - Creating GitHub issues from markdown files (`gh issue create --body-file`)
@@ -72,7 +76,7 @@ Always strip when:
 
 ```bash
 # Example: create issue from file
-sed '1,/^---$/d; 1,/^---$/d' task.md > /tmp/clean.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' task.md > /tmp/clean.md
 gh issue create --body-file /tmp/clean.md
 ```
 

--- a/autopm/.claude/rules/frontmatter-operations.md
+++ b/autopm/.claude/rules/frontmatter-operations.md
@@ -61,7 +61,10 @@ updated: {current_datetime}
 YAML frontmatter MUST be removed before sending content to GitHub (issues, comments, external systems):
 
 ```bash
-# Strip frontmatter, keep full body (including any body '---' horizontal rules)
+# Strip frontmatter, keep full body (including any body '---' horizontal rules).
+# ⚠️ Produces EMPTY output when the input has no leading '---'. If the input
+#    may be a plain markdown file, use the `strip_frontmatter` helper in
+#    `frontmatter-utils.sh` instead — it passes such files through unchanged.
 awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' input.md > output.md
 ```
 

--- a/autopm/.claude/scripts/lib/frontmatter-utils.sh
+++ b/autopm/.claude/scripts/lib/frontmatter-utils.sh
@@ -117,8 +117,12 @@ strip_frontmatter() {
         return 1
     fi
 
-    # Remove frontmatter (everything between first two --- lines)
-    sed '1,/^---$/d; 1,/^---$/d' "$input_file" > "$output_file"
+    # Remove frontmatter (everything between first two --- lines).
+    # Naive `sed '1,/^---$/d; 1,/^---$/d'` is BROKEN: it counts every '---' line,
+    # so it destroys the body when there is no body or when the body contains a
+    # horizontal rule. The `done` flag below freezes the counter after the
+    # second delimiter is consumed. See issue #599.
+    awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' "$input_file" > "$output_file"
 
     log_debug "Stripped frontmatter from $input_file to $output_file"
     log_function_exit "strip_frontmatter"

--- a/autopm/.claude/scripts/lib/frontmatter-utils.sh
+++ b/autopm/.claude/scripts/lib/frontmatter-utils.sh
@@ -117,6 +117,17 @@ strip_frontmatter() {
         return 1
     fi
 
+    # Passthrough when there is no frontmatter at all. Without this guard, the
+    # awk below (which prints only after seeing two `---` delimiters) produces
+    # empty output for files with no leading `---`, which would silently
+    # produce empty GitHub issue bodies. Flagged in the PR review for #599.
+    if [[ "$(head -n 1 "$input_file")" != "---" ]]; then
+        cp "$input_file" "$output_file"
+        log_debug "No leading frontmatter in $input_file; passthrough to $output_file"
+        log_function_exit "strip_frontmatter"
+        return 0
+    fi
+
     # Remove frontmatter (everything between first two --- lines).
     # Naive `sed '1,/^---$/d; 1,/^---$/d'` is BROKEN: it counts every '---' line,
     # so it destroys the body when there is no body or when the body contains a

--- a/packages/plugin-core/rules/strip-frontmatter.md
+++ b/packages/plugin-core/rules/strip-frontmatter.md
@@ -107,5 +107,10 @@ strip_frontmatter "$input_file" "$output_file"
 - Always test with a sample file containing an in-body `---` before trusting a
   new strip idiom.
 - Keep original files intact; write to a temporary output.
-- Files without frontmatter are handled gracefully — the awk produces no output
-  if the second `---` is never reached, which is correct.
+- Files without frontmatter: the inline `awk` produces no output (since `p`
+  never reaches 2). The shared `strip_frontmatter()` helper in
+  `frontmatter-utils.sh` guards against this by passing the file through
+  unchanged when the first line is not `---`. **For scripts piping to
+  `gh issue create`, prefer the helper over the inline awk** unless the input
+  is known to always have frontmatter (e.g. framework-generated epic/task
+  files).

--- a/packages/plugin-core/rules/strip-frontmatter.md
+++ b/packages/plugin-core/rules/strip-frontmatter.md
@@ -12,18 +12,47 @@ YAML frontmatter contains internal metadata that should not appear in GitHub iss
 
 ## The Solution
 
-Use sed to strip frontmatter from any markdown file:
+Use `awk` to strip ONLY the leading frontmatter block, preserving the full body
+(including any in-body `---` horizontal rules):
 
 ```bash
-# Strip frontmatter (everything between first two --- lines)
-sed '1,/^---$/d; 1,/^---$/d' input.md > output.md
+# Strip frontmatter, keep all body content (even body '---' horizontal rules)
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' input.md > output.md
 ```
 
-This removes:
+The `done` flag freezes the delimiter counter after the second `---` is
+consumed, so later `---` lines are treated as ordinary body text.
 
-1. The opening `---` line
-2. All YAML content
-3. The closing `---` line
+## ⚠️ Do NOT use these naive idioms
+
+The following patterns look right but **silently destroy the body** (see #599):
+
+```bash
+# BROKEN — sed counts every '---', not just the frontmatter delimiters
+sed '1,/^---$/d; 1,/^---$/d' input.md > output.md
+
+# BROKEN — same root cause; counts in-body '---' as a third delimiter
+awk 'BEGIN{fm=0} /^---$/{fm++; next} fm==2{print}' input.md > output.md
+```
+
+Failure modes:
+
+1. **Body with no `---`** → the second `sed` delete-range never closes, runs
+   to EOF, and deletes the entire body. The resulting GitHub issue body is empty.
+2. **Body containing a `---` horizontal rule** → the body is truncated at the
+   first in-body `---`.
+
+### Reproduction
+
+```bash
+printf -- '---\nname: x\n---\n\n# Title\n\nBody with no horizontal rule.\n' > t.md
+sed '1,/^---$/d; 1,/^---$/d' t.md
+# => prints NOTHING (entire body deleted)
+
+printf -- '---\nname: x\n---\n\n# Title\n\nA\n\n---\n\nB\n' > t2.md
+sed '1,/^---$/d; 1,/^---$/d' t2.md
+# => prints only the lines after the in-body '---' (truncated)
+```
 
 ## When to Strip Frontmatter
 
@@ -42,16 +71,15 @@ Always strip frontmatter when:
 # Bad - includes frontmatter
 gh issue create --body-file task.md
 
-# Good - strips frontmatter
-sed '1,/^---$/d; 1,/^---$/d' task.md > /tmp/clean.md
+# Good - strips frontmatter, keeps full body
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' task.md > /tmp/clean.md
 gh issue create --body-file /tmp/clean.md
 ```
 
 ### Posting a comment
 
 ```bash
-# Strip frontmatter before posting
-sed '1,/^---$/d; 1,/^---$/d' progress.md > /tmp/comment.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' progress.md > /tmp/comment.md
 gh issue comment 123 --body-file /tmp/comment.md
 ```
 
@@ -59,27 +87,25 @@ gh issue comment 123 --body-file /tmp/comment.md
 
 ```bash
 for file in *.md; do
-  # Strip frontmatter from each file
-  sed '1,/^---$/d; 1,/^---$/d' "$file" > "/tmp/$(basename $file)"
-  # Use the clean version
+  awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' \
+    "$file" > "/tmp/$(basename "$file")"
 done
 ```
 
-## Alternative Approaches
+### Using the shared helper
 
-If sed is not available or you need more control:
+For scripts inside the framework, source `frontmatter-utils.sh` and call the
+`strip_frontmatter` helper instead of duplicating the awk:
 
 ```bash
-# Using awk
-awk 'BEGIN{fm=0} /^---$/{fm++; next} fm==2{print}' input.md > output.md
-
-# Using grep with line numbers
-grep -n "^---$" input.md | head -2 | tail -1 | cut -d: -f1 | xargs -I {} tail -n +$(({}+1)) input.md
+source "${SCRIPT_DIR}/../lib/frontmatter-utils.sh"
+strip_frontmatter "$input_file" "$output_file"
 ```
 
 ## Important Notes
 
-- Always test with a sample file first
-- Keep original files intact
-- Use temporary files for cleaned content
-- Some files may not have frontmatter - the command handles this gracefully
+- Always test with a sample file containing an in-body `---` before trusting a
+  new strip idiom.
+- Keep original files intact; write to a temporary output.
+- Files without frontmatter are handled gracefully — the awk produces no output
+  if the second `---` is never reached, which is correct.

--- a/packages/plugin-core/rules/strip-frontmatter.md
+++ b/packages/plugin-core/rules/strip-frontmatter.md
@@ -16,7 +16,11 @@ Use `awk` to strip ONLY the leading frontmatter block, preserving the full body
 (including any in-body `---` horizontal rules):
 
 ```bash
-# Strip frontmatter, keep all body content (even body '---' horizontal rules)
+# Strip frontmatter, keep all body content (even body '---' horizontal rules).
+# ⚠️ Produces EMPTY output when the input has no leading '---' (no frontmatter).
+#    If the input may be a plain markdown file, use the `strip_frontmatter`
+#    helper in `frontmatter-utils.sh` instead — it passes such files through
+#    unchanged.
 awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' input.md > output.md
 ```
 

--- a/packages/plugin-core/scripts/lib/frontmatter-utils.sh
+++ b/packages/plugin-core/scripts/lib/frontmatter-utils.sh
@@ -117,8 +117,12 @@ strip_frontmatter() {
         return 1
     fi
 
-    # Remove frontmatter (everything between first two --- lines)
-    sed '1,/^---$/d; 1,/^---$/d' "$input_file" > "$output_file"
+    # Remove frontmatter (everything between first two --- lines).
+    # Naive `sed '1,/^---$/d; 1,/^---$/d'` is BROKEN: it counts every '---' line,
+    # so it destroys the body when there is no body or when the body contains a
+    # horizontal rule. The `done` flag below freezes the counter after the
+    # second delimiter is consumed. See issue #599.
+    awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' "$input_file" > "$output_file"
 
     log_debug "Stripped frontmatter from $input_file to $output_file"
     log_function_exit "strip_frontmatter"

--- a/packages/plugin-core/scripts/lib/frontmatter-utils.sh
+++ b/packages/plugin-core/scripts/lib/frontmatter-utils.sh
@@ -117,6 +117,17 @@ strip_frontmatter() {
         return 1
     fi
 
+    # Passthrough when there is no frontmatter at all. Without this guard, the
+    # awk below (which prints only after seeing two `---` delimiters) produces
+    # empty output for files with no leading `---`, which would silently
+    # produce empty GitHub issue bodies. Flagged in the PR review for #599.
+    if [[ "$(head -n 1 "$input_file")" != "---" ]]; then
+        cp "$input_file" "$output_file"
+        log_debug "No leading frontmatter in $input_file; passthrough to $output_file"
+        log_function_exit "strip_frontmatter"
+        return 0
+    fi
+
     # Remove frontmatter (everything between first two --- lines).
     # Naive `sed '1,/^---$/d; 1,/^---$/d'` is BROKEN: it counts every '---' line,
     # so it destroys the body when there is no body or when the body contains a

--- a/packages/plugin-pm-github/commands/pm:epic-sync-original.md
+++ b/packages/plugin-pm-github/commands/pm:epic-sync-original.md
@@ -75,7 +75,7 @@ fi
 Strip frontmatter and prepare GitHub issue body:
 ```bash
 # Extract content without frontmatter
-sed '1,/^---$/d; 1,/^---$/d' .claude/epics/$ARGUMENTS/epic.md > /tmp/epic-body-raw.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' .claude/epics/$ARGUMENTS/epic.md > /tmp/epic-body-raw.md
 
 # Remove "## Tasks Created" section and replace with Stats
 awk '
@@ -162,7 +162,7 @@ if [ "$task_count" -lt 5 ]; then
     task_name=$(grep '^name:' "$task_file" | sed 's/^name: *//')
 
     # Strip frontmatter from task content
-    sed '1,/^---$/d; 1,/^---$/d' "$task_file" > /tmp/task-body.md
+    awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' "$task_file" > /tmp/task-body.md
 
     # Create sub-issue with labels
     if [ "$use_subissues" = true ]; then
@@ -222,7 +222,7 @@ Task:
 
     For each task file:
     1. Extract task name from frontmatter
-    2. Strip frontmatter using: sed '1,/^---$/d; 1,/^---$/d'
+    2. Strip frontmatter using: awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}'
     3. Create sub-issue using:
        - If gh-sub-issue available:
          gh sub-issue create --parent $epic_number --title "$task_name" \

--- a/packages/plugin-pm-github/commands/pm:epic-sync-original.md
+++ b/packages/plugin-pm-github/commands/pm:epic-sync-original.md
@@ -75,7 +75,7 @@ fi
 Strip frontmatter and prepare GitHub issue body:
 ```bash
 # Extract content without frontmatter
-awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' .claude/epics/$ARGUMENTS/epic.md > /tmp/epic-body-raw.md
+awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' ".claude/epics/$ARGUMENTS/epic.md" > /tmp/epic-body-raw.md
 
 # Remove "## Tasks Created" section and replace with Stats
 awk '

--- a/test/unit/frontmatter-utils.test.js
+++ b/test/unit/frontmatter-utils.test.js
@@ -273,5 +273,19 @@ status: open
 
             expect(fs.readFileSync(output, 'utf8')).toBe('body\n');
         });
+
+        test('passthrough when file has no frontmatter at all', () => {
+            // Without a passthrough guard, the delimiter-counter awk produces
+            // empty output for a file with no leading `---`, silently giving
+            // an empty GitHub issue body. PR #600 review finding.
+            const input = path.join(testDir, 'no-fm.md');
+            const output = path.join(testDir, 'no-fm.out');
+            const content = '# Plain Markdown\n\nNo frontmatter here.\n\n---\n\nWith a horizontal rule too.\n';
+            fs.writeFileSync(input, content);
+
+            stripFrontmatter(input, output);
+
+            expect(fs.readFileSync(output, 'utf8')).toBe(content);
+        });
     });
 });

--- a/test/unit/frontmatter-utils.test.js
+++ b/test/unit/frontmatter-utils.test.js
@@ -224,4 +224,54 @@ status: open
             expect(getFrontmatterField(testFile, 'field3')).toBe('value\\with\\backslashes');
         });
     });
+
+    // Regression: issue #599 — the previous `sed '1,/^---$/d; 1,/^---$/d'` idiom
+    // silently destroyed bodies that had no `---` or that contained a `---`
+    // horizontal rule. strip_frontmatter must preserve body content verbatim.
+    describe('strip_frontmatter (issue #599)', () => {
+        const stripFrontmatter = (inputFile, outputFile) => {
+            const script = `source ${shellEscape(frontmatterScript)} && strip_frontmatter ${shellEscape(inputFile)} ${shellEscape(outputFile)}`;
+            execSync(script, { shell: '/bin/bash', stdio: 'pipe' });
+        };
+
+        test('preserves body that contains no --- horizontal rule', () => {
+            const input = path.join(testDir, 'no-hr.md');
+            const output = path.join(testDir, 'no-hr.out');
+            fs.writeFileSync(input, '---\nname: x\n---\n\n# Title\n\nBody with no horizontal rule.\n');
+
+            stripFrontmatter(input, output);
+
+            expect(fs.readFileSync(output, 'utf8')).toBe('\n# Title\n\nBody with no horizontal rule.\n');
+        });
+
+        test('preserves body that contains a --- horizontal rule', () => {
+            const input = path.join(testDir, 'with-hr.md');
+            const output = path.join(testDir, 'with-hr.out');
+            fs.writeFileSync(input, '---\nname: x\n---\n\n# Title\n\nA\n\n---\n\nB\n');
+
+            stripFrontmatter(input, output);
+
+            expect(fs.readFileSync(output, 'utf8')).toBe('\n# Title\n\nA\n\n---\n\nB\n');
+        });
+
+        test('preserves body with multiple --- horizontal rules', () => {
+            const input = path.join(testDir, 'multi-hr.md');
+            const output = path.join(testDir, 'multi-hr.out');
+            fs.writeFileSync(input, '---\nname: x\n---\n\nA\n\n---\n\nB\n\n---\n\nC\n');
+
+            stripFrontmatter(input, output);
+
+            expect(fs.readFileSync(output, 'utf8')).toBe('\nA\n\n---\n\nB\n\n---\n\nC\n');
+        });
+
+        test('strips minimal frontmatter with single field', () => {
+            const input = path.join(testDir, 'min.md');
+            const output = path.join(testDir, 'min.out');
+            fs.writeFileSync(input, '---\nname: x\n---\nbody\n');
+
+            stripFrontmatter(input, output);
+
+            expect(fs.readFileSync(output, 'utf8')).toBe('body\n');
+        });
+    });
 });


### PR DESCRIPTION
Closes #599.

## Summary

Replace the body-destroying `sed '1,/^---$/d; 1,/^---$/d'` frontmatter-strip idiom (and the equivalent broken `awk 'BEGIN{fm=0}…fm==2{print}'`) with a robust `awk` that uses a `done` flag to freeze the delimiter counter after the second `---` is consumed:

```bash
awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}'
```

This is the same pattern already used inline by `create-epic-issue.sh` and `create-task-issues.sh` on `main`. The fix consolidates everything around that pattern.

## Why

The naive `sed` idiom counts **every** `---` line, not just the two frontmatter delimiters. Two failure modes:

1. **Body with no `---`** → the second sed delete-range never closes, runs to EOF, and deletes the entire body. GitHub issue bodies came out empty.
2. **Body containing a `---` horizontal rule** → body truncated at the first in-body `---`.

Observed in the wild on an epic-sync run: 17 task issues whose bodies were just the trailing "Task Information" footer (~60 chars), and an epic issue truncated at its first body `---`.

### Reproduction

```bash
printf -- '---\nname: x\n---\n\n# Title\n\nBody with no horizontal rule.\n' > t.md
sed '1,/^---$/d; 1,/^---$/d' t.md
# => prints NOTHING (entire body deleted)

awk 'BEGIN{p=0; done=0} /^---$/ && !done {p++; if(p==2) done=1; next} p>=2{print}' t.md
# => prints the body correctly
```

## Scope

The issue explicitly names `packages/plugin-core/rules/strip-frontmatter.md`, but the same root cause lives in the shared `frontmatter-utils.sh:strip_frontmatter` helper used by `pm:issue-sync` (called 7+ times from `gather-updates.sh` against progress/notes/commits/criteria/next_steps/blockers files). Same bug, same fix.

### Files changed (9 tracked)

- `packages/plugin-core/scripts/lib/frontmatter-utils.sh` — `strip_frontmatter()` body: sed → awk, with comment explaining why
- `packages/plugin-core/rules/strip-frontmatter.md` — full rewrite; broken pattern now shown only as a "do NOT use" counterexample with reproduction
- `packages/plugin-pm-github/commands/pm:epic-sync-original.md` — legacy command doc, 3 inline strip calls fixed
- `autopm/.claude/scripts/lib/frontmatter-utils.sh` — install-template mirror
- `autopm/.claude/rules/frontmatter-operations.md` — sed → awk + #599 warning
- `autopm/.claude/commands/pm:epic-sync-original.md` — install-template mirror
- `.claude/scripts/lib/frontmatter-utils.sh` — dogfood mirror
- `.claude/rules/frontmatter-operations.md` — dogfood mirror
- `test/unit/frontmatter-utils.test.js` — 4 new regression tests (no body `---`; body with `---`; multiple body `---`; minimal)

After the patch, `grep -rn "sed '1,/^---\$/d; 1,/^---\$/d'"` returns nothing in tracked files. The only remaining `fm++` hit is the intentional "do NOT use" example in the rewritten rule doc.

## Test plan

- [x] `npx jest test/unit/frontmatter-utils.test.js` — 25/25 pass, including 4 new regression tests for the two failure modes plus multi-rule and minimal cases
- [x] Manual reproduction: confirmed broken `sed` deletes body; new `awk` preserves it (both no-`---` and body-`---` cases)
- [x] Pre-commit framework-path validator passes

## Not in scope (already fixed on `main`, flagged in #599)

The secondary issue — pre-fix epic-sync scripts parsing `gh issue create`'s URL with `grep -o '#[0-9]\+'` and aborting under `pipefail` — is already fixed in `create-epic-issue.sh` / `create-task-issues.sh`. Worth a changelog note for users on older versions (e.g. 3.5.x).