### PR TITLE
chore: sync AI review gate (pr-review-gate)

### DIFF
--- a/.github/workflows/copilot-comment-responder.yml
+++ b/.github/workflows/copilot-comment-responder.yml
@@ -1,0 +1,93 @@
+# copilot-comment-responder — CALLER. The logic lives in lagowski/pr-review-gate.
+#
+# GENERATED from lagowski/pr-review-gate (templates/copilot-comment-responder.yml) — do not
+# edit in place; change the template and re-deploy. drift-check.js reports any local edit.
+#
+# This file is deliberately thin. The ~700 lines that address Copilot's review comments are a
+# reusable workflow in pr-review-gate, so a fix lands once for the whole fleet. Before #158
+# the logic was copied by hand into each repo, and the veracrew#352/#353 fixes never reached
+# the copy — the drift this deployer exists to prevent, produced by the deployer not covering
+# the file.
+#
+# What stays HERE is what genuinely differs per repo:
+#   * the triggers — a reusable workflow cannot carry its own `schedule`, so the cron must
+#     live in the calling repo. GitHub's constraint, not a design preference.
+#   * the kill switch — RESPONDER_SCHEDULE_ENABLED, evaluated against THIS repo's variables.
+#   * the knobs — resolved here, because `vars` inside a reusable workflow reads the CALLER's
+#     context anyway; making that explicit beats a chain that looks central and is not.
+#
+# Every knob is a repository variable (Settings → Secrets and variables → Actions → Variables),
+# with a dispatch input winning over it. Nothing operational needs a PR to change:
+#
+#   RESPONDER_MAX_ROUNDS       pushes allowed to ONE PR                    (default 3)
+#   RESPONDER_MAX_TURNS        claude --max-turns per run                  (default 40)
+#   RESPONDER_ALLOWED_TOOLS    claude --allowedTools                       (default Edit Write Read Bash)
+#   RESPONDER_TIMEOUT_MINUTES  job timeout                                 (default 30)
+#   RESPONDER_SCHEDULE_ENABLED set to "false" to stop swept ticks (there is no cron here —
+#                              the k3s sweep dispatches; a human overrides with the `force` input)
+name: copilot-comment-responder
+
+# ONE DISPATCHER (pipeline-flow findings, 2026-07-31). This caller deliberately has NO
+# `schedule`: the k3s responder-sweep dispatches every repo that carries this file, and for a
+# while both it and an in-repo cron ran — two ticks per interval, two places owning the
+# cadence. The sweep won because it is zero-token and covers the whole fleet from one place.
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'run even when RESPONDER_SCHEDULE_ENABLED=false (human override)'
+        required: false
+        type: boolean
+        default: false
+      pr:
+        description: 'PR number to process (blank = first open PR with unresolved Copilot threads)'
+        required: false
+      dry_run:
+        description: 'run claude but do NOT push or resolve (preview)'
+        required: false
+        type: boolean
+        default: false
+      max_rounds:
+        description: 'max responder pushes per PR (blank = repo variable, else 3)'
+        required: false
+      max_turns:
+        description: 'claude --max-turns (blank = repo variable, else 40)'
+        required: false
+      allowed_tools:
+        description: 'claude --allowedTools (blank = repo variable, else "Edit Write Read Bash")'
+        required: false
+      timeout_minutes:
+        description: 'job timeout in minutes (blank = repo variable, else 30)'
+        required: false
+
+permissions:
+  contents: write        # push fixes to the PR head branch
+  pull-requests: write   # reply to + resolve review threads
+  actions: read          # list workflow runs for the pushed SHA (the #338 check)
+
+jobs:
+  respond:
+    # Opt-OUT, not opt-in — and the switch now gates the SWEEP's dispatches, because with no
+    # cron here every tick arrives as workflow_dispatch. The old form (`event_name !=
+    # 'schedule'`) would have let every swept tick through with the switch off: a kill switch
+    # that kills nothing. A human overrides with the `force` input, so turning it off still
+    # never blocks a person.
+    if: vars.RESPONDER_SCHEDULE_ENABLED != 'false' || github.event.inputs.force == 'true'
+    uses: lagowski/pr-review-gate/.github/workflows/fleet-copilot-comment-responder.yml@eea8f585a0fe06ed1fb5479a8901d72acf08e80a
+    with:
+      runs_on: '["self-hosted","claude-bridge"]'
+      pr: ${{ github.event.inputs.pr || '' }}
+      # `type: boolean` normalises the dispatch input, but an API dispatch can still deliver an
+      # arbitrary string. Normalised here and FAILING SAFE: only the exact "false" means really
+      # push. A surprise preview costs a wasted run; a surprise push costs a commit nobody
+      # asked for.
+      dry_run: ${{ (github.event.inputs.dry_run || 'false') != 'false' }}
+      max_rounds: ${{ github.event.inputs.max_rounds || vars.RESPONDER_MAX_ROUNDS || '3' }}
+      max_turns: ${{ github.event.inputs.max_turns || vars.RESPONDER_MAX_TURNS || '40' }}
+      allowed_tools: ${{ github.event.inputs.allowed_tools || vars.RESPONDER_ALLOWED_TOOLS || 'Edit Write Read Bash' }}
+      timeout_minutes: ${{ github.event.inputs.timeout_minutes || vars.RESPONDER_TIMEOUT_MINUTES || '30' }}
+    secrets:
+      # NAMED, never `secrets: inherit`. Inheriting would hand the reusable workflow every
+      # secret this repo holds; it needs exactly one. A repo without the PAT still runs — the
+      # workflow falls back to github.token and says at runtime what that costs (#338).
+      responder_push_token: ${{ secrets.RESPONDER_PUSH_TOKEN }}


### PR DESCRIPTION
Automated sync of the unified AI review gate from lagowski/pr-review-gate.

**Do not edit the workflow here** — change it centrally in pr-review-gate and redeploy. Found a gate bug? Open an issue there.