### PR TITLE
chore(dependabot): pin js-yaml to ^4, ignore semver-major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,16 @@ updates:
       # ora 9.x is pure ESM, incompatible with our CommonJS codebase
       - dependency-name: "ora"
         update-types: ["version-update:semver-major"]
+      # js-yaml 5.x is a breaking major: yaml.load() throws on empty input
+      # (was undefined in 4.x), default schema shifts YAML 1.1 -> 1.2
+      # (CORE_SCHEMA), !!set/!!merge semantics changed. Three load() call-sites
+      # need audited empty-input guards + schema review before we can migrate:
+      #   lib/services/UtilityService.js:770
+      #   autopm/.claude/scripts/start-parallel-streams.js:42
+      #   autopm/.claude/scripts/decompose-issue.js:320
+      # Closed #691 per owner go-ahead; migration deferred to a dedicated PR.
+      - dependency-name: "js-yaml"
+        update-types: ["version-update:semver-major"]
     
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Per owner go-ahead: pin `js-yaml` to `^4` in `.github/dependabot.yml` so dependabot stops re-proposing the 5.x major.

5.x is breaking (`yaml.load()` throws on empty input; default schema shifts YAML 1.1→1.2 CORE_SCHEMA; `!!set`/`!!merge` semantics changed). Three call-sites need audited guards before migration:

- `lib/services/UtilityService.js:770`
- `autopm/.claude/scripts/start-parallel-streams.js:42`
- `autopm/.claude/scripts/decompose-issue.js:320`

Migration is deferred to a dedicated audited PR. Closing #691 in this PR's flow.

Follows the existing `ora` ignore pattern. Minor/patch on ^4.x still flow.