### PR TITLE
fix(test): defensive defaults in beforeAll for 3 command-file tests (#671)

### DIFF
--- a/test/jest-tests/pm-issue-finish-jest.test.js
+++ b/test/jest-tests/pm-issue-finish-jest.test.js
@@ -10,6 +10,8 @@ describe('pm:issue-finish command file', () => {
   beforeAll(() => {
     if (fs.existsSync(COMMAND_FILE)) {
       content = fs.readFileSync(COMMAND_FILE, 'utf8');
+    } else {
+      content = '';
     }
   });
 

--- a/test/jest-tests/pm-review-fix-jest.test.js
+++ b/test/jest-tests/pm-review-fix-jest.test.js
@@ -10,6 +10,8 @@ describe('pm:review-fix command file', () => {
   beforeAll(() => {
     if (fs.existsSync(COMMAND_FILE)) {
       content = fs.readFileSync(COMMAND_FILE, 'utf8');
+    } else {
+      content = '';
     }
   });
 

--- a/test/jest-tests/pm-wrap-session-jest.test.js
+++ b/test/jest-tests/pm-wrap-session-jest.test.js
@@ -12,6 +12,9 @@ describe('wrap-session command file', () => {
     if (fs.existsSync(COMMAND_FILE)) {
       content = fs.readFileSync(COMMAND_FILE, 'utf8');
       fm = parseCommandFrontmatter(content);
+    } else {
+      content = '';
+      fm = {};
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds `else { content = ''; }` to `beforeAll` in `pm-issue-finish-jest.test.js` and `pm-review-fix-jest.test.js` so `content` is never `undefined` when the command file is absent
- Adds `else { content = ''; fm = {}; }` to `beforeAll` in `pm-wrap-session-jest.test.js` for the same reason, covering the `fm` variable too
- Mirrors the defensive pattern already used in `pm-backlog-jest.test.js` and `pm-handoff-jest.test.js`; missing-file conditions now produce readable Jest `expect` diffs instead of `TypeError` crashes that hide the RED-phase signal

## Tests

All 54 test suites passed (1641 tests, 19 skipped) — no regressions.

Closes #671