### PR TITLE
chore: sync AI review gate (pr-review-gate)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -73,7 +73,7 @@ jobs:
     # copilot-comment-responder.yml already fixed: a kill switch that kills nothing.
     # A human still overrides with `force`, so turning it off never blocks a person.
     if: vars.AUTO_APPROVE_ENABLED != 'false' || github.event.inputs.force == 'true'
-    uses: lagowski/pr-review-gate/.github/workflows/fleet-auto-approve.yml@941c05bdc396111430091cee4fb465c911a0ac44
+    uses: lagowski/pr-review-gate/.github/workflows/fleet-auto-approve.yml@100a65582e770db587d841a10e5c6e67041beb88
     with:
       runs_on: '["self-hosted","Linux","X64","build"]'
       protected_paths: '[".github/workflows/",".github/CODEOWNERS",".github/review-context.md",".github/scripts/"]'

--- a/.github/workflows/copilot-comment-responder.yml
+++ b/.github/workflows/copilot-comment-responder.yml
@@ -73,7 +73,7 @@ jobs:
     # that kills nothing. A human overrides with the `force` input, so turning it off still
     # never blocks a person.
     if: vars.RESPONDER_SCHEDULE_ENABLED != 'false' || github.event.inputs.force == 'true'
-    uses: lagowski/pr-review-gate/.github/workflows/fleet-copilot-comment-responder.yml@941c05bdc396111430091cee4fb465c911a0ac44
+    uses: lagowski/pr-review-gate/.github/workflows/fleet-copilot-comment-responder.yml@100a65582e770db587d841a10e5c6e67041beb88
     with:
       runs_on: '["self-hosted","claude-bridge"]'
       pr: ${{ github.event.inputs.pr || '' }}


### PR DESCRIPTION
Automated sync of the unified AI review gate from lagowski/pr-review-gate.

**Do not edit the workflow here** — change it centrally in pr-review-gate and redeploy. Found a gate bug? Open an issue there.