### PR TITLE
feat(pm): add pm:issue-finish command file and tests (#655)

### DIFF
--- a/autopm/.claude/commands/pm:issue-finish.md
+++ b/autopm/.claude/commands/pm:issue-finish.md
@@ -1,0 +1,142 @@
+---
+allowed-tools: Bash, Read
+---
+
+# pm:issue-finish
+
+Complete an issue and open a PR after all quality gates pass.
+
+## Usage
+
+```
+/pm:issue-finish [issue_number]
+```
+
+`issue_number` is optional — auto-detected from branch name if omitted.
+
+## Required Documentation Access
+
+**MANDATORY:** Query Context7 for project-management best practices before proceeding. Use the standard PM query set in `.claude/rules/context7-required.md`.
+
+## Steps
+
+### 1. Pre-flight
+
+```bash
+# Branch guard — must not be on main or develop
+CURRENT_BRANCH=$(git branch --show-current)
+if echo "$CURRENT_BRANCH" | grep -qE '^(main|develop)$'; then
+  echo "❌ Must be on a feature branch, not main/develop"
+  exit 1
+fi
+
+# Resolve issue number: explicit arg first, then extract from branch name
+if [ -n "$ARGUMENTS" ]; then
+  ISSUE_NUMBER="$ARGUMENTS"
+else
+  ISSUE_NUMBER=$(echo "$CURRENT_BRANCH" | grep -oE '[0-9]+' | head -1)
+fi
+[ -z "$ISSUE_NUMBER" ] && {
+  echo "❌ Cannot detect issue number from '$CURRENT_BRANCH'. Usage: /pm:issue-finish <number>"
+  exit 1
+}
+echo "Issue: #$ISSUE_NUMBER  Branch: $CURRENT_BRANCH"
+```
+
+### 2. Quality gate — tests
+
+Delegate to `@test-runner`:
+
+```
+Run the full test suite: npm test
+Do not proceed if any tests fail.
+```
+
+**BLOCK on failure** — if tests fail, stop here and report which tests are failing. No PR created.
+
+### 3. Quality gate — coverage
+
+```bash
+npm run test:coverage -- --coverageReporters=json-summary 2>/dev/null
+LINES=$(node -e "const c=require('./coverage/coverage-summary.json').total; console.log(c.lines.pct)")
+BRANCHES=$(node -e "const c=require('./coverage/coverage-summary.json').total; console.log(c.branches.pct)")
+FUNCTIONS=$(node -e "const c=require('./coverage/coverage-summary.json').total; console.log(c.functions.pct)")
+STATEMENTS=$(node -e "const c=require('./coverage/coverage-summary.json').total; console.log(c.statements.pct)")
+
+# Thresholds: lines >= 80%, branches >= 75%, functions >= 80%, statements >= 80%
+LINES_OK=$(node -e "process.exit(parseFloat('$LINES') >= 80 ? 0 : 1)" && echo "✅" || echo "❌")
+BRANCHES_OK=$(node -e "process.exit(parseFloat('$BRANCHES') >= 75 ? 0 : 1)" && echo "✅" || echo "❌")
+FUNCTIONS_OK=$(node -e "process.exit(parseFloat('$FUNCTIONS') >= 80 ? 0 : 1)" && echo "✅" || echo "❌")
+STATEMENTS_OK=$(node -e "process.exit(parseFloat('$STATEMENTS') >= 80 ? 0 : 1)" && echo "✅" || echo "❌")
+
+if [ "$LINES_OK" = "❌" ] || [ "$BRANCHES_OK" = "❌" ] || [ "$FUNCTIONS_OK" = "❌" ] || [ "$STATEMENTS_OK" = "❌" ]; then
+  echo "❌ Coverage below threshold — no PR created. Add tests to meet minimums."
+  exit 1
+fi
+```
+
+### 4. Linters
+
+```bash
+npx eslint . || { echo "❌ ESLint failed — fix linting errors before creating PR"; exit 1; }
+npx prettier --check . || { echo "❌ Prettier check failed — run: npx prettier --write ."; exit 1; }
+```
+
+### 5. Commit unstaged changes
+
+```bash
+git diff --quiet && git diff --staged --quiet || {
+  git add -A
+  git commit -m "chore: pre-PR cleanup"
+}
+```
+
+### 6. Push branch
+
+```bash
+git push origin "$CURRENT_BRANCH" || { echo "❌ Push failed: git push origin $CURRENT_BRANCH"; exit 1; }
+```
+
+### 7. Get issue title
+
+```bash
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q .title) || {
+  echo "❌ Cannot fetch issue #$ISSUE_NUMBER: gh issue view $ISSUE_NUMBER"
+  exit 1
+}
+```
+
+### 8. Create PR
+
+```bash
+gh pr create \
+  --title "$ISSUE_TITLE" \
+  --base develop \
+  --body "## Coverage
+
+| Metric     | Result         | Threshold | Status         |
+|------------|----------------|-----------|----------------|
+| Lines      | ${LINES}%      | 80%       | $LINES_OK      |
+| Branches   | ${BRANCHES}%   | 75%       | $BRANCHES_OK   |
+| Functions  | ${FUNCTIONS}%  | 80%       | $FUNCTIONS_OK  |
+| Statements | ${STATEMENTS}% | 80%       | $STATEMENTS_OK |
+
+Closes #$ISSUE_NUMBER" \
+  --label "in-progress"
+```
+
+### 9. Output
+
+```
+✅ PR created: <PR_URL>
+Waiting for review. Run /pm:review-fix after Copilot comments.
+```
+
+## Error Handling
+
+- On main/develop: `❌ Must be on a feature branch, not main/develop`
+- No issue number: `❌ Cannot detect issue number from '<branch>'. Usage: /pm:issue-finish <number>`
+- Tests fail: stop and report failing tests, no PR created
+- Coverage gate: `❌ Coverage below threshold — no PR created. Add tests to meet minimums.`
+- Linter fails: `❌ ESLint failed` / `❌ Prettier check failed`
+- Push fails: `❌ Push failed: git push origin <branch>`

--- a/test/jest-tests/pm-issue-finish-jest.test.js
+++ b/test/jest-tests/pm-issue-finish-jest.test.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+const { parseCommandFrontmatter } = require('../helpers/parse-command-frontmatter');
+
+const COMMAND_FILE = path.resolve(__dirname, '../../autopm/.claude/commands/pm:issue-finish.md');
+
+describe('pm:issue-finish command file', () => {
+  let content;
+
+  beforeAll(() => {
+    if (fs.existsSync(COMMAND_FILE)) {
+      content = fs.readFileSync(COMMAND_FILE, 'utf8');
+    }
+  });
+
+  // ── RED tests ─────────────────────────────────────────────────────────────
+
+  it('test_pm_issue_finish_command_file_exists — file exists at correct path', () => {
+    expect(fs.existsSync(COMMAND_FILE)).toBe(true);
+  });
+
+  it('test_pm_issue_finish_has_allowed_tools_frontmatter — frontmatter includes allowed-tools: Bash, Read', () => {
+    const fm = parseCommandFrontmatter(content);
+    expect(fm['allowed-tools']).toBe('Bash, Read');
+  });
+
+  it('test_pm_issue_finish_blocks_on_main_or_develop_branch — exact error message present', () => {
+    expect(content).toContain('❌ Must be on a feature branch, not main/develop');
+  });
+
+  it('test_pm_issue_finish_contains_coverage_table_with_four_rows — all four metric labels and thresholds present', () => {
+    expect(content).toContain('Lines');
+    expect(content).toContain('Branches');
+    expect(content).toContain('Functions');
+    expect(content).toContain('Statements');
+    expect(content).toContain('80%');
+    expect(content).toContain('75%');
+  });
+
+  // ── GREEN tests ───────────────────────────────────────────────────────────
+
+  it('test_pm_issue_finish_detects_issue_number_from_branch_name — git branch command with number extraction', () => {
+    const hasBranchCmd = content.includes('git branch') || content.includes('git rev-parse');
+    const hasNumberExtract = content.includes('grep -oE') || content.includes('[0-9]');
+    expect(hasBranchCmd).toBe(true);
+    expect(hasNumberExtract).toBe(true);
+  });
+
+  it('test_pm_issue_finish_accepts_explicit_issue_number_argument — references $ARGUMENTS or $1', () => {
+    const hasArgs = content.includes('$ARGUMENTS') || content.includes('$1');
+    expect(hasArgs).toBe(true);
+  });
+
+  it('test_pm_issue_finish_blocks_pr_when_tests_fail — npm test before gh pr create with block on failure', () => {
+    expect(content).toContain('npm test');
+    const testIdx = content.indexOf('npm test');
+    const prIdx = content.indexOf('gh pr create');
+    expect(testIdx).toBeGreaterThan(-1);
+    expect(prIdx).toBeGreaterThan(-1);
+    expect(testIdx).toBeLessThan(prIdx);
+    const lower = content.toLowerCase();
+    const hasBlock = lower.includes('block') || lower.includes('exit 1') || lower.includes('no pr');
+    expect(hasBlock).toBe(true);
+  });
+
+  it('test_pm_issue_finish_blocks_pr_when_coverage_below_threshold — threshold checks for all four metrics', () => {
+    expect(content).toContain('npm run test:coverage');
+    expect(content).toContain('>= 80');
+    expect(content).toContain('>= 75');
+    const lower = content.toLowerCase();
+    const hasBlock = lower.includes('exit 1') || lower.includes('no pr');
+    expect(hasBlock).toBe(true);
+  });
+
+  it('test_pm_issue_finish_pr_body_includes_coverage_table — gh pr create body has four-row coverage table with status symbols', () => {
+    expect(content).toContain('gh pr create');
+    expect(content).toContain('✅');
+    expect(content).toContain('❌');
+    expect(content).toContain('Lines');
+    expect(content).toContain('Branches');
+    expect(content).toContain('Functions');
+    expect(content).toContain('Statements');
+  });
+
+  it('test_pm_issue_finish_ends_with_review_prompt — exact output string present', () => {
+    expect(content).toContain('Waiting for review. Run /pm:review-fix after Copilot comments.');
+  });
+});


### PR DESCRIPTION
## Summary

- Creates `autopm/.claude/commands/pm:issue-finish.md` — the missing slash command that was documented in `pm-commands.md` but had no corresponding command file
- Adds branch guard (blocks on `main`/`develop`), full quality gate (tests + coverage thresholds + linters), and PR creation step with a four-row coverage table in the body
- Adds `test/jest-tests/pm-issue-finish-jest.test.js` with 10 test cases covering RED/GREEN assertions per spec (file existence, frontmatter, branch guard, coverage table, test/coverage blocks, explicit issue arg, review prompt)

## Test results

All 54 test suites passed (1641 tests, 19 skipped) — no regressions.

Closes #655