### PR TITLE
fix(pm:backlog): add unassigned-first tiebreaker to sortIssues() (#673)

### DIFF
--- a/autopm/.claude/scripts/pm/backlog.js
+++ b/autopm/.claude/scripts/pm/backlog.js
@@ -31,6 +31,10 @@ function sortIssues(issues) {
     if (pa !== pb) return pa - pb;
     const ea = getEffortRank(a), eb = getEffortRank(b);
     if (ea !== eb) return ea - eb;
+    // unassigned-first: surfaces actionable work before in-progress items
+    const ua = a.assignees.length === 0 ? 0 : 1;
+    const ub = b.assignees.length === 0 ? 0 : 1;
+    if (ua !== ub) return ua - ub;
     return new Date(a.createdAt) - new Date(b.createdAt);
   });
 }

--- a/test/jest-tests/pm-backlog-jest.test.js
+++ b/test/jest-tests/pm-backlog-jest.test.js
@@ -92,6 +92,26 @@ describe('pm-backlog', () => {
       const sorted = sortIssues(issues);
       expect(sorted.map(i => i.number)).toEqual([2, 3, 1, 4]);
     });
+
+    it('should sort unassigned before assigned when priority and effort are equal', () => {
+      const { sortIssues } = require('../../autopm/.claude/scripts/pm/backlog.js');
+      const issues = [
+        makeIssue(1, 'assigned', ['bug', 'effort:S'], ['alice'], '2024-01-01T00:00:00Z'),
+        makeIssue(2, 'unassigned', ['bug', 'effort:S'], [], '2024-01-01T00:00:00Z')
+      ];
+      const sorted = sortIssues(issues);
+      expect(sorted[0].number).toBe(2);
+    });
+
+    it('should sort unassigned before assigned even when the assigned issue was created earlier', () => {
+      const { sortIssues } = require('../../autopm/.claude/scripts/pm/backlog.js');
+      const issues = [
+        makeIssue(1, 'assigned-older', ['bug', 'effort:S'], ['alice'], '2024-01-01T00:00:00Z'),
+        makeIssue(2, 'unassigned-newer', ['bug', 'effort:S'], [], '2024-06-01T00:00:00Z')
+      ];
+      const sorted = sortIssues(issues);
+      expect(sorted[0].number).toBe(2);
+    });
   });
 
   describe('hasOpenDependency()', () => {


### PR DESCRIPTION
## Summary

- Inserts an unassigned-first tiebreaker in `sortIssues()` (`autopm/.claude/scripts/pm/backlog.js`) between the effort-rank comparison and the `createdAt` fallback, closing the gap between the documented sort order and the actual comparator
- Issues with no assignee (`assignees.length === 0`) now rank before assigned issues within the same priority+effort bucket
- Adds two regression tests to `test/jest-tests/pm-backlog-jest.test.js` using the existing `makeIssue` factory: same-`createdAt` case and older-assigned-vs-newer-unassigned case

## Test results

All 54 test suites passed (1641 tests, 19 skipped) — existing `sortIssues` tests and the two new regression tests are green.

Closes #673