### PR TITLE
fix(test): restore alternation semantics in post-install-check regex (#670)

### DIFF
--- a/test/jest-tests/post-install-check-jest.test.js
+++ b/test/jest-tests/post-install-check-jest.test.js
@@ -242,7 +242,7 @@ describe('PostInstallChecker', () => {
       expect(optionalEntry.message).toContain('Local mode');
 
       // No GitHub/Azure next-step nag.
-      expect(checker.results.nextSteps.some(s => /github\|azure/.test(s))).toBe(false);
+      expect(checker.results.nextSteps.some(s => /github|azure/.test(s))).toBe(false);
     });
 
     it('should treat Lite install (no provider plugin, no provider config) as local mode', () => {
@@ -265,7 +265,7 @@ describe('PostInstallChecker', () => {
       expect(optionalEntry.status).toBe(true);
       expect(optionalEntry.message).toMatch(/local|optional/i);
 
-      expect(checker.results.nextSteps.some(s => /github\|azure/.test(s))).toBe(false);
+      expect(checker.results.nextSteps.some(s => /github|azure/.test(s))).toBe(false);
     });
 
     it('should still flag missing provider config when a provider plugin IS installed', () => {


### PR DESCRIPTION
## Summary

- Replace `/github\|azure/` with `/github|azure/` at lines 245 and 268 in `test/jest-tests/post-install-check-jest.test.js`
- `\|` in a JS regex literal matches the literal two-character sequence `github|azure`, not a logical OR — the assertions silently passed when `nextSteps` contained only `github` or only `azure` alone
- Audit of the same file found no other `\|`-escaped alternation patterns

## Test results

All 54 test suites pass (1641 tests, 19 skipped) — no regressions.

Closes #670