### PR TITLE
fix(security): sanitize remote System.Tags before az field assignment

### DIFF
--- a/.claude/providers/azure/issue-start.js
+++ b/.claude/providers/azure/issue-start.js
@@ -259,9 +259,16 @@ class AzureIssueStart {
         console.warn(`Could not add tag: invalid tag value: ${tag}`);
         return;
       }
-      // Get current tags
+      // Get current tags. The remote value is untrusted input — keep only
+      // entries matching the same safe pattern as the new tag, so a corrupted
+      // or malicious stored value cannot smuggle extra field syntax into the
+      // System.Tags assignment below.
       const workItem = await this.getWorkItem(organization, project, workItemId);
-      const currentTags = workItem.fields?.['System.Tags'] || '';
+      const currentTags = (workItem.fields?.['System.Tags'] || '')
+        .split(';')
+        .map(t => t.trim())
+        .filter(t => t && AzureIssueStart.isValidTag(t))
+        .join('; ');
       const newTags = currentTags ? `${currentTags}; ${tag}` : tag;
 
       execFileSync('az', ['boards', 'work-item', 'update',

--- a/autopm/.claude/providers/azure/issue-start.js
+++ b/autopm/.claude/providers/azure/issue-start.js
@@ -259,9 +259,16 @@ class AzureIssueStart {
         console.warn(`Could not add tag: invalid tag value: ${tag}`);
         return;
       }
-      // Get current tags
+      // Get current tags. The remote value is untrusted input — keep only
+      // entries matching the same safe pattern as the new tag, so a corrupted
+      // or malicious stored value cannot smuggle extra field syntax into the
+      // System.Tags assignment below.
       const workItem = await this.getWorkItem(organization, project, workItemId);
-      const currentTags = workItem.fields?.['System.Tags'] || '';
+      const currentTags = (workItem.fields?.['System.Tags'] || '')
+        .split(';')
+        .map(t => t.trim())
+        .filter(t => t && AzureIssueStart.isValidTag(t))
+        .join('; ');
       const newTags = currentTags ? `${currentTags}; ${tag}` : tag;
 
       execFileSync('az', ['boards', 'work-item', 'update',


### PR DESCRIPTION
Follow-up from the v3.25.6 promotion review (#624): `addTag` validated the NEW tag but concatenated the REMOTE `System.Tags` value unsanitized into the `System.Tags=<value>` argv element — a corrupted/malicious stored value could smuggle extra field syntax. Remote tags are now filtered through the same `isValidTag` pattern. Both payload and root copies; 45/45 provider tests + 8/8 injection-vector tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)