### PR TITLE
fix(pm:issue-finish): delegate quality gate to /quality-gate and add coverage table to PR body (#672)

### DIFF
--- a/autopm/.claude/commands/pm:issue-finish.md
+++ b/autopm/.claude/commands/pm:issue-finish.md
@@ -45,9 +45,9 @@ echo "Issue: #$ISSUE_NUMBER  Branch: $CURRENT_BRANCH"
 
 ### 2. Quality gate
 
-Run `/quality-gate` — it checks lint, tests, and coverage with per-metric thresholds.
-
-**BLOCK on failure** — if `/quality-gate` exits non-zero, stop here. No PR created.
+```bash
+/quality-gate || exit 1
+```
 
 ### 3. Commit unstaged changes
 
@@ -76,10 +76,21 @@ ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q .title) || {
 ### 6. Create PR
 
 ```bash
+COVERAGE_TABLE="| Metric | Threshold | Status |
+|--------|-----------|--------|
+| Lines | 80% | ✅/❌ |
+| Branches | 75% | ✅/❌ |
+| Functions | 80% | ✅/❌ |
+| Statements | 80% | ✅/❌ |"
+
 gh pr create \
   --title "$ISSUE_TITLE" \
   --base develop \
-  --body "Closes #$ISSUE_NUMBER" \
+  --body "Closes #$ISSUE_NUMBER
+
+## Coverage
+
+$COVERAGE_TABLE" \
   --label "in-progress"
 ```
 

--- a/test/jest-tests/pm-issue-finish-jest.test.js
+++ b/test/jest-tests/pm-issue-finish-jest.test.js
@@ -53,22 +53,20 @@ describe('pm:issue-finish command file', () => {
     expect(hasArgs).toBe(true);
   });
 
-  it('test_pm_issue_finish_blocks_pr_when_tests_fail — npm test before gh pr create with block on failure', () => {
-    expect(content).toContain('npm test');
-    const testIdx = content.indexOf('npm test');
+  it('test_pm_issue_finish_blocks_pr_when_tests_fail — /quality-gate before gh pr create with block on failure', () => {
+    expect(content).toContain('/quality-gate || exit 1');
+    const gateIdx = content.indexOf('/quality-gate || exit 1');
     const prIdx = content.indexOf('gh pr create');
-    expect(testIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeGreaterThan(-1);
     expect(prIdx).toBeGreaterThan(-1);
-    expect(testIdx).toBeLessThan(prIdx);
+    expect(gateIdx).toBeLessThan(prIdx);
     const lower = content.toLowerCase();
     const hasBlock = lower.includes('block') || lower.includes('exit 1') || lower.includes('no pr');
     expect(hasBlock).toBe(true);
   });
 
-  it('test_pm_issue_finish_blocks_pr_when_coverage_below_threshold — threshold checks for all four metrics', () => {
-    expect(content).toContain('npm run test:coverage');
-    expect(content).toContain('>= 80');
-    expect(content).toContain('>= 75');
+  it('test_pm_issue_finish_blocks_pr_when_coverage_below_threshold — /quality-gate as quality-gate mechanism', () => {
+    expect(content).toContain('/quality-gate || exit 1');
     const lower = content.toLowerCase();
     const hasBlock = lower.includes('exit 1') || lower.includes('no pr');
     expect(hasBlock).toBe(true);


### PR DESCRIPTION
## Summary

- Updated `test/jest-tests/pm-issue-finish-jest.test.js` to assert `/quality-gate || exit 1` delegation instead of stale inline `npm test`/`npm run test:coverage`/`>= 80`/`>= 75` assertions in `test_pm_issue_finish_blocks_pr_when_tests_fail` and `test_pm_issue_finish_blocks_pr_when_coverage_below_threshold`
- Replaced prose-only Step 2 in `autopm/.claude/commands/pm:issue-finish.md` with a `bash` fence calling `/quality-gate || exit 1`, matching the code-fence style of surrounding steps
- Expanded Step 6 to build a `COVERAGE_TABLE` variable containing a four-row markdown table (Lines/Branches/Functions/Statements, thresholds 80/75/80/80, ✅/❌ markers) and pass it to `gh pr create --body`

## Test results

All 54 test suites passed (1641 tests, 19 skipped). Target tests now green:
- `test_pm_issue_finish_blocks_pr_when_tests_fail`
- `test_pm_issue_finish_blocks_pr_when_coverage_below_threshold`
- `test_pm_issue_finish_contains_coverage_table_with_four_rows`
- `test_pm_issue_finish_pr_body_includes_coverage_table`

No regressions in the six pre-existing passing tests.

Closes #672