### PR TITLE
chore(security): add CODEOWNERS lock on .github/workflows/**

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# ⚠️ Managed by lagowski/pr-review-gate — deployed to every gated repo as .github/CODEOWNERS.
+# Locks the review gate + its inputs so a PR can't silently weaken the gate (the "blind it"
+# from the security design). ADVISORY (auto-requests owners) until "Require review from Code
+# Owners" is enabled in branch protection — issue #11.
+#
+# Owners = the 3 org owners as individuals (no @lagowski/maintainers team needed → no admin:org
+# blocker). Switch to `@lagowski/maintainers` once that team exists. With 3 owners, a PR author
+# who is an owner can still be approved by another owner.
+/.github/workflows/        @rlagowski @Dixter999 @rafeekpro
+/.github/CODEOWNERS        @rlagowski @Dixter999 @rafeekpro
+/.github/review-context.md @rlagowski @Dixter999 @rafeekpro


### PR DESCRIPTION
Adds the fleet `.github/CODEOWNERS` lock so the review gate (and its inputs) can't be edited inside a PR to bypass itself — the structural control from [pr-review-gate#10](https://github.com/lagowski/pr-review-gate/issues/10), tracked for this repo in [#47](https://github.com/lagowski/pr-review-gate/issues/47).

**Engine-independent** — this only adds the CODEOWNERS file; it does **not** touch the review workflow, so nothing about how reviews run changes. Owners = the 3 org owners as individuals.

Once merged, the matching `require_code_owner_review` branch-protection toggle is enabled separately (it only gates PRs that touch `.github/workflows/**`, `.github/CODEOWNERS`, or `.github/review-context.md` — normal PRs are unaffected).

Refs lagowski/pr-review-gate#47 #10