### PR TITLE
chore(deps): stop offering chalk majors — 5.x+ is ESM, this package is CJS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,18 @@ updates:
       # Closed #691 per owner go-ahead; migration deferred to a dedicated PR.
       - dependency-name: "js-yaml"
         update-types: ["version-update:semver-major"]
+      # chalk 5.x+ is pure ESM — same wall as ora above. `require('chalk')` in a
+      # CommonJS file throws `SyntaxError: Cannot use import statement outside a
+      # module` at load time, so the bump does not fail a test, it fails every
+      # entry point that colours output. Ten call-sites today:
+      #   bin/commands/plugin.js, lib/cli/commands/{pm,task,epic,issue,context,prd,agent}.js,
+      #   test/integration/test-{azure,github}-manual.js
+      # 6.0.0 also raises the floor to Node 22, which drops the 22.x/24.x matrix
+      # to a single row. Closed #716; taking chalk 5+ means moving the package to
+      # ESM or swapping in a CJS-compatible colour library, which is a deliberate
+      # migration and not a dependency bump.
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]
     
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,10 +40,14 @@ updates:
       # entry point that colours output. Ten call-sites today:
       #   bin/commands/plugin.js, lib/cli/commands/{pm,task,epic,issue,context,prd,agent}.js,
       #   test/integration/test-{azure,github}-manual.js
-      # 6.0.0 also raises the floor to Node 22, which drops the 22.x/24.x matrix
-      # to a single row. Closed #716; taking chalk 5+ means moving the package to
-      # ESM or swapping in a CJS-compatible colour library, which is a deliberate
-      # migration and not a dependency bump.
+      # The ESM wall is the WHOLE reason. 6.0.0 also raises its floor to Node 22,
+      # but that costs nothing here: engines.node is already ">=22.0.0" and the CI
+      # matrix is [22.x, 24.x], so both rows satisfy it. (An earlier draft of this
+      # comment claimed the floor would collapse the matrix — it would not, and
+      # review caught it. A wrong reason attached to a right rule is how the rule
+      # gets reverted by someone who checks it.)
+      # Closed #716; taking chalk 5+ means moving the package to ESM or swapping
+      # in a CJS-compatible colour library — a deliberate migration, not a bump.
       - dependency-name: "chalk"
         update-types: ["version-update:semver-major"]
     


### PR DESCRIPTION
Closes the recurring red on #716 (`chalk 4.1.2 → 6.0.0`).

## Why the bump cannot be taken

chalk went **pure ESM at 5.0**. This package is CommonJS and reaches chalk through `require('chalk')` in ten files, so the bump does not fail a test — it fails at load time, in every entry point that colours output:

```
node_modules/chalk/source/index.js:1
SyntaxError: Cannot use import statement outside a module
  > 19 | const chalk = require('chalk');
  at Object.require (lib/cli/commands/prd.js:19:15)
  at Object.require (bin/commands/plugin.js:16:15)
```

Call-sites: `bin/commands/plugin.js`, `lib/cli/commands/{pm,task,epic,issue,context,prd,agent}.js`, `test/integration/test-{azure,github}-manual.js`.

That is the whole reason, and it is enough on its own.

> **Correction.** An earlier version of this PR and its comment also claimed chalk 6's Node 22 floor would "collapse the 22.x/24.x matrix to a single row". That is false — both rows satisfy `>=22`, and `engines.node` is already `">=22.0.0"`, so the floor asks for nothing this package does not already require. Copilot caught it; the claim is removed rather than softened (`8b5491b`), because a rule defended by an argument that does not survive checking is a rule the next person deletes.

## The fix is the rule that already exists

`.github/dependabot.yml` already ignores `ora` majors for exactly this reason, two lines above:

```yaml
# ora 9.x is pure ESM, incompatible with our CommonJS codebase
- dependency-name: "ora"
  update-types: ["version-update:semver-major"]
```

chalk belongs in the same list and was never added, so the same PR keeps arriving every major release and every arrival costs a red matrix and someone's afternoon. `ora` has not come back since its rule landed.

## What this does not decide

Taking chalk 5+ remains possible and is **a migration, not a bump**: either the package moves to ESM, or the ten call-sites move to a CJS-compatible colour library (`picocolors`, `kleur`, `ansi-colors`). Either is deliberate work with its own PR and its own review. This change only stops dependabot proposing it as routine maintenance.

**#716 is closed** — the ignore rule does not close an already-open PR, so it was closed by hand with this explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)