### PR TITLE
feat(pm): add /handoff command and delegate wrap-session step 5 (#654)

### DIFF
--- a/autopm/.claude/commands/handoff.md
+++ b/autopm/.claude/commands/handoff.md
@@ -1,0 +1,84 @@
+---
+allowed-tools: Read, Bash
+---
+
+# Handoff
+
+Generate a compact context primer to paste immediately after `/compact`. Keeps primer under 200 words so it fits a fresh context window.
+
+## Instructions
+
+### Step 1 — Capture current state
+
+Run these shell commands to collect context:
+
+```bash
+# Current branch (fallback: "unknown" if detached HEAD or not on a feature branch)
+BRANCH=$(git branch --show-current 2>/dev/null || git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+[ -z "$BRANCH" ] && BRANCH="unknown"
+
+# Issue number from branch name (e.g. feature/654-handoff → #654)
+ISSUE=$(echo "$BRANCH" | grep -oE '[0-9]+' | head -1 || echo "")
+[ -n "$ISSUE" ] && ISSUE="#$ISSUE" || ISSUE="(no issue)"
+
+# Files modified in this session
+MODIFIED=$(git diff --name-only HEAD 2>/dev/null | head -10 | tr '\n' ', ' | sed 's/, $//')
+[ -z "$MODIFIED" ] && MODIFIED="(none)"
+
+# Last 3–5 meaningful commits
+COMMITS=$(git log --oneline -5 2>/dev/null | sed 's/^/  /')
+```
+
+Also read any active task notes or recent CLAUDE.md entries to identify what was just completed and what the next concrete step is. If no task context is available, summarise the most recent commit message as "Just completed."
+
+### Step 2 — Write handoff file
+
+```bash
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+HANDOFF_FILE="/tmp/handoff-${TIMESTAMP}.md"
+```
+
+Write the primer to `$HANDOFF_FILE`:
+
+```bash
+cat > "$HANDOFF_FILE" <<EOF
+Context: $ISSUE — ${BRANCH}. Branch: ${BRANCH}.
+Just completed: [most recent work from commits/task].
+Modified: ${MODIFIED}.
+Next: [next concrete action].
+Relevant constraints: check CLAUDE.md for non-obvious rules.
+Continue.
+EOF
+```
+
+### Step 3 — Generate primer
+
+Compose the final primer (≤ 200 words):
+
+```
+Context: <issue-ref> (<brief title>). Branch: <branch-name>.
+Just completed: <what was just finished>.
+Modified: <file1>, <file2>.
+Next: <single concrete next action>.
+Relevant constraints: <any non-obvious rule from CLAUDE.md or memories>.
+Continue.
+```
+
+Use real values from Step 1. If not on a feature branch (e.g. on `main`, `develop`, or detached HEAD), set the context line to `Context: (no active feature branch). Branch: <branch-name>.` as a fallback.
+
+### Step 4 — Print primer
+
+Output exactly this format:
+
+```
+📋 Handoff ready — copy everything between the lines:
+────────────────────────────────────────
+Context: <issue-ref> (<brief title>). Branch: <branch-name>.
+Just completed: <completed work>.
+Modified: <file list>.
+Next: <next action>.
+Relevant constraints: <constraints or "none">.
+Continue.
+────────────────────────────────────────
+Saved to: /tmp/handoff-${TIMESTAMP}.md
+```

--- a/autopm/.claude/commands/wrap-session.md
+++ b/autopm/.claude/commands/wrap-session.md
@@ -58,11 +58,7 @@ Skip this step silently if no candidates are found.
 
 ### Step 5 — Print compact primer
 
-Produce a ready-to-paste context primer covering:
-- Active branch and issue number
-- Key decisions from this session
-- What was completed and what remains
-- Any critical gotchas
+Run `/handoff` to generate and print the context primer. The `/handoff` command captures current branch, modified files, recent commits, and next steps, then prints a ready-to-paste block under 200 words.
 
 ## Output Format
 

--- a/test/helpers/assert-real-timestamp.js
+++ b/test/helpers/assert-real-timestamp.js
@@ -1,0 +1,16 @@
+/**
+ * Shared assertion: content references /tmp/handoff- with a real date command,
+ * and contains no placeholder strings (YYYY, <timestamp>, [timestamp]).
+ *
+ * @param {string} content - file content to assert against
+ */
+function assertRealTimestamp(content) {
+  expect(content).toContain('/tmp/handoff-');
+  const hasDateCmd = content.includes('date') || content.includes('%Y%m%d');
+  expect(hasDateCmd).toBe(true);
+  expect(content).not.toContain('YYYY');
+  expect(content).not.toContain('<timestamp>');
+  expect(content).not.toContain('[timestamp]');
+}
+
+module.exports = { assertRealTimestamp };

--- a/test/jest-tests/pm-handoff-jest.test.js
+++ b/test/jest-tests/pm-handoff-jest.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const { parseCommandFrontmatter } = require('../helpers/parse-command-frontmatter');
+
+const COMMAND_FILE = path.resolve(__dirname, '../../autopm/.claude/commands/handoff.md');
+
+describe('handoff command file', () => {
+  let content;
+  let fm;
+
+  beforeAll(() => {
+    if (fs.existsSync(COMMAND_FILE)) {
+      content = fs.readFileSync(COMMAND_FILE, 'utf8');
+      fm = parseCommandFrontmatter(content);
+    } else {
+      content = '';
+      fm = {};
+    }
+  });
+
+  // ── RED tests (fail before implementation) ───────────────────────────────
+
+  it('test_handoff_command_file_exists — file exists at correct path', () => {
+    expect(fs.existsSync(COMMAND_FILE)).toBe(true);
+  });
+
+  it('test_handoff_frontmatter_allowed_tools_is_read_bash — frontmatter allowed-tools is Read, Bash', () => {
+    expect(fm['allowed-tools']).toBe('Read, Bash');
+  });
+
+  it('test_handoff_output_header_is_handoff_ready_copy_between_lines — output uses correct header', () => {
+    expect(content).toContain('📋 Handoff ready — copy everything between the lines:');
+  });
+
+  it('test_handoff_writes_to_tmp_with_real_timestamp_pattern — uses real timestamp, no placeholder', () => {
+    expect(content).toContain('/tmp/handoff-');
+    const hasDateCmd = content.includes('date') || content.includes('%Y%m%d');
+    expect(hasDateCmd).toBe(true);
+    expect(content).not.toContain('YYYY');
+    expect(content).not.toContain('<timestamp>');
+    expect(content).not.toContain('[timestamp]');
+  });
+
+  // ── GREEN tests (pass after implementation) ──────────────────────────────
+
+  it('test_handoff_captures_git_branch_and_diff_commands — mentions git branch and git diff --name-only HEAD', () => {
+    const hasBranch = content.includes('git branch') || content.includes('git rev-parse --abbrev-ref');
+    expect(hasBranch).toBe(true);
+    expect(content).toContain('git diff --name-only HEAD');
+  });
+
+  it('test_handoff_writes_to_tmp_with_real_timestamp_no_placeholder — /tmp/handoff- with real date cmd, no placeholder strings', () => {
+    expect(content).toContain('/tmp/handoff-');
+    const hasDateCmd = content.includes('date') || content.includes('%Y%m%d');
+    expect(hasDateCmd).toBe(true);
+    expect(content).not.toContain('YYYY');
+    expect(content).not.toContain('<timestamp>');
+    expect(content).not.toContain('[timestamp]');
+  });
+
+  it('test_handoff_primer_includes_context_branch_next_saved_to_lines — primer has required fields', () => {
+    expect(content).toContain('Context:');
+    expect(content).toContain('Branch:');
+    expect(content).toContain('Next:');
+    expect(content).toContain('Saved to:');
+  });
+
+  it('test_handoff_output_header_is_handoff_ready_copy_between_lines — AC: output format has exact header', () => {
+    expect(content).toContain('📋 Handoff ready — copy everything between the lines:');
+  });
+
+  it('test_handoff_states_200_word_limit_for_primer — documents the 200-word limit', () => {
+    const idx200 = content.indexOf('200');
+    expect(idx200).toBeGreaterThan(-1);
+    const window = content.slice(Math.max(0, idx200 - 30), idx200 + 30);
+    const hasWord = window.toLowerCase().includes('word');
+    expect(hasWord).toBe(true);
+  });
+
+  it('test_handoff_has_fallback_when_not_on_feature_branch — handles detached HEAD or non-feature branch', () => {
+    const lower = content.toLowerCase();
+    const hasFallback =
+      lower.includes('fallback') ||
+      lower.includes('unknown') ||
+      lower.includes('not on a feature') ||
+      lower.includes('main') ||
+      lower.includes('develop');
+    expect(hasFallback).toBe(true);
+  });
+});

--- a/test/jest-tests/pm-handoff-jest.test.js
+++ b/test/jest-tests/pm-handoff-jest.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { parseCommandFrontmatter } = require('../helpers/parse-command-frontmatter');
+const { assertRealTimestamp } = require('../helpers/assert-real-timestamp');
 
 const COMMAND_FILE = path.resolve(__dirname, '../../autopm/.claude/commands/handoff.md');
 
@@ -33,12 +34,7 @@ describe('handoff command file', () => {
   });
 
   it('test_handoff_writes_to_tmp_with_real_timestamp_pattern — uses real timestamp, no placeholder', () => {
-    expect(content).toContain('/tmp/handoff-');
-    const hasDateCmd = content.includes('date') || content.includes('%Y%m%d');
-    expect(hasDateCmd).toBe(true);
-    expect(content).not.toContain('YYYY');
-    expect(content).not.toContain('<timestamp>');
-    expect(content).not.toContain('[timestamp]');
+    assertRealTimestamp(content);
   });
 
   // ── GREEN tests (pass after implementation) ──────────────────────────────
@@ -50,12 +46,7 @@ describe('handoff command file', () => {
   });
 
   it('test_handoff_writes_to_tmp_with_real_timestamp_no_placeholder — /tmp/handoff- with real date cmd, no placeholder strings', () => {
-    expect(content).toContain('/tmp/handoff-');
-    const hasDateCmd = content.includes('date') || content.includes('%Y%m%d');
-    expect(hasDateCmd).toBe(true);
-    expect(content).not.toContain('YYYY');
-    expect(content).not.toContain('<timestamp>');
-    expect(content).not.toContain('[timestamp]');
+    assertRealTimestamp(content);
   });
 
   it('test_handoff_primer_includes_context_branch_next_saved_to_lines — primer has required fields', () => {

--- a/test/jest-tests/pm-wrap-session-jest.test.js
+++ b/test/jest-tests/pm-wrap-session-jest.test.js
@@ -88,4 +88,8 @@ describe('wrap-session command file', () => {
     expect(lower).toContain('hooks');
     expect(lower).toContain('primer');
   });
+
+  it('test_wrap_session_step5_delegates_to_handoff_command — step 5 references /handoff', () => {
+    expect(content).toContain('/handoff');
+  });
 });


### PR DESCRIPTION
## Summary

- Add `autopm/.claude/commands/handoff.md` — a standalone command that captures branch, modified files, recent commits, and next step, then writes a paste-ready primer to `/tmp/handoff-<timestamp>.md`
- Update `autopm/.claude/commands/wrap-session.md` step 5 to delegate to `/handoff` instead of duplicating inline primer logic
- Add `test/jest-tests/pm-handoff-jest.test.js` with full TDD RED→GREEN→REFACTOR coverage (file existence, frontmatter `allowed-tools: Read, Bash`, output format, real timestamp, primer fields, 200-word limit, non-feature-branch fallback, wrap-session delegation)
- Extract shared timestamp-validation logic into `test/helpers/assert-real-timestamp.js`

## Test results

All 54 test suites pass (1641 tests passed, 19 skipped, 0 failed).

## Closes

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)