### PR TITLE
fix(plugins): PluginManager uninstall path, semver ranges, I/O resilience

### DIFF
--- a/lib/plugins/PluginManager.js
+++ b/lib/plugins/PluginManager.js
@@ -115,35 +115,52 @@ class PluginManager extends EventEmitter {
   }
 
   /**
-   * Copy a file, reporting failure via 'install:file-error' instead of throwing
-   * so a single bad file does not abort the whole installation.
+   * Copy a file (optionally chmod it), reporting failure via
+   * 'install:file-error' instead of throwing so a single bad file does not
+   * abort the whole installation. If chmod fails after a successful copy the
+   * target is removed again, so no half-installed file is left behind to
+   * trip the "already exists" skip on the next install.
    * Returns true on success.
    */
   _safeCopy(sourcePath, targetPath, info, mode) {
     try {
       fs.copyFileSync(sourcePath, targetPath);
-      if (mode !== undefined) {
-        fs.chmodSync(targetPath, mode);
-      }
-      return true;
     } catch (error) {
       this.emit('install:file-error', { ...info, file: sourcePath, target: targetPath, error: error.message });
       return false;
     }
+
+    if (mode !== undefined) {
+      try {
+        fs.chmodSync(targetPath, mode);
+      } catch (error) {
+        try {
+          fs.unlinkSync(targetPath);
+        } catch (cleanupError) {
+          this._debug('install:chmod-rollback', cleanupError);
+        }
+        this.emit('install:file-error', { ...info, file: sourcePath, target: targetPath, error: error.message });
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
-   * Unlink a file if present, reporting failure via 'uninstall:file-error'
-   * instead of throwing so a single bad file does not abort the uninstall.
+   * Unlink a file, reporting failure via 'uninstall:file-error' instead of
+   * throwing so a single bad file does not abort the uninstall.
+   * A missing file counts as success.
    * Returns true on success.
    */
   _safeUnlink(targetPath, info) {
     try {
-      if (fs.existsSync(targetPath)) {
-        fs.unlinkSync(targetPath);
-      }
+      fs.unlinkSync(targetPath);
       return true;
     } catch (error) {
+      if (error.code === 'ENOENT') {
+        return true;
+      }
       this.emit('uninstall:file-error', { ...info, file: targetPath, error: error.message });
       return false;
     }
@@ -949,11 +966,16 @@ class PluginManager extends EventEmitter {
         const targetDir = path.join(this.options.projectRoot, '.claude', 'hooks');
         for (const hook of metadata.hooks) {
           const files = hook.dual && hook.files ? hook.files : [hook.file];
+          let allRemoved = true;
           for (const file of files) {
             const targetPath = path.join(targetDir, path.basename(file));
-            this._safeUnlink(targetPath, { type: 'hook', name: hook.name });
+            if (!this._safeUnlink(targetPath, { type: 'hook', name: hook.name })) {
+              allRemoved = false;
+            }
           }
-          results.hooks.push(hook.name);
+          if (allRemoved) {
+            results.hooks.push(hook.name);
+          }
         }
       }
 
@@ -961,13 +983,16 @@ class PluginManager extends EventEmitter {
       if (metadata.scripts && metadata.scripts.length > 0) {
         const targetBaseDir = path.join(this.options.projectRoot, '.claude', 'scripts');
         for (const script of metadata.scripts) {
+          let allRemoved = true;
           if (script.subdirectory && script.files) {
             // Remove 'scripts/' prefix from subdirectory if present
             const cleanSubdir = script.subdirectory.replace(/^scripts\//, '');
             const targetDir = path.join(targetBaseDir, cleanSubdir);
             for (const file of script.files) {
               const targetPath = path.join(targetDir, file);
-              this._safeUnlink(targetPath, { type: 'script', name: script.name });
+              if (!this._safeUnlink(targetPath, { type: 'script', name: script.name })) {
+                allRemoved = false;
+              }
             }
 
             // Remove empty subdirectory
@@ -982,9 +1007,13 @@ class PluginManager extends EventEmitter {
             // Remove 'scripts/' prefix from file path if present
             const cleanFile = script.file.replace(/^scripts\//, '');
             const targetPath = path.join(targetBaseDir, cleanFile);
-            this._safeUnlink(targetPath, { type: 'script', name: script.name });
+            if (!this._safeUnlink(targetPath, { type: 'script', name: script.name })) {
+              allRemoved = false;
+            }
           }
-          results.scripts.push(script.name);
+          if (allRemoved) {
+            results.scripts.push(script.name);
+          }
         }
       }
 
@@ -1469,7 +1498,10 @@ class PluginManager extends EventEmitter {
     const baseVersion = match[2];
     const cmp = this.compareVersions(currentVersion, baseVersion);
     const [curMajor, curMinor] = currentVersion.split('.').map(Number);
-    const [reqMajor, reqMinor] = baseVersion.split('.').map(Number);
+    const reqParts = baseVersion.split('.').map(Number);
+    const reqMajor = reqParts[0];
+    const reqMinor = reqParts.length > 1 ? reqParts[1] : undefined;
+    const reqPatch = reqParts.length > 2 ? reqParts[2] : undefined;
 
     switch (operator) {
       case '>': return cmp > 0;
@@ -1477,12 +1509,18 @@ class PluginManager extends EventEmitter {
       case '<=': return cmp <= 0;
       case '^':
         if (cmp < 0) return false;
-        // ^0.x.y allows only the same minor; otherwise same major
-        if (reqMajor === 0) return curMajor === 0 && curMinor === (reqMinor || 0);
-        return curMajor === reqMajor;
+        if (reqMajor > 0) return curMajor === reqMajor;
+        // ^0 → any 0.x
+        if (reqMinor === undefined) return curMajor === 0;
+        // ^0.minor / ^0.minor (no patch) → same minor
+        if (reqMinor > 0 || reqPatch === undefined) return curMajor === 0 && curMinor === reqMinor;
+        // ^0.0.patch → only the exact version
+        return cmp === 0;
       case '~':
         if (cmp < 0) return false;
-        return curMajor === reqMajor && curMinor === (reqMinor || 0);
+        // ~major → any minor within the major
+        if (reqMinor === undefined) return curMajor === reqMajor;
+        return curMajor === reqMajor && curMinor === reqMinor;
       case '>=':
       default:
         return cmp >= 0;

--- a/lib/plugins/PluginManager.js
+++ b/lib/plugins/PluginManager.js
@@ -105,6 +105,51 @@ class PluginManager extends EventEmitter {
   }
 
   /**
+   * Emit a debug diagnostic for intentionally suppressed errors
+   * (only when options.debug is enabled)
+   */
+  _debug(context, error) {
+    if (this.options.debug) {
+      this.emit('debug', { context, message: error && error.message ? error.message : String(error) });
+    }
+  }
+
+  /**
+   * Copy a file, reporting failure via 'install:file-error' instead of throwing
+   * so a single bad file does not abort the whole installation.
+   * Returns true on success.
+   */
+  _safeCopy(sourcePath, targetPath, info, mode) {
+    try {
+      fs.copyFileSync(sourcePath, targetPath);
+      if (mode !== undefined) {
+        fs.chmodSync(targetPath, mode);
+      }
+      return true;
+    } catch (error) {
+      this.emit('install:file-error', { ...info, file: sourcePath, target: targetPath, error: error.message });
+      return false;
+    }
+  }
+
+  /**
+   * Unlink a file if present, reporting failure via 'uninstall:file-error'
+   * instead of throwing so a single bad file does not abort the uninstall.
+   * Returns true on success.
+   */
+  _safeUnlink(targetPath, info) {
+    try {
+      if (fs.existsSync(targetPath)) {
+        fs.unlinkSync(targetPath);
+      }
+      return true;
+    } catch (error) {
+      this.emit('uninstall:file-error', { ...info, file: targetPath, error: error.message });
+      return false;
+    }
+  }
+
+  /**
    * Initialize the plugin system
    * Discovers and validates all installed plugins
    */
@@ -135,8 +180,6 @@ class PluginManager extends EventEmitter {
    * Based on npm workspaces pattern from Context7
    */
   async discoverPlugins() {
-    const pluginPattern = `${this.options.scopePrefix}/plugin-`;
-
     // Check multiple locations: local node_modules, global npm prefix, bundled packages/
     const searchPaths = [this.options.pluginDir];
 
@@ -147,8 +190,9 @@ class PluginManager extends EventEmitter {
       if (globalPath && !searchPaths.includes(globalPath)) {
         searchPaths.push(globalPath);
       }
-    } catch {
+    } catch (error) {
       // npm not available or error — skip global
+      this._debug('discover:global-npm-root', error);
     }
 
     // Add bundled packages/ directory (for development / autopm source repo)
@@ -174,9 +218,15 @@ class PluginManager extends EventEmitter {
               });
               this.emit('discover:found', { name: fullName, source: 'bundled' });
             }
-          } catch { /* skip invalid */ }
+          } catch (error) {
+            // skip invalid plugin.json
+            this._debug(`discover:bundled-invalid:${entry}`, error);
+          }
         }
-      } catch { /* skip unreadable */ }
+      } catch (error) {
+        // skip unreadable packages/ directory
+        this._debug('discover:bundled-unreadable', error);
+      }
     }
 
     for (const nodeModulesPath of searchPaths) {
@@ -190,46 +240,46 @@ class PluginManager extends EventEmitter {
 
         const scopedPackages = fs.readdirSync(scopePath);
 
-      for (const packageName of scopedPackages) {
-        if (!packageName.startsWith('plugin-')) {
-          continue;
+        for (const packageName of scopedPackages) {
+          if (!packageName.startsWith('plugin-')) {
+            continue;
+          }
+
+          const pluginPath = path.join(scopePath, packageName);
+          const pluginJsonPath = path.join(pluginPath, 'plugin.json');
+
+          if (!fs.existsSync(pluginJsonPath)) {
+            this.emit('discover:skip', {
+              package: packageName,
+              reason: 'No plugin.json found'
+            });
+            continue;
+          }
+
+          try {
+            const metadata = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+            const fullName = `${this.options.scopePrefix}/${packageName}`;
+
+            this.plugins.set(fullName, {
+              name: fullName,
+              path: pluginPath,
+              metadata,
+              loaded: false
+            });
+
+            this.emit('discover:found', { name: fullName, metadata });
+          } catch (error) {
+            this.emit('discover:error', {
+              package: packageName,
+              error: error.message
+            });
+          }
         }
-
-        const pluginPath = path.join(scopePath, packageName);
-        const pluginJsonPath = path.join(pluginPath, 'plugin.json');
-
-        if (!fs.existsSync(pluginJsonPath)) {
-          this.emit('discover:skip', {
-            package: packageName,
-            reason: 'No plugin.json found'
-          });
-          continue;
-        }
-
-        try {
-          const metadata = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
-          const fullName = `${this.options.scopePrefix}/${packageName}`;
-
-          this.plugins.set(fullName, {
-            name: fullName,
-            path: pluginPath,
-            metadata,
-            loaded: false
-          });
-
-          this.emit('discover:found', { name: fullName, metadata });
-        } catch (error) {
-          this.emit('discover:error', {
-            package: packageName,
-            error: error.message
-          });
-        }
+      } catch (error) {
+        this.emit('discover:error', { error: error.message });
+        // Continue to next search path instead of failing
       }
-    } catch (error) {
-      this.emit('discover:error', { error: error.message });
-      // Continue to next search path instead of failing
     }
-    } // end for searchPaths
   }
 
   /**
@@ -469,7 +519,9 @@ class PluginManager extends EventEmitter {
         continue;
       }
 
-      fs.copyFileSync(agent.filePath, targetPath);
+      if (!this._safeCopy(agent.filePath, targetPath, { type: 'agent', name: agent.name })) {
+        continue;
+      }
       installed.push({
         name: agent.name,
         file: targetPath,
@@ -509,7 +561,9 @@ class PluginManager extends EventEmitter {
             const sourcePath = path.join(commandsSourceDir, file);
             const targetPath = path.join(targetDir, file);
             if (!fs.existsSync(targetPath)) {
-              fs.copyFileSync(sourcePath, targetPath);
+              if (!this._safeCopy(sourcePath, targetPath, { type: 'command', name: file })) {
+                continue;
+              }
               installed.push({ name: file.replace('.md', ''), file: targetPath });
               this.emit('install:command', { command: file, path: targetPath });
             }
@@ -542,7 +596,9 @@ class PluginManager extends EventEmitter {
         continue;
       }
 
-      fs.copyFileSync(sourcePath, targetPath);
+      if (!this._safeCopy(sourcePath, targetPath, { type: 'command', name: command.name })) {
+        continue;
+      }
       installed.push({
         name: command.name,
         file: targetPath,
@@ -595,7 +651,9 @@ class PluginManager extends EventEmitter {
         continue;
       }
 
-      fs.copyFileSync(sourcePath, targetPath);
+      if (!this._safeCopy(sourcePath, targetPath, { type: 'rule', name: rule.name })) {
+        continue;
+      }
       installed.push({
         name: rule.name,
         file: targetPath,
@@ -657,11 +715,9 @@ class PluginManager extends EventEmitter {
           continue;
         }
 
-        fs.copyFileSync(sourcePath, targetPath);
-
-        // Make executable if shell script
-        if (file.endsWith('.sh')) {
-          fs.chmodSync(targetPath, 0o755);
+        const mode = file.endsWith('.sh') ? 0o755 : undefined;
+        if (!this._safeCopy(sourcePath, targetPath, { type: 'hook', name: hook.name }, mode)) {
+          continue;
         }
 
         installedFiles.push(targetPath);
@@ -742,11 +798,9 @@ class PluginManager extends EventEmitter {
             continue;
           }
 
-          fs.copyFileSync(sourcePath, targetPath);
-
-          // Make executable if shell script
-          if (file.endsWith('.sh')) {
-            fs.chmodSync(targetPath, 0o755);
+          const mode = file.endsWith('.sh') ? 0o755 : undefined;
+          if (!this._safeCopy(sourcePath, targetPath, { type: 'script', name: script.name }, mode)) {
+            continue;
           }
 
           installedFiles.push(targetPath);
@@ -801,11 +855,9 @@ class PluginManager extends EventEmitter {
           continue;
         }
 
-        fs.copyFileSync(sourcePath, targetPath);
-
-        // Make executable if shell script
-        if (script.file.endsWith('.sh')) {
-          fs.chmodSync(targetPath, 0o755);
+        const mode = script.file.endsWith('.sh') ? 0o755 : undefined;
+        if (!this._safeCopy(sourcePath, targetPath, { type: 'script', name: script.name }, mode)) {
+          continue;
         }
 
         installed.push({
@@ -855,18 +907,18 @@ class PluginManager extends EventEmitter {
         const targetDir = path.join(this.options.agentDir, metadata.category);
         for (const agent of metadata.agents) {
           const targetPath = path.join(targetDir, path.basename(agent.file));
-          if (fs.existsSync(targetPath)) {
-            fs.unlinkSync(targetPath);
+          if (fs.existsSync(targetPath) && this._safeUnlink(targetPath, { type: 'agent', name: agent.name })) {
             results.agents.push(agent.name);
           }
         }
 
         // Remove empty category directory
-        if (fs.existsSync(targetDir)) {
-          const remaining = fs.readdirSync(targetDir);
-          if (remaining.length === 0) {
+        try {
+          if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length === 0) {
             fs.rmdirSync(targetDir);
           }
+        } catch (error) {
+          this._debug('uninstall:rmdir-agents', error);
         }
       }
 
@@ -875,8 +927,7 @@ class PluginManager extends EventEmitter {
         const targetDir = path.join(this.options.projectRoot, '.claude', 'commands');
         for (const command of metadata.commands) {
           const targetPath = path.join(targetDir, path.basename(command.file));
-          if (fs.existsSync(targetPath)) {
-            fs.unlinkSync(targetPath);
+          if (fs.existsSync(targetPath) && this._safeUnlink(targetPath, { type: 'command', name: command.name })) {
             results.commands.push(command.name);
           }
         }
@@ -887,8 +938,7 @@ class PluginManager extends EventEmitter {
         const targetDir = path.join(this.options.projectRoot, '.claude', 'rules');
         for (const rule of metadata.rules) {
           const targetPath = path.join(targetDir, path.basename(rule.file));
-          if (fs.existsSync(targetPath)) {
-            fs.unlinkSync(targetPath);
+          if (fs.existsSync(targetPath) && this._safeUnlink(targetPath, { type: 'rule', name: rule.name })) {
             results.rules.push(rule.name);
           }
         }
@@ -901,17 +951,15 @@ class PluginManager extends EventEmitter {
           const files = hook.dual && hook.files ? hook.files : [hook.file];
           for (const file of files) {
             const targetPath = path.join(targetDir, path.basename(file));
-            if (fs.existsSync(targetPath)) {
-              fs.unlinkSync(targetPath);
-            }
+            this._safeUnlink(targetPath, { type: 'hook', name: hook.name });
           }
           results.hooks.push(hook.name);
         }
       }
 
-      // Remove scripts
+      // Remove scripts (same target as installScripts: .claude/scripts)
       if (metadata.scripts && metadata.scripts.length > 0) {
-        const targetBaseDir = path.join(this.options.projectRoot, 'scripts');
+        const targetBaseDir = path.join(this.options.projectRoot, '.claude', 'scripts');
         for (const script of metadata.scripts) {
           if (script.subdirectory && script.files) {
             // Remove 'scripts/' prefix from subdirectory if present
@@ -919,25 +967,22 @@ class PluginManager extends EventEmitter {
             const targetDir = path.join(targetBaseDir, cleanSubdir);
             for (const file of script.files) {
               const targetPath = path.join(targetDir, file);
-              if (fs.existsSync(targetPath)) {
-                fs.unlinkSync(targetPath);
-              }
+              this._safeUnlink(targetPath, { type: 'script', name: script.name });
             }
 
             // Remove empty subdirectory
-            if (fs.existsSync(targetDir)) {
-              const remaining = fs.readdirSync(targetDir);
-              if (remaining.length === 0) {
+            try {
+              if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length === 0) {
                 fs.rmdirSync(targetDir);
               }
+            } catch (error) {
+              this._debug('uninstall:rmdir-scripts', error);
             }
           } else if (script.file) {
             // Remove 'scripts/' prefix from file path if present
             const cleanFile = script.file.replace(/^scripts\//, '');
             const targetPath = path.join(targetBaseDir, cleanFile);
-            if (fs.existsSync(targetPath)) {
-              fs.unlinkSync(targetPath);
-            }
+            this._safeUnlink(targetPath, { type: 'script', name: script.name });
           }
           results.scripts.push(script.name);
         }
@@ -1391,7 +1436,10 @@ class PluginManager extends EventEmitter {
           return pkg.version;
         }
       }
-    } catch { /* fall through */ }
+    } catch (error) {
+      // fall through to global npm lookup
+      this._debug('core-version:local-package', error);
+    }
 
     try {
       // Fallback: check global npm install
@@ -1399,25 +1447,46 @@ class PluginManager extends EventEmitter {
       const version = execSync('npm list -g claude-autopm --depth=0 2>/dev/null | grep claude-autopm', { encoding: 'utf8' });
       const match = version.match(/@(\d+\.\d+\.\d+)/);
       if (match) return match[1];
-    } catch { /* fall through */ }
+    } catch (error) {
+      // fall through to configured minimum
+      this._debug('core-version:global-npm', error);
+    }
 
     return this.options.minCoreVersion;
   }
 
   /**
    * Check version compatibility
-   * Supports semver range syntax (>=, ^, ~)
+   * Supports semver range syntax: >=, >, <=, <, ^ (same major),
+   * ~ (same major.minor). A bare version is treated as >= for
+   * backward compatibility with existing plugin manifests.
    */
   isCompatible(currentVersion, requiredVersion) {
-    // Simple implementation - can be enhanced with semver library
-    const cleanRequired = requiredVersion.replace(/[><=^~]/g, '');
+    const match = String(requiredVersion).trim().match(/^(>=|<=|>|<|\^|~)?\s*(\d+(?:\.\d+){0,2})/);
+    if (!match) return false;
 
-    if (requiredVersion.startsWith('>=')) {
-      return this.compareVersions(currentVersion, cleanRequired) >= 0;
+    const operator = match[1] || '>=';
+    const baseVersion = match[2];
+    const cmp = this.compareVersions(currentVersion, baseVersion);
+    const [curMajor, curMinor] = currentVersion.split('.').map(Number);
+    const [reqMajor, reqMinor] = baseVersion.split('.').map(Number);
+
+    switch (operator) {
+      case '>': return cmp > 0;
+      case '<': return cmp < 0;
+      case '<=': return cmp <= 0;
+      case '^':
+        if (cmp < 0) return false;
+        // ^0.x.y allows only the same minor; otherwise same major
+        if (reqMajor === 0) return curMajor === 0 && curMinor === (reqMinor || 0);
+        return curMajor === reqMajor;
+      case '~':
+        if (cmp < 0) return false;
+        return curMajor === reqMajor && curMinor === (reqMinor || 0);
+      case '>=':
+      default:
+        return cmp >= 0;
     }
-
-    // Default: exact match or higher
-    return this.compareVersions(currentVersion, cleanRequired) >= 0;
   }
 
   /**

--- a/test/unit/plugins/PluginManager-bugfixes-jest.test.js
+++ b/test/unit/plugins/PluginManager-bugfixes-jest.test.js
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for PluginManager critical bugs (issue #607):
+ * 1. uninstallPlugin removed scripts from projectRoot/scripts while
+ *    installScripts writes to projectRoot/.claude/scripts → orphaned files
+ * 2. isCompatible silently treated ^ and ~ ranges as >=
+ * 3. a single file-copy/unlink failure crashed the whole install/uninstall
+ * 4. swallowed catch blocks gave no diagnostics even with debug enabled
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const PluginManager = require('../../../lib/plugins/PluginManager');
+
+function createScriptsPlugin(tempDir) {
+  const pluginPath = path.join(tempDir, 'plugin-src');
+  fs.mkdirSync(path.join(pluginPath, 'scripts', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(pluginPath, 'scripts', 'tool.sh'), '#!/bin/bash\necho tool\n');
+  fs.writeFileSync(path.join(pluginPath, 'scripts', 'other.sh'), '#!/bin/bash\necho other\n');
+  fs.writeFileSync(path.join(pluginPath, 'scripts', 'lib', 'util.sh'), '#!/bin/bash\necho util\n');
+
+  const metadata = {
+    name: '@claudeautopm/plugin-x',
+    category: 'test',
+    scripts: [
+      { name: 'tool', file: 'scripts/tool.sh' },
+      { name: 'other', file: 'scripts/other.sh' },
+      { name: 'libs', subdirectory: 'scripts/lib', files: ['util.sh'] }
+    ]
+  };
+
+  return {
+    pluginPath,
+    plugin: { name: '@claudeautopm/plugin-x', path: pluginPath, metadata, loaded: false }
+  };
+}
+
+describe('PluginManager bug fixes (#607)', () => {
+  let pm;
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-bugfix-'));
+    pm = new PluginManager({
+      pluginDir: path.join(tempDir, 'node_modules'),
+      agentDir: path.join(tempDir, '.claude', 'agents'),
+      projectRoot: tempDir
+    });
+    // Keep registry writes inside the temp dir
+    pm.registryPath = path.join(tempDir, 'registry.json');
+    pm.registry = { version: '1.0.0', installed: [], enabled: [], lastUpdate: '' };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('uninstall path matches install path', () => {
+    test('uninstallPlugin removes scripts from .claude/scripts leaving no orphans', async () => {
+      const { pluginPath, plugin } = createScriptsPlugin(tempDir);
+      pm.plugins.set(plugin.name, plugin);
+
+      await pm.installScripts(plugin, pluginPath);
+
+      const installedTool = path.join(tempDir, '.claude', 'scripts', 'tool.sh');
+      const installedUtil = path.join(tempDir, '.claude', 'scripts', 'lib', 'util.sh');
+      expect(fs.existsSync(installedTool)).toBe(true);
+      expect(fs.existsSync(installedUtil)).toBe(true);
+
+      await pm.uninstallPlugin('plugin-x');
+
+      expect(fs.existsSync(installedTool)).toBe(false);
+      expect(fs.existsSync(installedUtil)).toBe(false);
+    });
+  });
+
+  describe('isCompatible semver range handling', () => {
+    test('handles >= ranges', () => {
+      expect(pm.isCompatible('3.1.0', '>=2.8.0')).toBe(true);
+      expect(pm.isCompatible('2.8.0', '>=2.8.0')).toBe(true);
+      expect(pm.isCompatible('2.7.9', '>=2.8.0')).toBe(false);
+    });
+
+    test('handles ^ (caret) ranges — same major only', () => {
+      expect(pm.isCompatible('2.9.5', '^2.8.0')).toBe(true);
+      expect(pm.isCompatible('2.8.0', '^2.8.0')).toBe(true);
+      expect(pm.isCompatible('3.0.0', '^2.8.0')).toBe(false);
+      expect(pm.isCompatible('2.7.0', '^2.8.0')).toBe(false);
+    });
+
+    test('handles ^0.x ranges — same minor only', () => {
+      expect(pm.isCompatible('0.2.9', '^0.2.3')).toBe(true);
+      expect(pm.isCompatible('0.3.0', '^0.2.3')).toBe(false);
+    });
+
+    test('handles ~ (tilde) ranges — same major.minor only', () => {
+      expect(pm.isCompatible('2.8.4', '~2.8.0')).toBe(true);
+      expect(pm.isCompatible('2.9.0', '~2.8.0')).toBe(false);
+      expect(pm.isCompatible('2.7.9', '~2.8.0')).toBe(false);
+    });
+
+    test('bare version stays backward-compatible (treated as >=)', () => {
+      expect(pm.isCompatible('2.9.0', '2.8.0')).toBe(true);
+      expect(pm.isCompatible('2.7.0', '2.8.0')).toBe(false);
+    });
+  });
+
+  describe('file I/O error resilience', () => {
+    test('installScripts reports a failed copy and continues with remaining files', async () => {
+      const { pluginPath, plugin } = createScriptsPlugin(tempDir);
+      const errors = [];
+      pm.on('install:file-error', (e) => errors.push(e));
+
+      jest.spyOn(fs, 'copyFileSync').mockImplementationOnce(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      const installed = await pm.installScripts(plugin, pluginPath);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toMatch(/EACCES/);
+      expect(errors[0].file).toBeDefined();
+      // The remaining scripts still get installed
+      expect(installed.map((s) => s.name)).toEqual(expect.arrayContaining(['other', 'libs']));
+    });
+
+    test('installCommands reports a failed copy and continues', async () => {
+      const pluginPath = path.join(tempDir, 'plugin-cmd');
+      fs.mkdirSync(path.join(pluginPath, 'commands'), { recursive: true });
+      fs.writeFileSync(path.join(pluginPath, 'commands', 'a.md'), '# a');
+      fs.writeFileSync(path.join(pluginPath, 'commands', 'b.md'), '# b');
+      const plugin = {
+        name: '@claudeautopm/plugin-cmd',
+        path: pluginPath,
+        metadata: {
+          name: '@claudeautopm/plugin-cmd',
+          commands: [
+            { name: 'a', file: 'commands/a.md' },
+            { name: 'b', file: 'commands/b.md' }
+          ]
+        }
+      };
+      const errors = [];
+      pm.on('install:file-error', (e) => errors.push(e));
+
+      jest.spyOn(fs, 'copyFileSync').mockImplementationOnce(() => {
+        throw new Error('EIO: i/o error');
+      });
+
+      const installed = await pm.installCommands(plugin, pluginPath);
+
+      expect(errors).toHaveLength(1);
+      expect(installed.map((c) => c.name)).toEqual(['b']);
+    });
+
+    test('uninstallPlugin reports a failed unlink and still removes the rest', async () => {
+      const { pluginPath, plugin } = createScriptsPlugin(tempDir);
+      pm.plugins.set(plugin.name, plugin);
+      await pm.installScripts(plugin, pluginPath);
+
+      const errors = [];
+      pm.on('uninstall:file-error', (e) => errors.push(e));
+
+      jest.spyOn(fs, 'unlinkSync').mockImplementationOnce(() => {
+        throw new Error('EPERM: operation not permitted');
+      });
+
+      const result = await pm.uninstallPlugin('plugin-x');
+
+      expect(result.success).toBe(true);
+      expect(errors).toHaveLength(1);
+      // Files after the failing one are still removed
+      expect(fs.existsSync(path.join(tempDir, '.claude', 'scripts', 'lib', 'util.sh'))).toBe(false);
+    });
+  });
+
+  describe('debug diagnostics for swallowed errors', () => {
+    test('discoverPlugins emits debug event for invalid bundled plugin.json when debug enabled', async () => {
+      const dbg = new PluginManager({
+        pluginDir: path.join(tempDir, 'node_modules'),
+        agentDir: path.join(tempDir, '.claude', 'agents'),
+        projectRoot: tempDir,
+        debug: true
+      });
+      dbg.registryPath = path.join(tempDir, 'registry.json');
+
+      fs.mkdirSync(path.join(tempDir, 'packages', 'plugin-bad'), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, 'packages', 'plugin-bad', 'plugin.json'), '{not json');
+
+      const events = [];
+      dbg.on('debug', (e) => events.push(e));
+
+      await dbg.discoverPlugins();
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.some((e) => e.context && e.message)).toBe(true);
+    });
+  });
+});

--- a/test/unit/plugins/PluginManager-bugfixes-jest.test.js
+++ b/test/unit/plugins/PluginManager-bugfixes-jest.test.js
@@ -104,6 +104,18 @@ describe('PluginManager bug fixes (#607)', () => {
       expect(pm.isCompatible('2.9.0', '2.8.0')).toBe(true);
       expect(pm.isCompatible('2.7.0', '2.8.0')).toBe(false);
     });
+
+    test('handles partial versions: ~2 allows any 2.x, ^0 allows any 0.x', () => {
+      expect(pm.isCompatible('2.9.0', '~2')).toBe(true);
+      expect(pm.isCompatible('3.0.0', '~2')).toBe(false);
+      expect(pm.isCompatible('0.9.1', '^0')).toBe(true);
+      expect(pm.isCompatible('1.0.0', '^0')).toBe(false);
+    });
+
+    test('handles ^0.0.x — only the exact patch is compatible', () => {
+      expect(pm.isCompatible('0.0.3', '^0.0.3')).toBe(true);
+      expect(pm.isCompatible('0.0.4', '^0.0.3')).toBe(false);
+    });
   });
 
   describe('file I/O error resilience', () => {
@@ -112,8 +124,12 @@ describe('PluginManager bug fixes (#607)', () => {
       const errors = [];
       pm.on('install:file-error', (e) => errors.push(e));
 
-      jest.spyOn(fs, 'copyFileSync').mockImplementationOnce(() => {
-        throw new Error('EACCES: permission denied');
+      const realCopy = fs.copyFileSync.bind(fs);
+      jest.spyOn(fs, 'copyFileSync').mockImplementation((src, dest) => {
+        if (String(src).endsWith('tool.sh')) {
+          throw new Error('EACCES: permission denied');
+        }
+        return realCopy(src, dest);
       });
 
       const installed = await pm.installScripts(plugin, pluginPath);
@@ -144,8 +160,12 @@ describe('PluginManager bug fixes (#607)', () => {
       const errors = [];
       pm.on('install:file-error', (e) => errors.push(e));
 
-      jest.spyOn(fs, 'copyFileSync').mockImplementationOnce(() => {
-        throw new Error('EIO: i/o error');
+      const realCopy = fs.copyFileSync.bind(fs);
+      jest.spyOn(fs, 'copyFileSync').mockImplementation((src, dest) => {
+        if (String(src).endsWith('a.md')) {
+          throw new Error('EIO: i/o error');
+        }
+        return realCopy(src, dest);
       });
 
       const installed = await pm.installCommands(plugin, pluginPath);
@@ -162,8 +182,12 @@ describe('PluginManager bug fixes (#607)', () => {
       const errors = [];
       pm.on('uninstall:file-error', (e) => errors.push(e));
 
-      jest.spyOn(fs, 'unlinkSync').mockImplementationOnce(() => {
-        throw new Error('EPERM: operation not permitted');
+      const realUnlink = fs.unlinkSync.bind(fs);
+      jest.spyOn(fs, 'unlinkSync').mockImplementation((p) => {
+        if (String(p).endsWith('tool.sh')) {
+          throw new Error('EPERM: operation not permitted');
+        }
+        return realUnlink(p);
       });
 
       const result = await pm.uninstallPlugin('plugin-x');
@@ -172,6 +196,54 @@ describe('PluginManager bug fixes (#607)', () => {
       expect(errors).toHaveLength(1);
       // Files after the failing one are still removed
       expect(fs.existsSync(path.join(tempDir, '.claude', 'scripts', 'lib', 'util.sh'))).toBe(false);
+      // The failed script must NOT be reported as removed; the others are
+      expect(result.scripts).not.toContain('tool');
+      expect(result.scripts).toEqual(expect.arrayContaining(['other', 'libs']));
+    });
+
+    test('uninstallPlugin does not report a hook as removed when its unlink fails', async () => {
+      const pluginPath = path.join(tempDir, 'plugin-hooks');
+      fs.mkdirSync(path.join(pluginPath, 'hooks'), { recursive: true });
+      fs.writeFileSync(path.join(pluginPath, 'hooks', 'pre.sh'), '#!/bin/bash\n');
+      const plugin = {
+        name: '@claudeautopm/plugin-hooks',
+        path: pluginPath,
+        metadata: {
+          name: '@claudeautopm/plugin-hooks',
+          hooks: [{ name: 'pre', file: 'hooks/pre.sh' }]
+        }
+      };
+      pm.plugins.set(plugin.name, plugin);
+      await pm.installHooks(plugin, pluginPath);
+      expect(fs.existsSync(path.join(tempDir, '.claude', 'hooks', 'pre.sh'))).toBe(true);
+
+      jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {
+        throw new Error('EPERM: operation not permitted');
+      });
+
+      const result = await pm.uninstallPlugin('plugin-hooks');
+
+      expect(result.success).toBe(true);
+      expect(result.hooks).not.toContain('pre');
+      expect(result.hooksRemoved).toBe(0);
+    });
+
+    test('_safeCopy rolls back the copied file when chmod fails', async () => {
+      const { pluginPath, plugin } = createScriptsPlugin(tempDir);
+      const errors = [];
+      pm.on('install:file-error', (e) => errors.push(e));
+
+      jest.spyOn(fs, 'chmodSync').mockImplementation(() => {
+        throw new Error('EPERM: operation not permitted');
+      });
+
+      const installed = await pm.installScripts(plugin, pluginPath);
+
+      // chmod failed for every .sh file → nothing reported installed,
+      // and no half-installed files left behind ("already exists" trap)
+      expect(installed).toHaveLength(0);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(fs.existsSync(path.join(tempDir, '.claude', 'scripts', 'tool.sh'))).toBe(false);
     });
   });
 


### PR DESCRIPTION
Closes #607. Part of epic #605 (P0 stream).

## Fixes

1. **Uninstall path mismatch** — `uninstallPlugin` removed scripts from `projectRoot/scripts` while `installScripts` writes to `projectRoot/.claude/scripts`, leaving orphaned files on every uninstall. Both now use `.claude/scripts`.
2. **Semver range handling** — `isCompatible` treated every range as `>=`, silently accepting incompatible majors for `^`/`~` ranges. Now correctly handles `>=`, `>`, `<=`, `<`, `^` (same major; `^0.x` same minor) and `~` (same major.minor). Bare versions stay `>=` for backward compatibility with existing plugin manifests (all shipped plugins use `>=`). Implemented without adding a dependency.
3. **I/O resilience** — every `copyFileSync`/`unlinkSync` site in install*/uninstall* now goes through `_safeCopy`/`_safeUnlink`: a single failing file emits `install:file-error`/`uninstall:file-error` (with file path and error) and the operation continues deterministically instead of crashing mid-way.
4. **Debug diagnostics** — previously empty `catch {}` blocks (discovery, getCoreVersion) now emit a `debug` event when `options.debug` is set.
5. **Misleading indentation** in `discoverPlugins` inner loop fixed; unused `pluginPattern` removed.

## Tests (TDD)

- RED commit adds `test/unit/plugins/PluginManager-bugfixes-jest.test.js` (10 tests, 8 failing before the fix).
- GREEN: all 10 pass; `test/unit/plugins` and the quick suite show no regressions.

**Note (pre-existing, out of scope):** `test/core/PluginManager.test.js` discovery tests fail on machines with globally installed `@claudeautopm/*` packages — discovery via `npm root -g` leaks real plugins into test assertions. Reproduced identically on unmodified main; belongs to #608 (test hermeticity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
