### PR TITLE
fix(plugin-testing): drop self-peer on claude-autopm registry entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10849,7 +10849,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "claude-autopm": ">=2.8.0"
+        "claude-autopm": "*"
       }
     }
   }

--- a/packages/plugin-testing/package.json
+++ b/packages/plugin-testing/package.json
@@ -35,6 +35,6 @@
     "README.md"
   ],
   "peerDependencies": {
-    "claude-autopm": ">=2.8.0"
+    "claude-autopm": "*"
   }
 }


### PR DESCRIPTION
Bootstrap fix for FINDING A flagged by the AI gate on #689/#690/#691. Do not self-approve — needs owner + gate.

## Root cause

`packages/plugin-testing/package.json` declares:

```json
"peerDependencies": { "claude-autopm": ">=2.8.0" }
```

The workspace ROOT is named `claude-autopm`. Because the semver range is plain (no `workspace:` protocol), npm was resolving the peer from the REGISTRY — pulling `claude-autopm-4.0.0.tgz` into `node_modules/claude-autopm` and marking it `peer: true`. Grouped dependabot PRs regenerated the lock and inherited that entry. **Real risk**: `npm ci` in CI installs the published tarball, so tests may run against shipped code instead of the code under test.

Only 1 workspace has this: `packages/plugin-testing`. Others peer on `@claudeautopm/plugin-*` scoped names which resolve via workspace links correctly.

## Fix

- `packages/plugin-testing/package.json`: `">=2.8.0"` → `"*"` in `peerDependencies.claude-autopm`. Now any workspace-linked root satisfies the peer.
- `package-lock.json`: regenerated with `npm install --package-lock-only --ignore-scripts --legacy-peer-deps`. Verified: `node_modules/claude-autopm` (registry tarball) is GONE; `node_modules/@claudeautopm/plugin-testing` still links to `packages/plugin-testing` (`"link": true`).

`--legacy-peer-deps` needed because of a pre-existing cross-plugin peer conflict (`plugin-ai` peers on `plugin-core@^3.0.0` but workspace is at `4.0.0`). Same flag already used by all CI publish workflows, so no divergence.

## After merge

- Dependabot auto-rebases #689/#690 onto the fresh lock; AI gate re-runs; FINDING A should clear on both.
- **#691 stays blocked** by FINDING B (js-yaml 4→5 breaking major). Recommend closing #691 and pinning `js-yaml` to `^4` via `.github/dependabot.yml` `ignore` rule; migration is a separate audited PR across the 3 `yaml.load()` call-sites (`lib/services/UtilityService.js:770`, `autopm/.claude/scripts/{start-parallel-streams.js:42, decompose-issue.js:320}`). Owner's call.

## Scope

- 2 files, +2/-2.
- Not touching #689/#690/#691, not pushing to develop.