### PR TITLE
ci: run Tests on develop PRs (not just main)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 jobs:
   test-matrix:


### PR DESCRIPTION
## Why
`test.yml` triggered only on PRs targeting **main**, but all real work — and **every Dependabot PR** — targets **develop**. So the jest suite has **never run on a dependency PR**: dep bumps merge completely unvalidated.

That's the gap behind "why didn't anything catch a risky dep?": **AI review (Copilot / the OpenRouter gate) reviews the diff** — a bump is just a version string, nothing to flag — and **Dependabot only proposes versions, it doesn't validate them against your code.** The thing that *can* catch a bad bump (e.g. a runtime `marked` major) is **your test suite** — which exists but wasn't running here.

## Change
`test.yml` now runs on `push` + `pull_request` for **`main` and `develop`**.

## Follow-up (recommended)
Once Tests is confirmed running on a develop PR, make **Tests** a *required* check on `develop`. Then:
- auto-merged patch/minor deps only land if tests pass (real safety, not "merge on trust"),
- major deps (eslint/sinon/marked/…) are blocked if they break the suite.

Refs lagowski/pr-review-gate#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)