### PR TITLE
fix(dependabot-auto-merge): approve grouped PRs, not just single-dep

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,11 +26,40 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@v3
 
-      - name: Approve + enable auto-merge (npm patch/minor only)
-        if: >-
-          ${{ steps.meta.outputs.package-ecosystem == 'npm' &&
-              (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-               steps.meta.outputs.update-type == 'version-update:semver-minor') }}
+      # Grouped-aware gate. `fetch-metadata`'s top-level `package-ecosystem` /
+      # `update-type` outputs are populated only for single-dep PRs; grouped
+      # PRs (dependabot's *-minor-patch groups) leave those empty and put every
+      # updated dependency under `updated-dependencies-json` — a JSON array of
+      # {packageEcosystem, updateType, dependencyName, ...}. The previous
+      # single-dep-only gate therefore skipped every grouped PR (see #689/#690).
+      # New rule: approve iff EVERY entry is npm AND NONE is semver-major.
+      # `github-actions` is excluded implicitly (not npm); majors are held.
+      - name: Decide auto-merge (grouped-aware)
+        id: gate
+        uses: actions/github-script@v7
+        env:
+          UPDATES: ${{ steps.meta.outputs.updated-dependencies-json }}
+        with:
+          script: |
+            const updates = JSON.parse(process.env.UPDATES || '[]');
+            if (updates.length === 0) {
+              core.setOutput('approve', 'false');
+              core.info('No updates in metadata; nothing to gate.');
+              return;
+            }
+            const allNpm = updates.every(u => u.packageEcosystem === 'npm');
+            const anyMajor = updates.some(u => u.updateType === 'version-update:semver-major');
+            const approve = allNpm && !anyMajor;
+            core.setOutput('approve', String(approve));
+            core.info(
+              `Gate: approve=${approve} (deps=${updates.length}, allNpm=${allNpm}, anyMajor=${anyMajor})`
+            );
+            for (const u of updates) {
+              core.info(`  - ${u.dependencyName} (${u.packageEcosystem}, ${u.updateType})`);
+            }
+
+      - name: Approve + enable auto-merge
+        if: steps.gate.outputs.approve == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Bootstrap fix flagged by pr-review-gate orchestrator. Do not self-approve — needs owner.

## Bug

`fetch-metadata@v3` top-level `package-ecosystem`/`update-type` outputs are populated only for single-dep PRs. For grouped PRs (dependabot `*-minor-patch` groups) both are empty; every updated dep is nested inside `updated-dependencies-json`. Previous shell-expression `if` therefore evaluated false for every grouped PR — evidence in run [28229820774](https://github.com/lagowski/ClaudeAutoPM/actions/runs/28229820774) for #690: job succeeded, approve step SKIPPED.

## Fix

Replace the shell `if` with an `actions/github-script` step that parses `updated-dependencies-json` and approves iff EVERY entry is `packageEcosystem: npm` AND NONE is `updateType: version-update:semver-major`. `github-actions` is excluded implicitly (not `npm`). Majors are still held. Logs each dep for debuggability.

## Read-only token risk

The workflow declares `permissions: pull-requests: write`, so `GITHUB_TOKEN` *should* be able to approve. But dependabot-triggered `pull_request` runs get a read-only token by default unless repo setting **Settings → Actions → General → Workflow permissions → \"Allow GitHub Actions to create and approve pull requests\"** is enabled. **I cannot verify that setting from here — no qualifying run has ever fired to prove it.**

Post-merge on the next qualifying grouped PR, the approve step will either:
- ✅ succeed → done
- ❌ fail with `resource not accessible by integration` → switch to `pull_request_target` trigger (safer than a PAT), or toggle the repo setting

Prefer: (1) enable repo setting → (2) switch to `pull_request_target` → (3) PAT/App.

## Scope

- Fix: `.github/workflows/dependabot-auto-merge.yml` only. 1 file, +34/-5.
- **Not** touching #689/#690/#691 — owner's call per orchestrator instructions.
- **Not** pushing to protected develop.