### PR TITLE
chore: scoped Dependabot auto-merge + grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Batch routine minor/patch into 2 PRs (dev / prod) instead of many singles.
+    groups:
+      dev-minor-patch:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      prod-minor-patch:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
     assignees:
       - "rafeekpro"
     commit-message:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+# Scoped Dependabot auto-merge (lagowski/pr-review-gate#1 hardening — routine deps
+# shouldn't need a human, but the dangerous ones still must).
+#
+# Auto-merges ONLY: npm ecosystem, semver patch/minor. It approves + enables auto-merge,
+# so GitHub still holds the PR until required checks pass (the copilot-review gate + CI)
+# — auto-merge is "the gate is the reviewer," not "no checks."
+#
+# Deliberately NEVER auto-merged (left for a human):
+#   - github-actions ecosystem  → those edit .github/workflows/** (CODEOWNERS-locked) and
+#     are infra-critical, e.g. the gate's own actions/github-script (a node24 major bump).
+#   - any semver-major           → breaking-change risk.
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Approve + enable auto-merge (npm patch/minor only)
+        if: >-
+          ${{ steps.meta.outputs.package-ecosystem == 'npm' &&
+              (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+               steps.meta.outputs.update-type == 'version-update:semver-minor') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What
Routine deps shouldn't need a human, but the dangerous ones still must.

- **`dependabot-auto-merge.yml`** — auto-approves + enables auto-merge for **npm semver patch/minor only**. It uses `--auto`, so GitHub still holds each PR until required checks pass (the `copilot-review` gate + CI) — auto-merge means *the gate is the reviewer*, not *no checks*.
- **`dependabot.yml` grouping** — dev and prod minor/patch each batch into one PR instead of many singles.

## Deliberately NOT auto-merged (a human still decides)
- **`github-actions` ecosystem** — those edit `.github/workflows/**`, which is CODEOWNERS-locked and infra-critical (e.g. the live #633 `actions/github-script` 7→9, a Node-24 major that could break the gate). The CODEOWNERS lock already forces code-owner review on these.
- **any `semver-major`** — breaking-change risk.

## Two caveats
1. **AI gate is dormant while OpenRouter is at $0** — `copilot-review` returns `neutral`, so right now auto-merge is effectively **CI-gated** until credits return. Normal for patch/minor; flagging it.
2. **`GITHUB_TOKEN` approval** may not satisfy a required-review rule in every config; if patch/minor PRs still sit on `REVIEW_REQUIRED` after this lands, swap the approve step to a PAT.

Refs lagowski/pr-review-gate#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)