### PR TITLE
feat(pm): add pm:review-fix command file (#656)

### DIFF
--- a/autopm/.claude/commands/pm:review-fix.md
+++ b/autopm/.claude/commands/pm:review-fix.md
@@ -1,0 +1,89 @@
+---
+allowed-tools: Bash, Read, Edit
+---
+
+---
+
+## pm:review-fix
+
+Process Copilot review and fix all issues on the current PR.
+
+Fix priority order: **error** first, then **style**, then **comment**.
+
+## Required Documentation Access
+
+**MANDATORY:** Query Context7 for project-management best practices before proceeding. Use the standard PM query set in `.claude/rules/context7-required.md`.
+
+## Steps
+
+### 1. Detect current PR
+
+```bash
+gh pr view --json number,url,headRefName,reviewThreads
+```
+
+If this fails: `❌ No open PR for current branch. Run: /pm:issue-finish <number>`
+
+Store the `reviewThreads` array — each thread has `comments`, `isResolved`, and `path`.
+
+### 2. Parse and group open review threads
+
+Filter threads where `isResolved` is `false`. Group by severity:
+
+- **error** — compilation failures, test failures, security issues, broken logic
+- **style** — naming, formatting, whitespace, conventions
+- **comment** — questions, suggestions, nitpicks
+
+### 3. Fix in priority order
+
+Work through groups in order: **error** → **style** → **comment**
+
+- **error**: Must fix. Use `@code-analyzer` when a fix touches multiple files.
+- **style**: Fix if straightforward.
+- **comment**: Respond inline if no code change is needed.
+
+Track per-thread status as one of:
+- `fixed` — code change applied
+- `responded` — replied inline, no code change
+- `skipped` — out of scope or cannot reproduce
+
+### 4. Run full test suite
+
+Delegate to `@test-runner`:
+
+```
+Run the full test suite with: npm test
+```
+
+Do not push if tests fail. **BLOCK on failure** — report which tests are failing and stop.
+
+### 5. Push fixes
+
+Only run this if tests pass:
+
+```bash
+git push origin $(git branch --show-current)
+```
+
+### 6. Update PR status
+
+```bash
+gh pr comment --body "All review threads addressed. Re-requesting review."
+```
+
+### 7. Output summary
+
+```
+✅ Review processed
+  - fixed: N
+  - responded: M
+  - skipped: K
+Tests: green
+PR: pushed and updated
+```
+
+## Error Handling
+
+- No open PR: `❌ No PR found: Run /pm:issue-finish <number>`
+- Tests fail after fixes: `❌ Tests failing — push blocked. Fix failures before retrying.`
+- Push fails: `❌ Push failed: git push origin <branch>`

--- a/test/helpers/parse-command-frontmatter.js
+++ b/test/helpers/parse-command-frontmatter.js
@@ -1,0 +1,21 @@
+/**
+ * Parse YAML frontmatter from a command file (the leading --- block).
+ * Returns a plain object of key/value strings, or {} if no frontmatter.
+ */
+function parseCommandFrontmatter(content) {
+  if (!content || !content.startsWith('---')) return {};
+  const end = content.indexOf('\n---', 3);
+  if (end === -1) return {};
+  const yaml = content.slice(4, end);
+  const result = {};
+  for (const line of yaml.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    result[key] = value;
+  }
+  return result;
+}
+
+module.exports = { parseCommandFrontmatter };

--- a/test/jest-tests/pm-review-fix-jest.test.js
+++ b/test/jest-tests/pm-review-fix-jest.test.js
@@ -1,23 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const { parseCommandFrontmatter } = require('../helpers/parse-command-frontmatter');
 
 const COMMAND_FILE = path.resolve(__dirname, '../../autopm/.claude/commands/pm:review-fix.md');
-
-function parseFrontmatter(content) {
-  if (!content.startsWith('---')) return {};
-  const end = content.indexOf('\n---', 3);
-  if (end === -1) return {};
-  const yaml = content.slice(4, end);
-  const result = {};
-  for (const line of yaml.split('\n')) {
-    const colon = line.indexOf(':');
-    if (colon === -1) continue;
-    const key = line.slice(0, colon).trim();
-    const value = line.slice(colon + 1).trim();
-    result[key] = value;
-  }
-  return result;
-}
 
 describe('pm:review-fix command file', () => {
   let content;
@@ -35,7 +20,7 @@ describe('pm:review-fix command file', () => {
   });
 
   it('test_review_fix_frontmatter_includes_allowed_tools_bash_read_edit — frontmatter allowed-tools', () => {
-    const fm = parseFrontmatter(content);
+    const fm = parseCommandFrontmatter(content);
     expect(fm['allowed-tools']).toBe('Bash, Read, Edit');
   });
 
@@ -60,7 +45,7 @@ describe('pm:review-fix command file', () => {
   });
 
   it('test_review_fix_frontmatter_allowed_tools_is_bash_read_edit — AC: frontmatter matches pattern', () => {
-    const fm = parseFrontmatter(content);
+    const fm = parseCommandFrontmatter(content);
     expect(fm['allowed-tools']).toBe('Bash, Read, Edit');
   });
 

--- a/test/jest-tests/pm-review-fix-jest.test.js
+++ b/test/jest-tests/pm-review-fix-jest.test.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const path = require('path');
+
+const COMMAND_FILE = path.resolve(__dirname, '../../autopm/.claude/commands/pm:review-fix.md');
+
+function parseFrontmatter(content) {
+  if (!content.startsWith('---')) return {};
+  const end = content.indexOf('\n---', 3);
+  if (end === -1) return {};
+  const yaml = content.slice(4, end);
+  const result = {};
+  for (const line of yaml.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    result[key] = value;
+  }
+  return result;
+}
+
+describe('pm:review-fix command file', () => {
+  let content;
+
+  beforeAll(() => {
+    if (fs.existsSync(COMMAND_FILE)) {
+      content = fs.readFileSync(COMMAND_FILE, 'utf8');
+    }
+  });
+
+  // ── RED tests ────────────────────────────────────────────────────────────
+
+  it('test_review_fix_command_file_exists — file exists at correct path', () => {
+    expect(fs.existsSync(COMMAND_FILE)).toBe(true);
+  });
+
+  it('test_review_fix_frontmatter_includes_allowed_tools_bash_read_edit — frontmatter allowed-tools', () => {
+    const fm = parseFrontmatter(content);
+    expect(fm['allowed-tools']).toBe('Bash, Read, Edit');
+  });
+
+  it('test_review_fix_instructs_gh_pr_view_with_reviewThreads_json — uses gh pr view with reviewThreads', () => {
+    expect(content).toContain('gh pr view');
+    expect(content).toContain('reviewThreads');
+  });
+
+  it('test_review_fix_specifies_errors_first_fix_order — error before style before comment', () => {
+    const errorIdx = content.indexOf('error');
+    const styleIdx = content.indexOf('style');
+    const commentIdx = content.indexOf('comment');
+    expect(errorIdx).toBeGreaterThan(-1);
+    expect(styleIdx).toBeGreaterThan(errorIdx);
+    expect(commentIdx).toBeGreaterThan(styleIdx);
+  });
+
+  // ── GREEN tests ──────────────────────────────────────────────────────────
+
+  it('test_review_fix_file_exists_at_correct_path — AC: file created at naming-convention path', () => {
+    expect(fs.existsSync(COMMAND_FILE)).toBe(true);
+  });
+
+  it('test_review_fix_frontmatter_allowed_tools_is_bash_read_edit — AC: frontmatter matches pattern', () => {
+    const fm = parseFrontmatter(content);
+    expect(fm['allowed-tools']).toBe('Bash, Read, Edit');
+  });
+
+  it('test_review_fix_blocks_push_when_tests_fail_instruction_present — AC: no push on test failure', () => {
+    const lower = content.toLowerCase();
+    const hasBlock = lower.includes('do not push') ||
+      lower.includes('block') ||
+      lower.includes('skip') ||
+      (lower.includes('push') && lower.includes('fail'));
+    expect(hasBlock).toBe(true);
+  });
+
+  it('test_review_fix_delegates_to_test_runner_agent — AC: references @test-runner', () => {
+    expect(content).toContain('@test-runner');
+  });
+
+  it('test_review_fix_outputs_per_comment_status — AC: mentions fixed, responded, skipped', () => {
+    expect(content).toContain('fixed');
+    expect(content).toContain('responded');
+    expect(content).toContain('skipped');
+  });
+});


### PR DESCRIPTION
## Summary

- Creates the missing `autopm/.claude/commands/pm:review-fix.md` slash command file so `pm:review-fix` can be invoked (it was documented in `pm-commands.md` but had no backing file)
- Implements the four-step spec: fetch PR review threads via `gh pr view --json reviewThreads`, fix in error → style → comment priority, delegate test run to `@test-runner` and block push on failure, then report per-comment status (fixed / responded / skipped)
- Adds `test/jest-tests/pm-review-fix-jest.test.js` with full RED→GREEN TDD coverage (file existence, frontmatter, `gh pr view` usage, error-first order, push-block, `@test-runner` delegation, per-comment output)
- Extracts shared `test/helpers/parse-command-frontmatter.js` helper (REFACTOR phase), replacing inline duplication in the new test file

## Test results

All 54 test suites passed (1641 tests, 19 skipped) — no regressions.

## Closes #656