### PR TITLE
feat(pm): add wrap-session command and tests (#653)

### DIFF
--- a/autopm/.claude/commands/wrap-session.md
+++ b/autopm/.claude/commands/wrap-session.md
@@ -1,0 +1,80 @@
+---
+allowed-tools: Read, Edit, Write, Bash
+---
+
+# Wrap Session
+
+Perform the full pre-compact ritual: summarize session, persist memories, update CLAUDE.md, review hook candidates, and print a context primer.
+
+## Instructions
+
+### Step 1 — Summarize session
+
+Review the current conversation. Extract:
+- Key decisions made
+- Patterns or commands discovered (what worked, what failed)
+- Blockers resolved
+- Anything surprising or non-obvious
+
+Hold this summary in memory for use in subsequent steps.
+
+### Step 2 — Update memories
+
+Write or update memory files in `.claude/projects/<cwd>/memory/` (create the directory if absent).
+
+Memory types to cover — check each one and write/update as needed:
+- `user` — role, preferences, expertise level discovered this session
+- `feedback` — corrections or confirmations the user gave (what to stop/keep doing)
+- `project` — decisions, deadlines, constraints, active initiatives
+- `reference` — pointers to external systems, dashboards, or docs referenced
+
+Each memory file uses YAML frontmatter with `name`, `description`, and `metadata.type` fields, followed by a body section.
+
+After writing memory files, update `MEMORY.md` in the same directory:
+- One line per memory: `- [Title](file.md) — one-line hook`
+- Keep the index under 200 lines (truncate oldest low-value entries if MEMORY.md exceeds 200 lines)
+- Idempotent: check whether an entry for the same slug already exists before adding; update in place rather than appending a duplicate
+
+### Step 3 — Update CLAUDE.md
+
+Scan the session for anything not yet captured in `.claude.local.md` (prefer this for personal notes) or `CLAUDE.md`:
+- New commands or workflows discovered
+- Gotchas, invariants, or non-obvious constraints
+- Patterns that should be repeated
+
+Read the target file first, then append only what is genuinely missing — do not duplicate existing content.
+
+### Step 4 — Review hooks
+
+Scan the session for repeated manual actions the user had to do more than once:
+- Running a linter after every edit
+- Fetching a URL before testing
+- Any consistent before/after pattern
+
+For each candidate output one line of the form:
+Hook candidate: after `<event>` → run `<command>`
+
+Skip this step silently if no candidates are found.
+
+### Step 5 — Print compact primer
+
+Produce a ready-to-paste context primer covering:
+- Active branch and issue number
+- Key decisions from this session
+- What was completed and what remains
+- Any critical gotchas
+
+## Output Format
+
+Print the following block when done (substitute real counts):
+
+    ✅ wrap-session complete
+      - <N> memories updated
+      - CLAUDE.md: <N> lines added
+      - Hook candidates: <N> (or "none")
+
+Next: copy the primer below → /compact → paste primer
+
+```
+[primer text here — branch, decisions, completed work, open items, gotchas]
+```

--- a/test/jest-tests/pm-wrap-session-jest.test.js
+++ b/test/jest-tests/pm-wrap-session-jest.test.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const { parseCommandFrontmatter } = require('../helpers/parse-command-frontmatter');
+
+const COMMAND_FILE = path.resolve(__dirname, '../../autopm/.claude/commands/wrap-session.md');
+
+describe('wrap-session command file', () => {
+  let content;
+  let fm;
+
+  beforeAll(() => {
+    if (fs.existsSync(COMMAND_FILE)) {
+      content = fs.readFileSync(COMMAND_FILE, 'utf8');
+      fm = parseCommandFrontmatter(content);
+    }
+  });
+
+  // ── RED tests ────────────────────────────────────────────────────────────
+
+  it('test_wrap_session_command_file_exists — file exists at correct path', () => {
+    expect(fs.existsSync(COMMAND_FILE)).toBe(true);
+  });
+
+  it('test_wrap_session_frontmatter_allowed_tools_lists_read_edit_write_bash — frontmatter allowed-tools', () => {
+    expect(fm['allowed-tools']).toBe('Read, Edit, Write, Bash');
+  });
+
+  it('test_wrap_session_output_header_is_wrap_session_complete — output uses correct header', () => {
+    expect(content).toContain('✅ wrap-session complete');
+  });
+
+  it('test_wrap_session_lists_all_four_memory_types — mentions all four types', () => {
+    expect(content).toContain('user');
+    expect(content).toContain('feedback');
+    expect(content).toContain('project');
+    expect(content).toContain('reference');
+  });
+
+  // ── GREEN tests ──────────────────────────────────────────────────────────
+
+  it('test_wrap_session_file_exists_at_correct_path — AC: file created at naming-convention path', () => {
+    expect(fs.existsSync(COMMAND_FILE)).toBe(true);
+  });
+
+  it('test_wrap_session_frontmatter_allowed_tools_is_read_edit_write_bash — AC: frontmatter matches spec', () => {
+    expect(fm['allowed-tools']).toBe('Read, Edit, Write, Bash');
+  });
+
+  it('test_wrap_session_lists_all_four_memory_types — AC: Update memories step covers all four types', () => {
+    expect(content).toContain('user');
+    expect(content).toContain('feedback');
+    expect(content).toContain('project');
+    expect(content).toContain('reference');
+  });
+
+  it('test_wrap_session_enforces_memory_md_200_line_guard — AC: MEMORY.md stays under 200 lines', () => {
+    expect(content).toContain('200');
+    expect(content.toLowerCase()).toContain('memory.md');
+  });
+
+  it('test_wrap_session_marks_idempotency_requirement — AC: running twice does not duplicate entries', () => {
+    const lower = content.toLowerCase();
+    const hasIdempotent = lower.includes('idempotent');
+    const hasDuplicateTwice = lower.includes('duplicate') && lower.includes('twice');
+    expect(hasIdempotent || hasDuplicateTwice).toBe(true);
+  });
+
+  it('test_wrap_session_output_header_is_wrap_session_complete — AC: output format has exact header', () => {
+    expect(content).toContain('✅ wrap-session complete');
+  });
+
+  it('test_wrap_session_output_includes_next_line — AC: output format has Next: line per standard-patterns.md', () => {
+    expect(content).toContain('Next:');
+  });
+
+  it('test_wrap_session_output_includes_fenced_primer_block — AC: ready-to-paste primer in fenced block after Next:', () => {
+    const nextIdx = content.indexOf('Next:');
+    const fenceIdx = content.indexOf('```');
+    expect(nextIdx).toBeGreaterThan(-1);
+    expect(fenceIdx).toBeGreaterThan(nextIdx);
+  });
+
+  it('test_wrap_session_contains_five_numbered_steps — AC: 5-step Instructions body per technical spec', () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain('summarize');
+    expect(lower).toContain('memories');
+    expect(lower).toContain('claude.md');
+    expect(lower).toContain('hooks');
+    expect(lower).toContain('primer');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `autopm/.claude/commands/wrap-session.md` — a new command that consolidates the full pre-compact ritual (session summary → memory updates → CLAUDE.md refresh → hook scan → context primer) into a single invocation
- Command carries `allowed-tools: Read, Edit, Write, Bash` frontmatter, a 5-step `## Instructions` body, and the standard `✅ wrap-session complete` output block with `Next:` line and fenced primer
- Adds `test/jest-tests/pm-wrap-session-jest.test.js` covering 9 assertions: file existence, frontmatter `allowed-tools`, all four memory types, 200-line `MEMORY.md` guard, idempotency, output header, `Next:` line, and fenced primer block

## Test results

All 54 test suites passed (1641 tests, 19 skipped) — no regressions.

Closes #653