### PR TITLE
chore(release): 3.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.25.5] - 2026-06-09
+
+### Fixed
+- **strip-frontmatter** (`pm:epic-sync`, `pm:issue-sync`): the documented `sed '1,/^---$/d; 1,/^---$/d'` idiom counted every `---` line, silently destroying GitHub issue bodies when the markdown body had no `---` (entire body deleted) or contained a `---` horizontal rule (body truncated). Replaced with a delimiter-counter `awk` that freezes after the second `---`. `strip_frontmatter()` in `frontmatter-utils.sh` now also passes files without a leading `---` through unchanged so plain-markdown inputs don't produce empty issue bodies. Affects `@claudeautopm/plugin-core` and `@claudeautopm/plugin-pm-github`. (#599, #600)
+- **CI** (`enforce-main-source.yml`): workflow now fires on all PRs (not just PRs into `main`) so the required `Verify PR source is develop` status check reports a result on PRs into `develop` too, instead of sitting "expected" and blocking merge. Enforcement still only runs when `base_ref == 'main'`. (#600)
+
+### Dependencies
+- Bump `yaml` from 2.8.3 to 2.9.0 (#598)
+- Bump `markdown-it` from 14.1.1 to 14.2.0 (#597)
+- Bump `@playwright/mcp` from 0.0.70 to 0.0.75 (#596)
+- Bump `fs-extra` from 11.3.4 to 11.3.5 (#595)
+- Bump `mocha` from 11.7.5 to 11.7.6 (dev, #594)
+- Bump `actions/github-script` from 7 to 9 (#593)
+- Bump `axios` from 1.16.0 to 1.17.0 (#590)
+- Bump `jest-extended` from 6.0.0 to 7.0.0 (dev, #589)
+- Bump `js-yaml` from 4.1.1 to 4.2.0 (#588)
+- Bump `@anthropic-ai/sdk` to 0.100.1 (#586)
+- Bump `glob` to 13.0.6 (#585)
+
 ## [3.25.4] - 2026-04-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-autopm",
-  "version": "3.25.4",
+  "version": "3.25.5",
   "description": "Autonomous Project Management Framework for Claude Code - Advanced AI-powered development automation",
   "main": "bin/autopm.js",
   "workspaces": [

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-core",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Core framework functionality for ClaudeAutoPM - universal agents, rules, hooks, and utilities",
   "main": "index.js",
   "type": "module",

--- a/packages/plugin-pm-github/package.json
+++ b/packages/plugin-pm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-pm-github",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "GitHub provider for ClaudeAutoPM PM system",
   "main": "plugin.json",
   "files": [


### PR DESCRIPTION
Release prep for `v3.25.5` — patch release shipping the #599 strip-frontmatter fix (#600) plus the dependabot bumps accumulated since `v3.25.4`.

## Version bumps

| Package | From → To | Reason |
|---|---|---|
| `claude-autopm` (root CLI) | 3.25.4 → **3.25.5** | Touches `autopm/.claude/` install-template files (`frontmatter-utils.sh`, `frontmatter-operations.md`, `pm:epic-sync-original.md`) plus CI workflow gate |
| `@claudeautopm/plugin-core` | 3.13.0 → **3.13.1** | `scripts/lib/frontmatter-utils.sh` changed (consumed by `pm:issue-sync`); `rules/strip-frontmatter.md` rewritten |
| `@claudeautopm/plugin-pm-github` | 3.13.1 → **3.13.2** | `commands/pm:epic-sync-original.md` strip pattern + `$ARGUMENTS` quoting |

Other plugins unchanged → no bumps.

## CHANGELOG

`## [Unreleased]` → `## [3.25.5] - 2026-06-09`, with `### Fixed` for the strip-frontmatter and CI-workflow changes, and `### Dependencies` grouping the dependabot bumps (#585, #586, #588, #589, #590, #593, #594, #595, #596, #597, #598).

## Release flow after merge

1. Merge this PR → `develop` is at 3.25.5
2. Open a promotion PR `develop → main` (the `enforce-main-source.yml` gate requires `head_ref == develop`)
3. Tag `v3.25.5` on `main` → `npm-publish.yml` auto-publishes `claude-autopm`
4. Manually `workflow_dispatch` `plugin-publish.yml` for `plugin-core` (3.13.1) and `plugin-pm-github` (3.13.2)

## Test plan

- [x] `npx jest test/unit/frontmatter-utils.test.js` — 26/26 pass on `develop` tip after #600 merge
- [ ] Smoke-test `npm pack` for each bumped package after merge to verify file lists